### PR TITLE
fix(api): drop redundant adapter notification on approval resolve

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1536,20 +1536,10 @@ func (s *Server) handleResolveApproval(approved bool) http.HandlerFunc {
 			}
 		}
 
-		// Notify the originating adapter channel of the resolution.
-		action := "Denied"
-		if approved {
-			action = "Approved"
-		}
-		notifyMsg := fmt.Sprintf("%s via API: %s", action, resolved.Summary)
-		if err := s.deps.Dispatcher.SendVia(r.Context(), resolved.AdapterName, adapter.OutgoingMessage{
-			ExternalID: resolved.ExternalID,
-			Text:       notifyMsg,
-		}); err != nil {
-			// Non-fatal: the action was already applied; just log.
-			s.logger.Warn("failed to send approval notification", "id", id, "error", err)
-		}
-
+		// The originating adapter is updated via the engine's event stream:
+		// approval resumes → engine emits tool_start/tool_end (or tool_approval
+		// status="denied"), which the dispatcher folds into the activity log
+		// in-place. Audit log records the API resolution via Manager.Resolve.
 		writeJSON(w, http.StatusOK, resolved)
 	}
 }

--- a/internal/integration/approval_test.go
+++ b/internal/integration/approval_test.go
@@ -5,10 +5,43 @@ package integration
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 
+	"github.com/Temikus/denkeeper/internal/adapter"
 	"github.com/Temikus/denkeeper/internal/approval"
+	"github.com/Temikus/denkeeper/internal/audit"
 )
+
+// recordingAdapter is a minimal adapter.Adapter implementation that records
+// every Send call. Used by tests that need to assert no adapter-level message
+// was emitted (e.g. that the API approval handler does not push a redundant
+// notification on top of the engine-driven activity log).
+type recordingAdapter struct {
+	name string
+	mu   sync.Mutex
+	sent []adapter.OutgoingMessage
+}
+
+func (r *recordingAdapter) Name() string { return r.name }
+func (r *recordingAdapter) Start(_ context.Context, _ chan<- adapter.IncomingMessage) error {
+	select {} // never delivers — tests submit approvals directly via the manager
+}
+func (r *recordingAdapter) Send(_ context.Context, msg adapter.OutgoingMessage) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sent = append(r.sent, msg)
+	return nil
+}
+func (r *recordingAdapter) SendTyping(_ context.Context, _ string) error { return nil }
+func (r *recordingAdapter) Stop() error                                  { return nil }
+func (r *recordingAdapter) Sent() []adapter.OutgoingMessage {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]adapter.OutgoingMessage, len(r.sent))
+	copy(out, r.sent)
+	return out
+}
 
 func TestApproval_SubmitAndApproveViaAPI(t *testing.T) {
 	h := NewHarness(t, nil)
@@ -96,6 +129,78 @@ func TestApproval_ApproveNonexistent_Returns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// TestApproval_ResolveViaAPI_DoesNotNotifyAdapter locks in the contract that
+// the API approval handler does not push a redundant raw notification onto the
+// originating adapter. Resolution feedback flows exclusively through the
+// engine event stream (tool_start/tool_end → activity log) and the audit log.
+// See server.go:handleResolveApproval for the rationale.
+func TestApproval_ResolveViaAPI_DoesNotNotifyAdapter(t *testing.T) {
+	rec := &recordingAdapter{name: "telegram"}
+	h := NewHarness(t, &HarnessOpts{Adapters: []adapter.Adapter{rec}})
+
+	// Approve path.
+	approveReq, err := h.Approvals.Submit(
+		context.Background(),
+		"default", approval.ActionKindUserUpdate,
+		"approve this", "payload",
+		"chat-123", "telegram", "session-1",
+		func(_ context.Context, _ string) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("Submit approve: %v", err)
+	}
+	resp := h.Do(h.AuthedRequest(http.MethodPost, "/api/v1/approvals/"+approveReq.ID+"/approve", nil))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("approve status = %d, body: %s", resp.Code, resp.Body.String())
+	}
+
+	// Deny path.
+	denyReq, err := h.Approvals.Submit(
+		context.Background(),
+		"default", approval.ActionKindUserUpdate,
+		"deny this", "payload",
+		"chat-123", "telegram", "session-1",
+		func(_ context.Context, _ string) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("Submit deny: %v", err)
+	}
+	resp = h.Do(h.AuthedRequest(http.MethodPost, "/api/v1/approvals/"+denyReq.ID+"/deny", nil))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("deny status = %d, body: %s", resp.Code, resp.Body.String())
+	}
+
+	if got := rec.Sent(); len(got) != 0 {
+		t.Errorf("adapter Send called %d time(s); want 0. Messages: %+v", len(got), got)
+	}
+
+	// Audit log must still record both resolutions so operators have a record
+	// of the API-driven decision even though no adapter message was emitted.
+	h.FlushAudit(t)
+	events, _, err := h.AuditStore.List(context.Background(), audit.ListOpts{Category: audit.CategoryApproval})
+	if err != nil {
+		t.Fatalf("listing audit events: %v", err)
+	}
+	approveSeen, denySeen := false, false
+	for _, e := range events {
+		if e.Source != "api" {
+			continue
+		}
+		switch e.Action {
+		case "approve":
+			approveSeen = true
+		case "deny":
+			denySeen = true
+		}
+	}
+	if !approveSeen {
+		t.Error("expected audit event with action=approve, source=api")
+	}
+	if !denySeen {
+		t.Error("expected audit event with action=deny, source=api")
 	}
 }
 

