### PR TITLE
fix(tool): prevent SSE MCP tools from disappearing on restart

### DIFF
--- a/internal/tool/health_test.go
+++ b/internal/tool/health_test.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -107,5 +108,72 @@ func TestHandleServerFailure_MaxAttempts(t *testing.T) {
 	}
 	if sc.restartCount != 4 {
 		t.Errorf("restartCount = %d, want 4", sc.restartCount)
+	}
+}
+
+func TestRestartServer_SSE_Success(t *testing.T) {
+	ts := startStreamableServer(t)
+	m := NewManager(testLogger(), config.MCPConfig{RequestTimeoutSecs: 10})
+	cfg := config.ToolConfig{
+		Transport:     "sse",
+		URL:           ts.URL,
+		AllowLoopback: true,
+	}
+
+	err := m.RegisterServer(context.Background(), "test-sse", cfg)
+	if err != nil {
+		t.Fatalf("initial registration failed: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	err = m.RestartServer(context.Background(), "test-sse")
+	if err != nil {
+		t.Fatalf("RestartServer failed: %v", err)
+	}
+
+	info, ok := m.ServerInfo("test-sse")
+	if !ok {
+		t.Fatal("server should be registered after restart")
+	}
+	if info.Status != "connected" {
+		t.Errorf("Status = %q, want %q", info.Status, "connected")
+	}
+	if len(info.ToolNames) != 1 || info.ToolNames[0] != "greet" {
+		t.Errorf("ToolNames = %v, want [greet]", info.ToolNames)
+	}
+}
+
+func TestRestartServer_SSE_RecoveryOnFailure(t *testing.T) {
+	ts := startStreamableServer(t)
+	m := NewManager(testLogger(), config.MCPConfig{RequestTimeoutSecs: 2})
+	cfg := config.ToolConfig{
+		Transport:     "sse",
+		URL:           ts.URL,
+		AllowLoopback: true,
+	}
+
+	err := m.RegisterServer(context.Background(), "test-sse", cfg)
+	if err != nil {
+		t.Fatalf("initial registration failed: %v", err)
+	}
+
+	// Shut down the remote server so reconnection fails.
+	ts.Close()
+
+	err = m.RestartServer(context.Background(), "test-sse")
+	if err == nil {
+		t.Fatal("expected error from RestartServer after remote server shutdown")
+	}
+
+	// The tool should still be visible with error status, not lost.
+	info, ok := m.ServerInfo("test-sse")
+	if !ok {
+		t.Fatal("server should still be registered after failed restart")
+	}
+	if info.Status != "error" {
+		t.Errorf("Status = %q, want %q", info.Status, "error")
+	}
+	if info.LastError == "" {
+		t.Error("LastError should be set after failed restart")
 	}
 }

--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -609,9 +609,13 @@ func (m *Manager) UnregisterServer(name string) error {
 
 	delete(m.servers, name)
 
+	// Best-effort session cleanup. The server is already removed from the map,
+	// so returning an error here would leave callers in an inconsistent state
+	// (entry gone but error returned). Log and move on.
 	if sc.session != nil {
 		if err := sc.session.Close(); err != nil {
-			return fmt.Errorf("closing MCP server %q: %w", name, err)
+			m.logger.Warn("error closing MCP session during unregister",
+				"server", name, "error", err)
 		}
 	}
 	return nil
@@ -619,6 +623,8 @@ func (m *Manager) UnregisterServer(name string) error {
 
 // RestartServer stops and re-registers an MCP server using its stored config.
 // It resets the server's health state (disabled flag, error, restart count).
+// If re-registration fails the server remains visible with status "error"
+// so the user can retry or the health checker can pick it up.
 func (m *Manager) RestartServer(ctx context.Context, name string) error {
 	m.mu.RLock()
 	sc, ok := m.servers[name]
@@ -627,13 +633,32 @@ func (m *Manager) RestartServer(ctx context.Context, name string) error {
 		return fmt.Errorf("server %q is not registered", name)
 	}
 	cfg := sc.cfg
+	transport := sc.transport
+	url := sc.url
 	m.mu.RUnlock()
 
 	if err := m.UnregisterServer(name); err != nil {
 		return fmt.Errorf("stopping server %q: %w", name, err)
 	}
 
+	// Re-add a placeholder so registerSSE sees isReregistration=true (needed
+	// for OAuth tools) and so the tool stays visible if RegisterServer fails.
+	m.mu.Lock()
+	placeholder := &serverConn{
+		name:      name,
+		transport: transport,
+		url:       url,
+		cfg:       cfg,
+	}
+	m.servers[name] = placeholder
+	m.mu.Unlock()
+
 	if err := m.RegisterServer(ctx, name, cfg); err != nil {
+		// Registration failed — keep the placeholder with error status so the
+		// tool remains visible in the UI and can be retried.
+		m.mu.Lock()
+		placeholder.lastError = err.Error()
+		m.mu.Unlock()
 		return fmt.Errorf("restarting server %q: %w", name, err)
 	}
 
@@ -883,12 +908,19 @@ func (m *Manager) handleServerFailure(ctx context.Context, sc *serverConn, maxAt
 
 	// Close old session, re-register.
 	_ = m.UnregisterServer(name)
+
+	// Re-add the old entry so registerSSE sees isReregistration=true (needed
+	// for OAuth tools) and so the tool stays visible if RegisterServer fails.
+	// Keep sc.session as-is (closed but non-nil) so the health checker's
+	// next cycle can probe it, fail, and retry via handleServerFailure.
+	m.mu.Lock()
+	m.servers[name] = sc
+	m.mu.Unlock()
+
 	if err := m.RegisterServer(ctx, name, cfg); err != nil {
 		m.logger.Error("MCP server restart failed", "server", name, "attempt", attempt, "error", err)
 		m.mu.Lock()
-		// Re-add a placeholder so the next health check can retry.
 		sc.lastError = err.Error()
-		m.servers[name] = sc
 		m.mu.Unlock()
 	} else {
 		m.logger.Info("MCP server restarted successfully", "server", name, "attempt", attempt)


### PR DESCRIPTION
Three issues caused remote MCP tools to vanish when restarted:

1. UnregisterServer deleted the server from the map before closing the
   session. If session.Close() failed (e.g. remote server already down),
   the error was returned but the entry was already gone — leaving the
   system in an inconsistent state. Fixed by making session close
   best-effort (log warning instead of returning error).

2. RestartServer had no recovery path when RegisterServer failed after
   UnregisterServer. The tool was permanently lost from the server map,
   invisible to the health checker and UI. Fixed by inserting a
   placeholder entry before re-registration that persists with error
   status on failure.

3. Both RestartServer and handleServerFailure called UnregisterServer
   (which deletes from the map) before RegisterServer, causing
   registerSSE's isReregistration check to return false. For OAuth
   tools without a cached token this triggered an early return to
   pending_auth state instead of reconnecting. Fixed by inserting the
   placeholder before RegisterServer so isReregistration is true.

https://claude.ai/code/session_01AZ6EVScwweVr16h2ZCEaWa