### PR TITLE
feat(approval): replace "session" auto-approve with time-limited 15 min rules

### DIFF
--- a/internal/agent/dispatcher.go
+++ b/internal/agent/dispatcher.go
@@ -397,7 +397,7 @@ func (d *Dispatcher) handleToolApproval(ctx context.Context, a adapter.Adapter, 
 			Buttons: []adapter.KeyboardButton{
 				{Label: "✅ Approve", CallbackData: evt.ApprovalCallback + ":approve"},
 				{Label: "❌ Deny", CallbackData: evt.ApprovalCallback + ":deny"},
-				{Label: "🔄 Auto (session)", CallbackData: evt.ApprovalCallback + ":approve_session"},
+				{Label: "🔄 Auto (15 min)", CallbackData: evt.ApprovalCallback + ":approve_session"},
 				{Label: "♾️ Auto (always)", CallbackData: evt.ApprovalCallback + ":approve_always"},
 			},
 		})
@@ -417,7 +417,7 @@ func (d *Dispatcher) handleToolApproval(ctx context.Context, a adapter.Adapter, 
 		Buttons: []adapter.KeyboardButton{
 			{Label: "✅ Approve", CallbackData: evt.ApprovalCallback + ":approve"},
 			{Label: "❌ Deny", CallbackData: evt.ApprovalCallback + ":deny"},
-			{Label: "🔄 Session", CallbackData: evt.ApprovalCallback + ":approve_session"},
+			{Label: "🔄 15 min", CallbackData: evt.ApprovalCallback + ":approve_session"},
 			{Label: "♾️ Always", CallbackData: evt.ApprovalCallback + ":approve_always"},
 		},
 		ButtonLayout: []int{2, 2},

--- a/internal/approval/autoapprove.go
+++ b/internal/approval/autoapprove.go
@@ -20,14 +20,15 @@ const (
 )
 
 // AutoApproveRule is a rule that allows a specific tool to bypass the approval
-// workflow for a given agent. Session-scoped rules are held in memory;
-// permanent rules are persisted in SQLite.
+// workflow for a given agent. Session-scoped rules are held in memory and
+// expire after a TTL; permanent rules are persisted in SQLite.
 type AutoApproveRule struct {
 	ID             string           `db:"id"              json:"id"`
 	AgentName      string           `db:"agent_name"      json:"agent_name"`
 	ToolName       string           `db:"tool_name"       json:"tool_name"`
 	Scope          AutoApproveScope `db:"scope"           json:"scope"`
 	ConversationID string           `db:"conversation_id" json:"conversation_id,omitempty"`
+	ExpiresAt      *time.Time       `db:"-"               json:"expires_at,omitempty"`
 	CreatedAt      time.Time        `db:"created_at"      json:"created_at"`
 	CreatedBy      string           `db:"created_by"      json:"created_by"`
 }

--- a/internal/approval/autoapprove_test.go
+++ b/internal/approval/autoapprove_test.go
@@ -3,6 +3,7 @@ package approval
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestShouldAutoApprove_NoRules(t *testing.T) {
@@ -366,5 +367,60 @@ func TestAutoResolvePending_SessionRule(t *testing.T) {
 
 	if !resolved {
 		t.Error("expected pending approval to be auto-resolved by session rule")
+	}
+}
+
+func TestShouldAutoApprove_SessionRuleExpired(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	// Manually store an already-expired session rule.
+	key := sessionRuleKey("default", "conv1", "web_search")
+	m.sessionRules.Store(key, time.Now().Add(-1*time.Minute))
+
+	ok, _ := m.ShouldAutoApprove(ctx, "default", "web_search", "conv1")
+	if ok {
+		t.Error("expired session rule should not match")
+	}
+
+	// Verify the expired rule was cleaned up.
+	if _, loaded := m.sessionRules.Load(key); loaded {
+		t.Error("expired session rule should have been deleted")
+	}
+}
+
+func TestListAutoApproveRules_ExcludesExpired(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	// Add one active and one expired session rule.
+	m.AddSessionRule(ctx, "default", "tool_active", "conv1", "test")
+
+	expiredKey := sessionRuleKey("default", "conv1", "tool_expired")
+	m.sessionRules.Store(expiredKey, time.Now().Add(-1*time.Minute))
+
+	rules, err := m.ListAutoApproveRules(ctx, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range rules {
+		if r.ToolName == "tool_expired" {
+			t.Error("expired session rule should not appear in listing")
+		}
+	}
+
+	// The active rule should be present.
+	found := false
+	for _, r := range rules {
+		if r.ToolName == "tool_active" {
+			found = true
+			if r.ExpiresAt == nil {
+				t.Error("active session rule should have ExpiresAt set")
+			}
+		}
+	}
+	if !found {
+		t.Error("active session rule should appear in listing")
 	}
 }

--- a/internal/approval/callback.go
+++ b/internal/approval/callback.go
@@ -59,7 +59,7 @@ func (h *Handler) Resolve(ctx context.Context, data string) (string, error) {
 	_, action, _ := parseCallback(data)
 	switch action {
 	case CallbackApproveSession:
-		return "✅ Approved (auto-approve for this session): " + resolved.Summary, nil
+		return "✅ Approved (auto-approve for 15 min): " + resolved.Summary, nil
 	case CallbackApproveAlways:
 		return "✅ Approved (auto-approve always): " + resolved.Summary, nil
 	case CallbackApprove:

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -62,6 +62,10 @@ func NewManager(store Store, logger *slog.Logger) *Manager {
 // automatically expired by the background worker.
 const DefaultTTL = 24 * time.Hour
 
+// SessionRuleTTL is the duration a session auto-approve rule stays active.
+// After this period, the rule expires and the user must re-approve.
+const SessionRuleTTL = 15 * time.Minute
+
 // Submit creates a new pending approval, registers the action closure, and
 // returns the persisted Request with its ID populated. The request expires
 // after DefaultTTL if not resolved.
@@ -419,10 +423,14 @@ func sessionRuleKey(agentName, conversationID, toolName string) string {
 // It checks session rules (in-memory) first, then permanent rules (DB).
 // Returns (true, scope) on match, (false, "") on no match.
 func (m *Manager) ShouldAutoApprove(ctx context.Context, agentName, toolName, conversationID string) (bool, AutoApproveScope) {
-	// 1. Session rules (in-memory, conversation-scoped).
+	// 1. Session rules (in-memory, conversation-scoped, time-limited).
 	key := sessionRuleKey(agentName, conversationID, toolName)
-	if _, ok := m.sessionRules.Load(key); ok {
-		return true, ScopeSession
+	if v, ok := m.sessionRules.Load(key); ok {
+		if expiresAt, isTime := v.(time.Time); isTime && time.Now().Before(expiresAt) {
+			return true, ScopeSession
+		}
+		// Expired — clean up lazily.
+		m.sessionRules.Delete(key)
 	}
 
 	// 2. Permanent rules (DB, agent-scoped).
@@ -437,13 +445,16 @@ func (m *Manager) ShouldAutoApprove(ctx context.Context, agentName, toolName, co
 	return false, ""
 }
 
-// AddSessionRule creates an ephemeral auto-approve rule for the current conversation.
+// AddSessionRule creates a time-limited auto-approve rule for the current conversation.
+// The rule expires after SessionRuleTTL (15 minutes).
 // After storing the rule it auto-resolves any pending approvals for the same agent+tool.
 func (m *Manager) AddSessionRule(ctx context.Context, agentName, toolName, conversationID, createdBy string) {
 	key := sessionRuleKey(agentName, conversationID, toolName)
-	m.sessionRules.Store(key, true)
+	expiresAt := time.Now().Add(SessionRuleTTL)
+	m.sessionRules.Store(key, expiresAt)
 	m.logger.Info("session auto-approve rule added",
-		"agent", agentName, "tool", toolName, "conversation", conversationID, "by", createdBy)
+		"agent", agentName, "tool", toolName, "conversation", conversationID,
+		"by", createdBy, "expires_at", expiresAt.Format(time.RFC3339))
 	m.autoResolvePending(ctx, agentName, toolName)
 }
 
@@ -522,10 +533,16 @@ func (m *Manager) ListAutoApproveRules(ctx context.Context, agentName string) ([
 		rules = append(rules, dbRules...)
 	}
 
-	// Session rules from memory.
-	m.sessionRules.Range(func(key, _ any) bool {
+	// Session rules from memory (skip expired).
+	now := time.Now()
+	m.sessionRules.Range(func(key, val any) bool {
 		k, ok := key.(string)
 		if !ok {
+			return true
+		}
+		expiresAt, isTime := val.(time.Time)
+		if !isTime || !now.Before(expiresAt) {
+			m.sessionRules.Delete(key) // clean up expired
 			return true
 		}
 		parts := strings.SplitN(k, "\x00", 3)
@@ -541,6 +558,7 @@ func (m *Manager) ListAutoApproveRules(ctx context.Context, agentName string) ([
 			ToolName:       tool,
 			Scope:          ScopeSession,
 			ConversationID: convID,
+			ExpiresAt:      &expiresAt,
 		})
 		return true
 	})

--- a/web/src/__tests__/pages/Chat.test.js
+++ b/web/src/__tests__/pages/Chat.test.js
@@ -162,7 +162,8 @@ describe('Chat page', () => {
       const approveButtons = screen.getAllByText('Approve')
       expect(approveButtons.length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText('Deny').length).toBeGreaterThanOrEqual(1)
-      expect(screen.getAllByText('Always Approve').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('15 min').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText('Always').length).toBeGreaterThanOrEqual(1)
     })
   })
 

--- a/web/src/pages/Approvals.svelte
+++ b/web/src/pages/Approvals.svelte
@@ -154,7 +154,7 @@
 
 <!-- Auto-Approve Rules Section -->
 <h2 class="section-title">Auto-Approve Rules</h2>
-<p class="section-desc">Rules that automatically approve tool calls without prompting. Session rules are ephemeral; permanent rules survive restarts.</p>
+<p class="section-desc">Rules that automatically approve tool calls without prompting. Timed rules expire after 15 minutes; permanent rules survive restarts.</p>
 
 <ErrorBanner message={autoError} />
 

--- a/web/src/pages/Chat.svelte
+++ b/web/src/pages/Chat.svelte
@@ -259,7 +259,8 @@
           <div class="approval-actions">
             <button class="btn-appr btn-ok" onclick={() => resolvePending(appr, true)} disabled={appr._resolving} aria-label="Approve tool {appr.summary}">Approve</button>
             <button class="btn-appr btn-bad" onclick={() => resolvePending(appr, false)} disabled={appr._resolving} aria-label="Deny tool {appr.summary}">Deny</button>
-            <button class="btn-appr btn-auto" onclick={() => resolvePending(appr, true, 'permanent')} disabled={appr._resolving} title="Permanently auto-approve this tool for this agent" aria-label="Always approve {appr.summary}">Always Approve</button>
+            <button class="btn-appr btn-session" onclick={() => resolvePending(appr, true, 'session')} disabled={appr._resolving} title="Auto-approve this tool for the next 15 minutes" aria-label="Approve {appr.summary} for 15 minutes">15 min</button>
+            <button class="btn-appr btn-auto" onclick={() => resolvePending(appr, true, 'permanent')} disabled={appr._resolving} title="Permanently auto-approve this tool for this agent" aria-label="Always approve {appr.summary}">Always</button>
           </div>
         </div>
       {/each}
@@ -308,7 +309,8 @@
                       <div class="approval-actions">
                         <button class="btn-appr btn-ok" onclick={() => resolveApproval(appr, true)} disabled={appr.resolving} aria-label="Approve {appr.tool}">Approve</button>
                         <button class="btn-appr btn-bad" onclick={() => resolveApproval(appr, false)} disabled={appr.resolving} aria-label="Deny {appr.tool}">Deny</button>
-                        <button class="btn-appr btn-auto" onclick={() => resolveApproval(appr, true, 'permanent')} disabled={appr.resolving} title="Permanently auto-approve this tool for this agent" aria-label="Always approve {appr.tool}">Always Approve</button>
+                        <button class="btn-appr btn-session" onclick={() => resolveApproval(appr, true, 'session')} disabled={appr.resolving} title="Auto-approve this tool for the next 15 minutes" aria-label="Approve {appr.tool} for 15 minutes">15 min</button>
+                        <button class="btn-appr btn-auto" onclick={() => resolveApproval(appr, true, 'permanent')} disabled={appr.resolving} title="Permanently auto-approve this tool for this agent" aria-label="Always approve {appr.tool}">Always</button>
                       </div>
                     {:else}
                       <span class="approval-badge">{approvalStatusLabel(appr.status)}</span>
@@ -592,6 +594,8 @@
   .btn-ok:hover:not(:disabled) { background: var(--accent); color: #fff; }
   .btn-bad { border-color: var(--danger); color: var(--danger); }
   .btn-bad:hover:not(:disabled) { background: var(--danger); color: #fff; }
+  .btn-session { border-color: var(--accent); color: var(--accent); opacity: 0.75; }
+  .btn-session:hover:not(:disabled) { background: var(--accent); color: #fff; opacity: 1; }
   .btn-auto { border-color: var(--text-muted); color: var(--text-muted); }
   .btn-auto:hover:not(:disabled) { background: var(--text-muted); color: #fff; }
   .approval-badge {


### PR DESCRIPTION
The "approve for session" concept was abstract and confusing. This replaces it
with a concrete 15-minute TTL: session rules now expire after 15 minutes,
lazily cleaned up on access and listing. Button labels updated across all
interfaces (Telegram, Discord, Web UI) from "Session" to "15 min". The web UI
Chat page now includes a "15 min" button (previously only had "Always Approve").

https://claude.ai/code/session_01TpKQa42yYzywGH39Jwm7Ef