### PR TITLE
feat(agents): make max tool rounds configurable (default 50)

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -27,7 +27,7 @@ import (
 )
 
 const defaultMaxContextMessages = 50
-const defaultMaxToolRounds = 10
+const defaultMaxToolRounds = 50
 const defaultRepeatDetectionThreshold = 3 // consecutive identical tool calls before abort
 const toolExecTimeout = 30 * time.Second
 const defaultApprovalTimeout = 5 * time.Minute
@@ -171,6 +171,11 @@ func (e *Engine) SetMaxContextMessages(n int) {
 	if n > 0 {
 		e.maxContextMessages = n
 	}
+}
+
+// MaxToolRounds returns the current tool round limit.
+func (e *Engine) MaxToolRounds() int {
+	return e.maxToolRounds
 }
 
 // SetMaxToolRounds overrides the default tool round limit.

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -25,6 +25,7 @@ type agentConfigUpdateInput struct {
 	LLMProvider         *string                  `json:"llm_provider,omitempty"`
 	LLMModel            *string                  `json:"llm_model,omitempty"`
 	Description         *string                  `json:"description,omitempty"`
+	MaxToolRounds       *int                     `json:"max_tool_rounds,omitempty"`
 	BrowserURLAllowlist *[]string                `json:"browser_url_allowlist,omitempty"`
 	Fallbacks           *[]config.FallbackConfig `json:"fallbacks,omitempty"`
 }
