### PR TITLE
chore: log max_tool_rounds in agent init

### DIFF
--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -1083,6 +1083,7 @@ func buildAgentEngine(ctx context.Context, ac config.AgentInstanceConfig, abc ag
 		"model", model,
 		"tier", tier,
 		"skills", len(sr.skills),
+		"max_tool_rounds", e.MaxToolRounds(),
 	)
 
 	return e, bindings, nil


### PR DESCRIPTION
## Summary
- Add `max_tool_rounds` to the existing "agent initialized" startup log line
- Gives operators visibility into the effective value without inspecting TOML config

## Test plan
- [x] `go build ./...` compiles clean
- [ ] Manual: start the server, verify log line includes `max_tool_rounds=50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)