--- a/internal/integration/harness_test.go
+++ b/internal/integration/harness_test.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/Temikus/denkeeper/internal/adapter"
 	"github.com/Temikus/denkeeper/internal/agent"
 	"github.com/Temikus/denkeeper/internal/api"
 	"github.com/Temikus/denkeeper/internal/approval"
@@ -184,6 +185,11 @@ type HarnessOpts struct {
 	// RestartFunc, when non-nil, populates deps.RestartFunc so that
 	// POST /api/v1/server/restart invokes this callback instead of returning 503.
 	RestartFunc func() error
+
+	// Adapters registers adapters with the dispatcher. Tests that need to
+	// observe (or assert the absence of) adapter Send calls should provide a
+	// recording mock here.
+	Adapters []adapter.Adapter
 }
 
 type agentSetup struct {
@@ -257,6 +263,10 @@ func NewHarness(t *testing.T, opts *HarnessOpts) *Harness {
 	auditor := audit.NewBufferedEmitter(auditStore, 100, logger)
 	auditor.Start(context.Background())
 	t.Cleanup(func() { auditor.Close() })
+
+	// Wire the auditor into the approval manager so resolutions land in the
+	// audit log (the runtime wires this in cmd/denkeeper/main.go).
+	approvalMgr.Auditor = auditor
 
 	costTracker := llm.NewCostTracker(llm.SessionLimits{Hard: 10.0}, nil)
 
@@ -336,7 +346,7 @@ func NewHarness(t *testing.T, opts *HarnessOpts) *Harness {
 	if len(opts.Channels) > 0 {
 		dispatcherOpts = append(dispatcherOpts, agent.WithChannels(opts.Channels, mem))
 	}
-	dispatcher := agent.NewDispatcher(engines, bindings, nil, logger, dispatcherOpts...)
+	dispatcher := agent.NewDispatcher(engines, bindings, opts.Adapters, logger, dispatcherOpts...)
 
 	// Wire Config MCP channel tools into the ToolManager after dispatcher creation.
 	if opts.WithConfigMCP && len(opts.Channels) > 0 {


### PR DESCRIPTION
## Summary

- Removes the `SendVia` call in `handleResolveApproval` that was pushing a raw `Approved/Denied via API: Execute tool "..." with args: {...}` message directly into the originating adapter (Telegram). This landed as an unformatted, full-JSON notification on top of the engine-driven activity log, which already shows the resolution in-place via `tool_start`/`tool_end` events.
- Adds `TestApproval_ResolveViaAPI_DoesNotNotifyAdapter` to lock in the no-adapter-send contract, asserting both the negative (zero `adapter.Send` calls) and the positive (audit log records the API resolution).
- Extends `HarnessOpts` with `Adapters []adapter.Adapter` so tests can inject recording adapters into the dispatcher.
- Wires `approvalMgr.Auditor = auditor` in the integration test harness — closing a production-vs-test parity gap; the runtime wires this in `cmd/denkeeper/main.go` but the harness did not, meaning audit assertions on approval events were silently wrong.

## Why the removal is safe

The approval is pinned to the `adapterName`/`externalID` where the originating message came from (stored in the approval record). When a Telegram-originated approval is resolved via the web UI:
1. The engine unblocks from `WaitForResolution`.
2. It emits `tool_start` → dispatcher's `onEvent` clears the pending state and edits the activity log in-place (buttons removed, ⏳ shown).
3. It emits `tool_end` → activity log shows ✅/❌.
4. `Manager.Resolve` already emits an `audit.CategoryApproval` event with `Source: "api"`, so operators retain a full record.

The removed `SendVia` call was therefore pure noise that duplicated information already conveyed by the activity log update.

## Test plan

- [x] `go test -race ./internal/api/ ./internal/approval/` — passes
- [x] `go test -tags=integration -race ./internal/integration/` — passes (including new `TestApproval_ResolveViaAPI_DoesNotNotifyAdapter`)
- [x] `golangci-lint run` — 0 issues
- [x] Full `go test -race ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)