### PR TITLE
feat: add permanent delete for revoked API keys

### DIFF
--- a/internal/api/keys.go
+++ b/internal/api/keys.go
@@ -206,6 +206,23 @@ func (ks *KeyStore) HasActiveKey(ctx context.Context) (bool, error) {
 	return count > 0, nil
 }
 
+// Delete permanently removes a revoked key from the store.
+// Returns an error if the key does not exist or is still active (not revoked).
+func (ks *KeyStore) Delete(ctx context.Context, id string) error {
+	res, err := ks.db.ExecContext(ctx,
+		`DELETE FROM api_keys WHERE id = ? AND revoked_at IS NOT NULL`,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("deleting key: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("key not found or still active")
+	}
+	return nil
+}
+
 // Rotate revokes the existing key and creates a replacement with the same name and scopes.
 // Returns the new record and plaintext key.
 func (ks *KeyStore) Rotate(ctx context.Context, id string) (APIKeyRecord, string, error) {

--- a/internal/api/keys_test.go
+++ b/internal/api/keys_test.go
@@ -143,6 +143,46 @@ func TestKeyStore_Revoke_AlreadyRevoked(t *testing.T) {
 	}
 }
 
+func TestKeyStore_Delete(t *testing.T) {
+	ks := testKeyStore(t)
+	ctx := context.Background()
+
+	rec, _, _ := ks.Create(ctx, "deleteme", []string{"chat"})
+	_ = ks.Revoke(ctx, rec.ID)
+
+	if err := ks.Delete(ctx, rec.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Should be completely gone from List.
+	recs, _ := ks.List(ctx)
+	for _, r := range recs {
+		if r.ID == rec.ID {
+			t.Error("deleted key should not appear in List")
+		}
+	}
+}
+
+func TestKeyStore_Delete_ActiveKey(t *testing.T) {
+	ks := testKeyStore(t)
+	ctx := context.Background()
+
+	rec, _, _ := ks.Create(ctx, "still-active", []string{"chat"})
+
+	if err := ks.Delete(ctx, rec.ID); err == nil {
+		t.Error("expected error deleting an active (non-revoked) key")
+	}
+}
+
+func TestKeyStore_Delete_NotFound(t *testing.T) {
+	ks := testKeyStore(t)
+	ctx := context.Background()
+
+	if err := ks.Delete(ctx, "nonexistent"); err == nil {
+		t.Error("expected error deleting a nonexistent key")
+	}
+}
+
 func TestKeyStore_Rotate(t *testing.T) {
 	ks := testKeyStore(t)
 	ctx := context.Background()
@@ -293,6 +333,66 @@ func TestHandleRevokeKey_NotFound(t *testing.T) {
 	srv := New(testAdminConfig(), deps, testLogger())
 
 	req := httptest.NewRequest("DELETE", "/api/v1/keys/nonexistent-id", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleDeleteKey(t *testing.T) {
+	ks := testKeyStore(t)
+	deps := testDeps()
+	deps.KeyStore = ks
+	srv := New(testAdminConfig(), deps, testLogger())
+
+	ctx := context.Background()
+	rec, _, _ := ks.Create(ctx, "todelete", []string{"chat"})
+	_ = ks.Revoke(ctx, rec.ID) // must be revoked first
+
+	req := httptest.NewRequest("DELETE", "/api/v1/keys/"+rec.ID+"/permanent", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+
+	// Verify it's gone from the list.
+	keys, _ := ks.List(ctx)
+	for _, k := range keys {
+		if k.ID == rec.ID {
+			t.Fatal("deleted key still present in list")
+		}
+	}
+}
+
+func TestHandleDeleteKey_ActiveKeyRejected(t *testing.T) {
+	ks := testKeyStore(t)
+	deps := testDeps()
+	deps.KeyStore = ks
+	srv := New(testAdminConfig(), deps, testLogger())
+
+	ctx := context.Background()
+	rec, _, _ := ks.Create(ctx, "active", []string{"chat"})
+
+	req := httptest.NewRequest("DELETE", "/api/v1/keys/"+rec.ID+"/permanent", nil)
+	req.Header.Set("Authorization", "Bearer admin-token")
+	w := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for active key", w.Code)
+	}
+}
+
+func TestHandleDeleteKey_NotFound(t *testing.T) {
+	ks := testKeyStore(t)
+	deps := testDeps()
+	deps.KeyStore = ks
+	srv := New(testAdminConfig(), deps, testLogger())
+
+	req := httptest.NewRequest("DELETE", "/api/v1/keys/nonexistent/permanent", nil)
 	req.Header.Set("Authorization", "Bearer admin-token")
 	w := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(w, req)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -93,6 +93,7 @@ func New(cfg config.APIConfig, deps Deps, logger *slog.Logger) *Server {
 	mux.HandleFunc("GET /api/v1/keys", s.RequireScope("admin", s.handleListKeys))
 	mux.HandleFunc("POST /api/v1/keys", s.RequireScope("admin", s.handleCreateKey))
 	mux.HandleFunc("DELETE /api/v1/keys/{id}", s.RequireScope("admin", s.handleRevokeKey))
+	mux.HandleFunc("DELETE /api/v1/keys/{id}/permanent", s.RequireScope("admin", s.handleDeleteKey))
 	mux.HandleFunc("POST /api/v1/keys/{id}/rotate", s.RequireScope("admin", s.handleRotateKey))
 
 	// Web dashboard — catch-all for non-API paths (more-specific /api/v1/ routes always win).
@@ -794,6 +795,19 @@ func (s *Server) handleRevokeKey(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	if err := s.deps.KeyStore.Revoke(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDeleteKey handles DELETE /api/v1/keys/{id}/permanent.
+func (s *Server) handleDeleteKey(w http.ResponseWriter, r *http.Request) {
+	if !s.keyStoreRequired(w) {
+		return
+	}
+	id := r.PathValue("id")
+	if err := s.deps.KeyStore.Delete(r.Context(), id); err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 		return
 	}

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -78,6 +78,7 @@ export const api = {
   }),
   revokeKey: id => apiFetch(`/api/v1/keys/${encodeURIComponent(id)}`, { method: 'DELETE' }),
   rotateKey: id => apiFetch(`/api/v1/keys/${encodeURIComponent(id)}/rotate`, { method: 'POST' }),
+  deleteKey: id => apiFetch(`/api/v1/keys/${encodeURIComponent(id)}/permanent`, { method: 'DELETE' }),
 
   // Chat with SSE streaming.
   // onChunk(text) is called for each content chunk.

--- a/web/src/pages/ApiKeys.svelte
+++ b/web/src/pages/ApiKeys.svelte
@@ -15,7 +15,7 @@
   let newKeyId = ''
 
   // Confirm action state
-  let confirmAction = null // { type: 'revoke'|'rotate', id, name }
+  let confirmAction = null // { type: 'revoke'|'rotate'|'delete', id, name }
   let actionLoading = false
   let rotatedKey = ''
 
@@ -77,6 +77,21 @@
     try {
       const res = await api.rotateKey(confirmAction.id)
       rotatedKey = res.key
+      confirmAction = null
+      await loadKeys()
+    } catch (e) {
+      error = e.message
+    } finally {
+      actionLoading = false
+    }
+  }
+
+  async function confirmDelete() {
+    if (!confirmAction) return
+    actionLoading = true
+    error = ''
+    try {
+      await api.deleteKey(confirmAction.id)
       confirmAction = null
       await loadKeys()
     } catch (e) {
@@ -179,6 +194,10 @@
                 <button class="btn-sm danger" onclick={() => { confirmAction = { type: 'revoke', id: key.id, name: key.name } }}>
                   Revoke
                 </button>
+              {:else}
+                <button class="btn-sm danger" onclick={() => { confirmAction = { type: 'delete', id: key.id, name: key.name } }}>
+                  Delete
+                </button>
               {/if}
             </td>
           </tr>
@@ -230,6 +249,15 @@
         <div class="modal-actions">
           <button class="btn-danger" onclick={confirmRevoke} disabled={actionLoading}>
             {actionLoading ? 'Revoking…' : 'Revoke'}
+          </button>
+          <button class="btn-ghost" onclick={() => confirmAction = null}>Cancel</button>
+        </div>
+      {:else if confirmAction.type === 'delete'}
+        <h2>Delete Key</h2>
+        <p>Permanently delete <strong>{confirmAction.name}</strong>? This will remove the key record entirely.</p>
+        <div class="modal-actions">
+          <button class="btn-danger" onclick={confirmDelete} disabled={actionLoading}>
+            {actionLoading ? 'Deleting…' : 'Delete'}
           </button>
           <button class="btn-ghost" onclick={() => confirmAction = null}>Cancel</button>
         </div>


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/v1/keys/{id}/permanent` endpoint (admin scope) to permanently remove revoked API keys from the database
- Adds "Delete" button in the web UI API Keys page for revoked keys, with a confirmation modal
- Only revoked keys can be deleted — active keys are rejected with 404

## Test plan
- [x] Store-level tests: `TestKeyStore_Delete`, `TestKeyStore_Delete_ActiveKey`, `TestKeyStore_Delete_NotFound`
- [x] Handler tests: `TestHandleDeleteKey`, `TestHandleDeleteKey_ActiveKeyRejected`, `TestHandleDeleteKey_NotFound`
- [x] All existing tests pass with `-race`
- [x] Linter: 0 issues
- [ ] Manual: revoke a key in the web UI, verify "Delete" button appears, confirm deletion removes the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)