@@ -105,6 +106,12 @@ func applyAgentRuntimeChanges(e *agent.Engine, input *agentConfigUpdateInput) (i
 	if input.LLMModel != nil {
 		e.SetModel(*input.LLMModel)
 	}
+	if input.MaxToolRounds != nil {
+		if *input.MaxToolRounds <= 0 {
+			return http.StatusBadRequest, "max_tool_rounds must be >= 1"
+		}
+		e.SetMaxToolRounds(*input.MaxToolRounds)
+	}
 	if input.Fallbacks != nil {
 		e.LLMRouter().SetFallbacks(convertFallbackConfigs(*input.Fallbacks))
 	}
@@ -171,6 +178,9 @@ func (s *Server) persistAgentConfig(name string, input *agentConfigUpdateInput) 
 	if input.Description != nil {
 		changes["description"] = *input.Description
 	}
+	if input.MaxToolRounds != nil {
+		changes["max_tool_rounds"] = *input.MaxToolRounds
+	}
 	if input.BrowserURLAllowlist != nil {
 		allowlist := make([]any, len(*input.BrowserURLAllowlist))
 		for i, d := range *input.BrowserURLAllowlist {
@@ -227,6 +237,9 @@ func applyAgentFields(ac *config.AgentInstanceConfig, input *agentConfigUpdateIn
 	}
 	if input.Description != nil {
 		ac.Description = *input.Description
+	}
+	if input.MaxToolRounds != nil {
+		ac.MaxToolRounds = *input.MaxToolRounds
 	}
 	if input.BrowserURLAllowlist != nil {
 		ac.BrowserURLAllowlist = *input.BrowserURLAllowlist

--- a/internal/api/agents_test.go
+++ b/internal/api/agents_test.go
@@ -516,6 +516,105 @@ func TestAgentDetail_IncludesFallbacks(t *testing.T) {
 	}
 }
 
+func TestAgentConfigUpdate_MaxToolRounds(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"max_tool_rounds": 25})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/agents/default", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	// Verify runtime value changed on the engine.
+	e := deps.Dispatcher.Agent("default")
+	if e.MaxToolRounds() != 25 {
+		t.Errorf("max_tool_rounds = %d, want 25", e.MaxToolRounds())
+	}
+
+	// Verify in-memory config updated.
+	var found bool
+	for _, ac := range deps.Config.Agents {
+		if ac.Name == "default" {
+			found = true
+			if ac.MaxToolRounds != 25 {
+				t.Errorf("config max_tool_rounds = %d, want 25", ac.MaxToolRounds)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("agent 'default' not found in config")
+	}
+}
+
+func TestAgentConfigUpdate_MaxToolRounds_Zero(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	srv := New(cfg, testDeps(), testLogger())
+
+	body, _ := json.Marshal(map[string]any{"max_tool_rounds": 0})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/agents/default", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAgentConfigUpdate_MaxToolRounds_Negative(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	srv := New(cfg, testDeps(), testLogger())
+
+	body, _ := json.Marshal(map[string]any{"max_tool_rounds": -1})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/agents/default", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAgentDetail_IncludesMaxToolRounds(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	srv := New(cfg, deps, testLogger())
+
+	req := authedRequest(http.MethodGet, "/api/v1/agents/default")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	mtr, ok := resp["max_tool_rounds"].(float64)
+	if !ok {
+		t.Fatalf("max_tool_rounds field missing or wrong type: %v", resp["max_tool_rounds"])
+	}
+	if int(mtr) != 50 {
+		t.Errorf("max_tool_rounds = %d, want 50 (default)", int(mtr))
+	}
+}
+
 func TestAgentDetail_FallbacksEmptyNotNull(t *testing.T) {
 	cfg := testConfig(allScopesKey())
 	deps := testDeps()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -452,6 +452,7 @@ func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {
 		"permission_tier":  e.PermissionTier(),
 		"provider":         e.ProviderName(),
 		"model":            e.ModelName(),
+		"max_tool_rounds":  e.MaxToolRounds(),
 		"has_tools":        e.HasTools(),
 		"adapters":         adapters,
 		"skills":           skillList,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -417,7 +417,8 @@ type AgentInstanceConfig struct {
 	MaxContextMessages int `toml:"max_context_messages"`
 
 	// MaxToolRounds limits the number of tool-call rounds per message.
-	// 0 means use the default (10).
+	// 0 means use the default (50). The REST API requires >= 1; the zero
+	// default sentinel is only valid in TOML config (at startup).
 	MaxToolRounds int `toml:"max_tool_rounds"`
 
 	// Fallbacks overrides the global [[llm.fallback]] rules for this agent.

--- a/internal/integration/agent_config_test.go
+++ b/internal/integration/agent_config_test.go
@@ -140,6 +140,36 @@ func TestAgentConfig_RenameToDuplicate(t *testing.T) {
 	}
 }
 
+func TestAgentConfig_UpdateMaxToolRounds(t *testing.T) {
+	h := NewHarness(t, nil)
+
+	rec := h.Do(h.AuthedRequest(http.MethodPatch, "/api/v1/agents/default", map[string]any{
+		"max_tool_rounds": 25,
+	}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	// Verify via agent detail endpoint.
+	detailRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/agents/default", nil))
+	var detail map[string]any
+	DecodeJSON(t, detailRec, &detail)
+	if int(detail["max_tool_rounds"].(float64)) != 25 {
+		t.Errorf("max_tool_rounds = %v, want 25", detail["max_tool_rounds"])
+	}
+}
+
+func TestAgentConfig_UpdateMaxToolRounds_Invalid(t *testing.T) {
+	h := NewHarness(t, nil)
+
+	rec := h.Do(h.AuthedRequest(http.MethodPatch, "/api/v1/agents/default", map[string]any{
+		"max_tool_rounds": 0,
+	}))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
 func TestAgentConfig_NotFound(t *testing.T) {
 	h := NewHarness(t, nil)
 

--- a/web/src/pages/Agents.svelte
+++ b/web/src/pages/Agents.svelte
@@ -209,6 +209,7 @@
   let configModel = $state('')
   let configProvider = $state('')
   let configDescription = $state('')
+  let configMaxToolRounds = $state(0)
   let configAllowlist = $state('')
   let configSaving = $state(false)
   let configSaveOk = $state(false)
@@ -222,6 +223,7 @@
     configModel = d.model || ''
     configProvider = d.provider || ''
     configDescription = ''
+    configMaxToolRounds = d.max_tool_rounds ?? 50
     configAllowlist = ''
     if (agents.length) {
       const agentConf = agents.find(a => a.name === d.name)
@@ -256,6 +258,8 @@
         if (configDescription !== undefined) data.description = configDescription
       } else if (expandedCard === 'permission') {
         if (configTier !== detail.permission_tier) data.session_tier = configTier
+        const rounds = parseInt(configMaxToolRounds, 10)
+        if (!isNaN(rounds) && rounds !== detail.max_tool_rounds) data.max_tool_rounds = rounds
       }
       if (Object.keys(data).length) {
         await api.updateAgentConfig(detail.name, data)
@@ -519,6 +523,9 @@
                 <option value="supervised">Supervised</option>
                 <option value="restricted">Restricted</option>
               </select>
+              <label class="config-label" for="cfg-max-tool-rounds">Max Tool Rounds</label>
+              <input id="cfg-max-tool-rounds" class="config-input" type="number" min="1" max="500" bind:value={configMaxToolRounds} />
+              <span class="hint">Maximum tool-call rounds per message before the agent stops. Default: 50.</span>
             </div>
           {/if}
           <div class="config-panel-actions">


### PR DESCRIPTION
## Summary
- Increase default max tool-call rounds from 10 to 50
- Expose `max_tool_rounds` as a per-agent setting via `PATCH /api/v1/agents/{name}` and `GET /api/v1/agents/{name}` detail response
- Add number input in the Permission Configuration panel on the Agents web UI page
- Unit tests (happy path, zero rejection, negative rejection, detail response field) and integration tests (update + invalid)

## Test plan
- [x] Unit tests: `go test -race -run "TestAgentConfig|TestAgentDetail" ./internal/api/`
- [x] Integration tests: `go test -race -tags integration -run "TestAgentConfig_UpdateMaxToolRounds" ./internal/integration/`
- [x] Web UI tests: `just test-ui` (552 tests pass)
- [ ] Manual: open Agents page, expand Permission card, verify Max Tool Rounds field shows current value, change it, save, reload and confirm persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)