### PR TITLE
fix: update baseURL to denkeeper.io and add CNAME for GitHub Pages

### DIFF
--- a/website/config/production/hugo.toml
+++ b/website/config/production/hugo.toml
@@ -1,3 +1,2 @@
 # Overrides for production environment
-# Update this when denkeeper.io is live
-baseurl = "https://temikus.github.io/denkeeper/"
+baseurl = "https://denkeeper.io/"

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+denkeeper.io


### PR DESCRIPTION
The production Hugo config still pointed to temikus.github.io/denkeeper/,
causing all CSS/JS asset paths to 404 on the custom domain. Update baseURL
to https://denkeeper.io/ and add a CNAME file so GitHub Pages persists the
custom domain setting across deployments.

https://claude.ai/code/session_01HLQ6tS6mkrQWVMHCryrzh8