### PR TITLE
feat(errors): user-friendly LLM error messages for adapters

### DIFF
--- a/internal/agent/dispatcher.go
+++ b/internal/agent/dispatcher.go
@@ -773,7 +773,7 @@ func (d *Dispatcher) handleMessage(ctx context.Context, wg *sync.WaitGroup, e *E
 		}
 		d.logger.Error("handling message", "error", err, "agent", e.Name(), "adapter", msg.Adapter, "user", msg.UserName)
 		span.RecordError(err)
-		d.sendErrorFeedback(msgCtx, msg)
+		d.sendErrorFeedback(msgCtx, msg, err)
 		return
 	}
 
@@ -1412,7 +1412,7 @@ func (d *Dispatcher) sendStandaloneApprovalPrompt(ctx context.Context, a adapter
 // sendErrorFeedback attempts to notify the user that their message could not be
 // processed. This prevents the silent-failure scenario where the user sends a
 // message and never receives any response.
-func (d *Dispatcher) sendErrorFeedback(ctx context.Context, msg adapter.IncomingMessage) {
+func (d *Dispatcher) sendErrorFeedback(ctx context.Context, msg adapter.IncomingMessage, err error) {
 	a, ok := d.adapters[msg.Adapter]
 	if !ok {
 		return
@@ -1420,7 +1420,7 @@ func (d *Dispatcher) sendErrorFeedback(ctx context.Context, msg adapter.Incoming
 	_ = a.Send(ctx, adapter.OutgoingMessage{
 		Adapter:    msg.Adapter,
 		ExternalID: msg.ExternalID,
-		Text:       "Sorry, I encountered an error processing your message. Please try again.",
+		Text:       llm.UserFacingError(err),
 	})
 }
 

--- a/internal/agent/dispatcher_test.go
+++ b/internal/agent/dispatcher_test.go
@@ -436,7 +436,7 @@ func TestDispatcher_SendErrorFeedback_OnEngineFailure(t *testing.T) {
 		Adapter:    "telegram",
 		ExternalID: "99999",
 	}
-	d.sendErrorFeedback(context.Background(), msg)
+	d.sendErrorFeedback(context.Background(), msg, fmt.Errorf("something broke"))
 
 	sent := ma.Sent()
 	if len(sent) != 1 {
@@ -456,7 +456,7 @@ func TestDispatcher_SendErrorFeedback_UnknownAdapter(t *testing.T) {
 
 	msg := adapter.IncomingMessage{Adapter: "nonexistent", ExternalID: "123"}
 	// Should not panic.
-	d.sendErrorFeedback(context.Background(), msg)
+	d.sendErrorFeedback(context.Background(), msg, fmt.Errorf("ignored"))
 }
 
 func TestStartTypingTicker_SendsTypingPeriodically(t *testing.T) {

--- a/internal/llm/usererror.go
+++ b/internal/llm/usererror.go
@@ -1,0 +1,32 @@
+package llm
+
+import (
+	"context"
+	"errors"
+)
+
+// UserFacingError translates an LLM pipeline error into a short, actionable
+// message for end users. Unknown errors get a generic fallback.
+func UserFacingError(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "The request to the LLM provider timed out. Please try again or consider using a faster model."
+	}
+
+	var llmErr *LLMError
+	if errors.As(err, &llmErr) {
+		switch llmErr.StatusCode {
+		case 401:
+			return "The LLM provider rejected the API key. Please check your provider configuration."
+		case 402:
+			return "The LLM provider ran out of credits or the request exceeds the available balance. Please top up your account or adjust model limits."
+		case 404:
+			return "The configured model was not found by the provider. Please check the agent's model setting."
+		case 422:
+			return "The LLM provider could not process the request. This usually indicates a configuration issue."
+		case 429:
+			return "The LLM provider is rate-limiting requests. Please try again in a moment."
+		}
+	}
+
+	return "Sorry, I encountered an error processing your message. Please try again."
+}

--- a/internal/llm/usererror_test.go
+++ b/internal/llm/usererror_test.go
@@ -1,0 +1,40 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestUserFacingError_LLMErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		substr string
+	}{
+		{"402 credits", fmt.Errorf("LLM completion: %w", &LLMError{StatusCode: 402, Message: "insufficient credits"}), "ran out of credits"},
+		{"401 auth", &LLMError{StatusCode: 401, Message: "invalid key"}, "rejected the API key"},
+		{"404 model", &LLMError{StatusCode: 404, Message: "model not found"}, "model was not found"},
+		{"422 unprocessable", &LLMError{StatusCode: 422, Message: "bad params"}, "configuration issue"},
+		{"429 rate limit", &LLMError{StatusCode: 429, Message: "slow down"}, "rate-limiting"},
+		{"500 generic LLM", &LLMError{StatusCode: 500, Message: "internal"}, "Sorry, I encountered an error"},
+		{"non-LLM error", fmt.Errorf("network timeout"), "Sorry, I encountered an error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UserFacingError(tt.err)
+			if !strings.Contains(got, tt.substr) {
+				t.Errorf("UserFacingError(%v) = %q, want substring %q", tt.err, got, tt.substr)
+			}
+		})
+	}
+}
+
+func TestUserFacingError_Timeout(t *testing.T) {
+	err := fmt.Errorf("chat completion: %w", context.DeadlineExceeded)
+	got := UserFacingError(err)
+	if !strings.Contains(got, "timed out") {
+		t.Errorf("UserFacingError(DeadlineExceeded) = %q, want substring %q", got, "timed out")
+	}
+}


### PR DESCRIPTION
## Summary
- Map `LLMError` status codes (401/402/404/422/429) and `context.DeadlineExceeded` to actionable user-facing strings instead of a generic fallback
- Extract into `llm.UserFacingError()` for reuse across adapters (Discord, REST)
- Add tests in `internal/llm/usererror_test.go`

## Test plan
- [x] `TestUserFacingError_LLMErrors` — all mapped status codes + generic fallback
- [x] `TestUserFacingError_Timeout` — deadline exceeded produces "timed out" message
- [x] `TestDispatcher_SendErrorFeedback_OnEngineFailure` — updated for new signature
- [x] Full `just hook` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)