### PR TITLE
feat(tools): enable/disable MCP servers + graceful config validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ cached_input = 0.5 # per million cached input tokens (0 = same as input)
 
 `internal/tool/manager.go` manages MCP server connections (stdio subprocess or SSE remote).
 
-**Health monitoring**: `StartHealthChecker(ctx, interval)` probes servers via ListTools every 30s. Crashed servers are auto-restarted with exponential backoff. Config: `[mcp]` section with `auto_restart` (default true), `max_restart_attempts` (default 3), `restart_cooldown` (default "5m"). `ServerStatus` reports `connected`/`error`/`disabled` with `restart_count`, `last_error`, `uptime_secs`. Manual restart via `Manager.RestartServer()`, `LifecycleManager.RestartTool()`, REST `POST /api/v1/tools/{name}/restart`, or Config MCP `tool_restart`.
+**Health monitoring**: `StartHealthChecker(ctx, interval)` probes servers via ListTools every 30s. Crashed servers are auto-restarted with exponential backoff. Config: `[mcp]` section with `auto_restart` (default true), `max_restart_attempts` (default 3), `restart_cooldown` (default "5m"). `ServerStatus` reports `connected`/`error`/`disabled`/`config_error` with `restart_count`, `last_error`, `uptime_secs`, `enabled`, `config_error`. Manual restart via `Manager.RestartServer()`, `LifecycleManager.RestartTool()`, REST `POST /api/v1/tools/{name}/restart`, or Config MCP `tool_restart`. Enable/disable via `LifecycleManager.EnableTool()`/`DisableTool()`, REST `POST /api/v1/tools/{name}/enable` and `/disable`.
 
 **OAuth 2.1 for MCP tools**: `internal/tool/oauth/` implements the MCP OAuth 2.1 spec for remote SSE tool servers that require authorization. Config per tool: `auth = "oauth"` with optional `client_id`, `client_secret`, `scopes`. OAuth routes are mounted at `/api/v1/tools/{name}/oauth/...`. Token storage in SQLite. `api.external_url` used for callback URL construction.
 
@@ -142,6 +142,8 @@ Key endpoints (all require auth unless noted):
 - `GET/POST/PUT/DELETE /api/v1/tools/...` — tool/plugin CRUD (PUT for edit)
 - `GET /api/v1/tools/{name}/health` (scope `tools:read`) — server health status
 - `POST /api/v1/tools/{name}/restart` (scope `tools:write`) — manually restart a tool server
+- `POST /api/v1/tools/{name}/enable` (scope `tools:write`) — enable a disabled tool server; starts the MCP process and persists to TOML
+- `POST /api/v1/tools/{name}/disable` (scope `tools:write`) — disable a tool server; stops the MCP process and persists `enabled = false` to TOML
 - `POST /api/v1/agents` (scope `admin`) — create a new agent; body: `{name, llm_provider, llm_model, session_tier, description, create_supervisor}`. Optional `create_supervisor: {name, llm_model, timeout, context_messages}` atomically creates a companion supervisor when `session_tier="supervised"`. Creates persona directory, persists to `[[agents]]` in TOML.
 - `PATCH /api/v1/agents/{name}` — agent config mutation; supports `name` (rename), `session_tier`, `llm_provider`, `llm_model`, `description`, `browser_url_allowlist`, `fallbacks`, `cost_limit_soft`, `cost_limit_hard`, `supervisor`, `supervisor_timeout`, `supervisor_context_messages`
 - `DELETE /api/v1/agents/{name}` (scope `admin`) — remove agent. Rejects if referenced by channels/schedules or if it is the last agent. Removes from TOML. Does not delete persona files.
@@ -234,6 +236,8 @@ Things you can't infer by reading the code at a glance:
 - **Safety commands**: panic state is transient (cleared on restart). `Scheduler.Pause()/Resume()` cancels entry goroutines without cancelling the root context. Dispatcher keys in-flight requests by `adapter:externalID`.
 - **Pricing lookup priority**: provider-reported > registry exact > registry longest-prefix > `[costs]` fallback > $0 (with warning). Source ends up as the `pricing_source` OTel attribute.
 - **MCP server health**: `StartHealthChecker` polls via `ListTools` every 30s. Restart defaults: `auto_restart=true`, `max_restart_attempts=3`, `restart_cooldown=5m`.
+- **Tool `enabled` field**: `ToolConfig.Enabled *bool` — `nil` (absent in TOML) defaults to `true` via `applyToolDefaults`. Explicit `enabled = false` disables without removing the config. `IsEnabled()` helper method. Config writer omits the key when true (backward compat).
+- **Graceful tool validation**: `validateTools` is non-fatal — invalid tools are auto-disabled with `Enabled = &false` and their validation error is stored in `Config.ToolWarnings`. The server starts and runs with the remaining valid tools. Invalid tools appear in the tools list with `config_error` status.
 - **Supervisor config validation**: supervisor must exist, must not itself be supervised (no chaining), must not use `supervised` tier (would deadlock), and `supervisor` is only valid on supervised agents. Delete guard rejects removing an agent referenced as a supervisor. `supervisor_timeout` is a Go duration string (e.g. `"30s"`, `"1m"`); `supervisor_context_messages` is an int (0 = use default of 5).
 - **Config MCP tools** (the in-process per-agent set, not the REST API): `schedule_update`, `schedule_delete`, `set_fallback`, `get_cost_summary`, `skill_delete`, `channel_list`, `channel_switch`, `channel_info`.
 - **Shared validators** (in `internal/config`): `ValidResourceName`, `ValidProviderType`, `IsProviderReferenced` — use these when adding new CRUD endpoints to keep validation consistent.

--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -518,10 +518,21 @@ func registerWithInitRetry(ctx context.Context, mgr *tool.Manager, mcpCfg config
 
 // registerNonOAuthTools registers tools that don't require OAuth at startup.
 // OAuth tools are deferred until after initOAuthSupport wires the handler factory.
-func registerNonOAuthTools(ctx context.Context, tools map[string]config.ToolConfig, mgr *tool.Manager, mcpCfg config.MCPConfig, logger *slog.Logger) error {
-	for name, tc := range tools {
+func registerNonOAuthTools(ctx context.Context, cfg *config.Config, mgr *tool.Manager, mcpCfg config.MCPConfig, logger *slog.Logger) error {
+	for name, tc := range cfg.Tools {
 		if tc.Auth == "oauth" {
 			logger.Info("tool server deferred (needs OAuth)", "name", name)
+			continue
+		}
+		if warning, hasWarning := cfg.ToolWarnings[name]; hasWarning {
+			logger.Warn("tool server has invalid configuration — registered as disabled",
+				"name", name, "error", warning)
+			mgr.RegisterDisabled(name, tc, warning, true)
+			continue
+		}
+		if !tc.IsEnabled() {
+			logger.Info("tool server disabled by config", "name", name)
+			mgr.RegisterDisabled(name, tc, "disabled by user", false)
 			continue
 		}
 		bg, err := registerWithInitRetry(ctx, mgr, mcpCfg, name, tc, logger)
@@ -543,6 +554,17 @@ func registerNonOAuthTools(ctx context.Context, tools map[string]config.ToolConf
 func registerDeferredOAuthTools(ctx context.Context, cfg *config.Config, mgr *tool.Manager, logger *slog.Logger) error {
 	for name, tc := range cfg.Tools {
 		if tc.Auth != "oauth" {
+			continue
+		}
+		if warning, hasWarning := cfg.ToolWarnings[name]; hasWarning {
+			logger.Warn("OAuth tool server has invalid configuration — registered as disabled",
+				"name", name, "error", warning)
+			mgr.RegisterDisabled(name, tc, warning, true)
+			continue
+		}
+		if !tc.IsEnabled() {
+			logger.Info("OAuth tool server disabled by config", "name", name)
+			mgr.RegisterDisabled(name, tc, "disabled by user", false)
 			continue
 		}
 		bg, err := registerWithInitRetry(ctx, mgr, cfg.MCP, name, tc, logger)
@@ -572,7 +594,7 @@ func initSharedTools(ctx context.Context, cfg *config.Config, logger *slog.Logge
 
 	if len(cfg.Tools) > 0 {
 		ensureToolMgr()
-		if err := registerNonOAuthTools(ctx, cfg.Tools, sharedToolMgr, cfg.MCP, logger); err != nil {
+		if err := registerNonOAuthTools(ctx, cfg, sharedToolMgr, cfg.MCP, logger); err != nil {
 			return nil, "", cleanups, err
 		}
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -247,6 +247,8 @@ func New(cfg config.APIConfig, deps Deps, logger *slog.Logger) *Server {
 	mux.HandleFunc("GET /api/v1/tools/{name}/health", s.RequireScope("tools:read", s.handleToolHealth))
 	mux.HandleFunc("POST /api/v1/tools/{name}/restart", s.RequireScope("tools:write", s.handleRestartTool))
 	mux.HandleFunc("PUT /api/v1/tools/{name}/disabled-tools", s.RequireScope("tools:write", s.handleUpdateDisabledTools))
+	mux.HandleFunc("POST /api/v1/tools/{name}/enable", s.RequireScope("tools:write", s.handleEnableTool))
+	mux.HandleFunc("POST /api/v1/tools/{name}/disable", s.RequireScope("tools:write", s.handleDisableTool))
 
 	// OAuth tool endpoints.
 	mux.HandleFunc("GET /api/v1/tools/oauth/callback", s.handleOAuthCallback) // no auth (browser redirect)
@@ -1890,6 +1892,10 @@ func (s *Server) handleGetTool(w http.ResponseWriter, r *http.Request) {
 		"restart_count": info.RestartCount,
 		"last_error":    info.LastError,
 		"uptime_secs":   info.UptimeSecs,
+		"enabled":       info.Enabled,
+	}
+	if info.ConfigError != "" {
+		resp["config_error"] = info.ConfigError
 	}
 	if info.AuthType != "" {
 		resp["auth_type"] = info.AuthType
@@ -2206,6 +2212,56 @@ func (s *Server) handleRestartTool(w http.ResponseWriter, r *http.Request) {
 	if err := s.deps.LifecycleMgr.RestartTool(r.Context(), name); err != nil {
 		s.logger.Error("restarting tool", "name", name, "error", err)
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+	info, _ := s.deps.LifecycleMgr.ToolManager().ServerInfo(name)
+	writeJSON(w, http.StatusOK, info)
+}
+
+// handleEnableTool godoc
+// @Summary Enable a tool server
+// @Description Starts a previously disabled MCP tool server and persists the change.
+// @Tags tools
+// @Produce json
+// @Security BearerAuth
+// @Param name path string true "Tool server name"
+// @Success 200 {object} tool.ServerStatus "Enabled tool server"
+// @Failure 400 {object} map[string]string
+// @Failure 503 {object} map[string]string "Tool management not configured"
+// @Router /tools/{name}/enable [post]
+func (s *Server) handleEnableTool(w http.ResponseWriter, r *http.Request) {
+	if !s.lifecycleRequired(w) {
+		return
+	}
+	name := r.PathValue("name")
+	if err := s.deps.LifecycleMgr.EnableTool(r.Context(), name); err != nil {
+		s.logger.Error("enabling tool", "name", name, "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	info, _ := s.deps.LifecycleMgr.ToolManager().ServerInfo(name)
+	writeJSON(w, http.StatusOK, info)
+}
+
+// handleDisableTool godoc
+// @Summary Disable a tool server
+// @Description Stops an MCP tool server and marks it as disabled.
+// @Tags tools
+// @Produce json
+// @Security BearerAuth
+// @Param name path string true "Tool server name"
+// @Success 200 {object} tool.ServerStatus "Disabled tool server"
+// @Failure 400 {object} map[string]string
+// @Failure 503 {object} map[string]string "Tool management not configured"
+// @Router /tools/{name}/disable [post]
+func (s *Server) handleDisableTool(w http.ResponseWriter, r *http.Request) {
+	if !s.lifecycleRequired(w) {
+		return
+	}
+	name := r.PathValue("name")
+	if err := s.deps.LifecycleMgr.DisableTool(r.Context(), name); err != nil {
+		s.logger.Error("disabling tool", "name", name, "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 	info, _ := s.deps.LifecycleMgr.ToolManager().ServerInfo(name)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,10 @@ type Config struct {
 	MCP       MCPConfig               `toml:"mcp"`
 	Costs     CostsConfig             `toml:"costs"`
 	Audit     AuditConfig             `toml:"audit"`
+
+	// ToolWarnings holds per-tool validation errors that were demoted to
+	// warnings (the tool is auto-disabled instead of blocking startup).
+	ToolWarnings map[string]string `toml:"-"`
 }
 
 // CostsConfig controls the pricing registry and cost calculation.
@@ -523,6 +527,7 @@ type MCPConfig struct {
 
 // ToolConfig defines an MCP tool server to spawn.
 type ToolConfig struct {
+	Enabled            *bool             `toml:"enabled"` // nil = true (default); explicit false = disabled
 	Command            string            `toml:"command"`
 	Args               []string          `toml:"args"`
 	Env                map[string]string `toml:"env"`
@@ -543,6 +548,11 @@ type ToolConfig struct {
 
 	// Unsafe options.
 	AllowLoopback bool `toml:"allow_loopback"` // bypass SSRF loopback block (localhost/127.x/::1)
+}
+
+// IsEnabled returns whether the tool server is enabled.
+func (tc ToolConfig) IsEnabled() bool {
+	return tc.Enabled == nil || *tc.Enabled
 }
 
 // PluginConfig defines a denkeeper plugin with explicit capability declarations.
@@ -886,6 +896,7 @@ func applyDefaults(cfg *Config) {
 	applyAgentDefaults(cfg)
 	synthesizeChannels(cfg)
 	applyScheduleDefaults(cfg)
+	applyToolDefaults(cfg)
 }
 
 // migrateCostsToProviders copies global cost limits onto providers that don't
@@ -1421,6 +1432,16 @@ func applyScheduleDefaults(cfg *Config) {
 	}
 }
 
+func applyToolDefaults(cfg *Config) {
+	for name, tc := range cfg.Tools {
+		if tc.Enabled == nil {
+			v := true
+			tc.Enabled = &v
+			cfg.Tools[name] = tc
+		}
+	}
+}
+
 // validTiers is the set of recognised permission tier names.
 var validTiers = map[string]bool{
 	"supervised": true,
@@ -1574,9 +1595,7 @@ func validate(cfg *Config) error {
 	if err := validateMCP(&cfg.MCP); err != nil {
 		return fmt.Errorf("validate mcp: %w", err)
 	}
-	if err := validateTools(cfg.Tools); err != nil {
-		return fmt.Errorf("validate tools: %w", err)
-	}
+	validateTools(cfg)
 	if err := validatePlugins(cfg.Plugins, cfg.Tools); err != nil {
 		return fmt.Errorf("validate plugins: %w", err)
 	}
@@ -2294,13 +2313,21 @@ func validateMCP(mcp *MCPConfig) error {
 	return nil
 }
 
-func validateTools(tools map[string]ToolConfig) error {
-	for name, tc := range tools {
+func validateTools(cfg *Config) {
+	for name, tc := range cfg.Tools {
+		if !tc.IsEnabled() {
+			continue
+		}
 		if err := validateToolConfig(name, tc); err != nil {
-			return err
+			if cfg.ToolWarnings == nil {
+				cfg.ToolWarnings = make(map[string]string)
+			}
+			cfg.ToolWarnings[name] = err.Error()
+			v := false
+			tc.Enabled = &v
+			cfg.Tools[name] = tc
 		}
 	}
-	return nil
 }
 
 func validateToolConfig(name string, tc ToolConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -751,12 +751,19 @@ func TestParse_ToolMissingCommand(t *testing.T) {
 args = ["--flag"]
 `)
 
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for tool missing command")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "command is required") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-tool"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-tool")
+	}
+	if !strings.Contains(w, "command is required") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-tool"].IsEnabled() {
+		t.Error("expected bad-tool to be disabled")
 	}
 }
 
@@ -3310,12 +3317,19 @@ func TestParse_ToolSSEMissingURL(t *testing.T) {
 [tools.bad-sse]
 transport = "sse"
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for SSE tool missing URL")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "url is required") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-sse"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-sse")
+	}
+	if !strings.Contains(w, "url is required") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-sse"].IsEnabled() {
+		t.Error("expected bad-sse to be disabled")
 	}
 }
 
@@ -3326,12 +3340,19 @@ transport = "sse"
 url = "https://mcp.example.com"
 command = "/usr/bin/should-not-be-here"
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for SSE tool with command")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "command must be empty") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-sse"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-sse")
+	}
+	if !strings.Contains(w, "command must be empty") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-sse"].IsEnabled() {
+		t.Error("expected bad-sse to be disabled")
 	}
 }
 
@@ -3341,12 +3362,19 @@ func TestParse_ToolStdioWithURL(t *testing.T) {
 command = "/usr/bin/tool"
 url = "https://should-not-be-here.com"
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for stdio tool with URL")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "url must be empty") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-stdio"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-stdio")
+	}
+	if !strings.Contains(w, "url must be empty") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-stdio"].IsEnabled() {
+		t.Error("expected bad-stdio to be disabled")
 	}
 }
 
@@ -3358,12 +3386,19 @@ command = "/usr/bin/tool"
 [tools.bad-stdio.headers]
 Authorization = "Bearer should-not-be-here"
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for stdio tool with headers")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "headers are not supported") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-stdio"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-stdio")
+	}
+	if !strings.Contains(w, "headers are not supported") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-stdio"].IsEnabled() {
+		t.Error("expected bad-stdio to be disabled")
 	}
 }
 
@@ -3373,12 +3408,19 @@ func TestParse_ToolUnknownTransport(t *testing.T) {
 transport = "grpc"
 command = "/usr/bin/tool"
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for unknown transport")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unsupported transport") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-transport"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-transport")
+	}
+	if !strings.Contains(w, "unsupported transport") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-transport"].IsEnabled() {
+		t.Error("expected bad-transport to be disabled")
 	}
 }
 
@@ -3388,12 +3430,19 @@ func TestParse_ToolMissingCommand_StdioExplicit(t *testing.T) {
 transport = "stdio"
 args = ["--flag"]
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for stdio tool missing command")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "command is required") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-tool"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-tool")
+	}
+	if !strings.Contains(w, "command is required") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-tool"].IsEnabled() {
+		t.Error("expected bad-tool to be disabled")
 	}
 }
 
@@ -3404,12 +3453,80 @@ transport = "sse"
 url = "https://mcp.example.com"
 args = ["--flag"]
 `)
-	_, err := Parse(tomlData)
-	if err == nil {
-		t.Fatal("expected error for SSE tool with args")
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "args must be empty") {
-		t.Errorf("unexpected error: %v", err)
+	w, ok := cfg.ToolWarnings["bad-sse"]
+	if !ok {
+		t.Fatal("expected tool warning for bad-sse")
+	}
+	if !strings.Contains(w, "args must be empty") {
+		t.Errorf("unexpected warning: %s", w)
+	}
+	if cfg.Tools["bad-sse"].IsEnabled() {
+		t.Error("expected bad-sse to be disabled")
+	}
+}
+
+func TestParse_ToolEnabled_DefaultTrue(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[tools.my-tool]
+command = "/usr/bin/tool"
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.Tools["my-tool"].IsEnabled() {
+		t.Error("expected tool to be enabled by default")
+	}
+	if len(cfg.ToolWarnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", cfg.ToolWarnings)
+	}
+}
+
+func TestParse_ToolEnabled_ExplicitFalse(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[tools.my-tool]
+command = "/usr/bin/tool"
+enabled = false
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Tools["my-tool"].IsEnabled() {
+		t.Error("expected tool to be disabled")
+	}
+	if len(cfg.ToolWarnings) > 0 {
+		t.Errorf("expected no warnings for explicitly disabled tool, got: %v", cfg.ToolWarnings)
+	}
+}
+
+func TestParse_ToolValidAndInvalidMixed(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[tools.good-tool]
+command = "/usr/bin/tool"
+
+[tools.bad-tool]
+args = ["--flag"]
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !cfg.Tools["good-tool"].IsEnabled() {
+		t.Error("expected good-tool to remain enabled")
+	}
+	if cfg.Tools["bad-tool"].IsEnabled() {
+		t.Error("expected bad-tool to be disabled")
+	}
+	if _, ok := cfg.ToolWarnings["bad-tool"]; !ok {
+		t.Error("expected warning for bad-tool")
+	}
+	if _, ok := cfg.ToolWarnings["good-tool"]; ok {
+		t.Error("expected no warning for good-tool")
 	}
 }
 

--- a/internal/integration/tools_test.go
+++ b/internal/integration/tools_test.go
@@ -145,6 +145,24 @@ func TestTools_DefsNotFound(t *testing.T) {
 	}
 }
 
+func TestTools_EnableNotFound(t *testing.T) {
+	h := toolHarness(t)
+
+	rec := h.Do(h.AuthedRequest(http.MethodPost, "/api/v1/tools/nonexistent/enable", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+func TestTools_DisableNotFound(t *testing.T) {
+	h := toolHarness(t)
+
+	rec := h.Do(h.AuthedRequest(http.MethodPost, "/api/v1/tools/nonexistent/disable", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Happy-path CRUD tests (Phase 2 — require test MCP server)
 // ---------------------------------------------------------------------------

--- a/internal/tool/config_writer.go
+++ b/internal/tool/config_writer.go
@@ -58,6 +58,9 @@ func addToolToConfig(path, name string, cfg config.ToolConfig) error {
 // omitting zero-value fields.
 func toolConfigToMap(cfg config.ToolConfig) map[string]any {
 	entry := map[string]any{}
+	if cfg.Enabled != nil && !*cfg.Enabled {
+		entry["enabled"] = false
+	}
 	if cfg.Transport != "" && cfg.Transport != "stdio" {
 		entry["transport"] = cfg.Transport
 	}
@@ -131,6 +134,37 @@ func updateDisabledToolsInConfig(path, name string, disabledTools []string) erro
 		entry["disabled_tools"] = disabledTools
 	} else {
 		delete(entry, "disabled_tools")
+	}
+	tools[name] = entry
+	raw["tools"] = tools
+
+	return writeRawConfig(path, raw)
+}
+
+// updateEnabledInConfig persists only the enabled field for a specific tool
+// server without touching any other config fields.
+func updateEnabledInConfig(path, name string, enabled bool) error {
+	configMu.Lock()
+	defer configMu.Unlock()
+
+	raw, err := readRawConfig(path)
+	if err != nil {
+		return err
+	}
+
+	tools, ok := raw["tools"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("config: tools section not found")
+	}
+	entry, ok := tools[name].(map[string]any)
+	if !ok {
+		return fmt.Errorf("config: tool %q not found", name)
+	}
+
+	if enabled {
+		delete(entry, "enabled")
+	} else {
+		entry["enabled"] = false
 	}
 	tools[name] = entry
 	raw["tools"] = tools

--- a/internal/tool/config_writer_test.go
+++ b/internal/tool/config_writer_test.go
@@ -167,6 +167,87 @@ command = "/usr/bin/other"
 	}
 }
 
+func TestToolConfigToMap_IncludesEnabledFalse(t *testing.T) {
+	f := false
+	cfg := config.ToolConfig{
+		Command: "/usr/bin/tool",
+		Enabled: &f,
+	}
+	m := toolConfigToMap(cfg)
+	v, ok := m["enabled"]
+	if !ok {
+		t.Fatal("enabled not present in map when false")
+	}
+	if v != false {
+		t.Errorf("enabled = %v, want false", v)
+	}
+}
+
+func TestToolConfigToMap_OmitsEnabledTrue(t *testing.T) {
+	tr := true
+	cfg := config.ToolConfig{
+		Command: "/usr/bin/tool",
+		Enabled: &tr,
+	}
+	m := toolConfigToMap(cfg)
+	if _, ok := m["enabled"]; ok {
+		t.Error("enabled should be omitted when true")
+	}
+}
+
+func TestToolConfigToMap_OmitsEnabledNil(t *testing.T) {
+	cfg := config.ToolConfig{
+		Command: "/usr/bin/tool",
+	}
+	m := toolConfigToMap(cfg)
+	if _, ok := m["enabled"]; ok {
+		t.Error("enabled should be omitted when nil")
+	}
+}
+
+func TestUpdateEnabledInConfig_Disable(t *testing.T) {
+	path := writeTestConfig(t, `[tools]
+[tools.my-server]
+command = "/usr/bin/tool"
+`)
+
+	if err := updateEnabledInConfig(path, "my-server", false); err != nil {
+		t.Fatal(err)
+	}
+	content := readConfig(t, path)
+	if !strings.Contains(content, "enabled = false") {
+		t.Error("config should contain enabled = false after disabling")
+	}
+}
+
+func TestUpdateEnabledInConfig_Enable(t *testing.T) {
+	path := writeTestConfig(t, `[tools]
+[tools.my-server]
+command = "/usr/bin/tool"
+enabled = false
+`)
+
+	if err := updateEnabledInConfig(path, "my-server", true); err != nil {
+		t.Fatal(err)
+	}
+	content := readConfig(t, path)
+	if strings.Contains(content, "enabled") {
+		t.Error("config should not contain enabled key after enabling (omit = default true)")
+	}
+}
+
+func TestUpdateEnabledInConfig_ToolNotFound(t *testing.T) {
+	path := writeTestConfig(t, `[tools]
+[tools.other]
+command = "/usr/bin/other"
+`)
+
+	err := updateEnabledInConfig(path, "nonexistent", false)
+	if err == nil {
+		t.Fatal("expected error for nonexistent tool")
+	}
+}
+
 func TestAddPluginToConfig(t *testing.T) {
 	path := writeTestConfig(t, `[telegram]
 token = "test"

--- a/internal/tool/health_test.go
+++ b/internal/tool/health_test.go
@@ -92,6 +92,9 @@ func TestServerStatus_Disabled(t *testing.T) {
 	if status.RestartCount != 4 {
 		t.Errorf("RestartCount = %d, want 4", status.RestartCount)
 	}
+	if status.Enabled {
+		t.Error("expected Enabled = false for restart-exhausted server")
+	}
 }
 
 func TestStartHealthChecker_DisabledByConfig(t *testing.T) {
@@ -270,5 +273,69 @@ func TestRestartServer_SSE_RecoveryOnFailure(t *testing.T) {
 	}
 	if info.LastError == "" {
 		t.Error("LastError should be set after failed restart")
+	}
+}
+
+func TestRegisterDisabled_UserDisabled(t *testing.T) {
+	m := NewManager(testLogger())
+	cfg := config.ToolConfig{
+		Command: "/usr/bin/tool",
+	}
+
+	m.RegisterDisabled("my-tool", cfg, "disabled by user", false)
+
+	status, ok := m.ServerInfo("my-tool")
+	if !ok {
+		t.Fatal("expected server to be found")
+	}
+	if status.Status != "disabled" {
+		t.Errorf("Status = %q, want %q", status.Status, "disabled")
+	}
+	if status.Enabled {
+		t.Error("expected Enabled = false")
+	}
+	if status.ConfigError != "" {
+		t.Errorf("ConfigError = %q, want empty", status.ConfigError)
+	}
+}
+
+func TestRegisterDisabled_ConfigError(t *testing.T) {
+	m := NewManager(testLogger())
+	cfg := config.ToolConfig{
+		Transport: "sse",
+	}
+
+	m.RegisterDisabled("bad-tool", cfg, "url is required for sse transport", true)
+
+	status, ok := m.ServerInfo("bad-tool")
+	if !ok {
+		t.Fatal("expected server to be found")
+	}
+	if status.Status != "config_error" {
+		t.Errorf("Status = %q, want %q", status.Status, "config_error")
+	}
+	if status.Enabled {
+		t.Error("expected Enabled = false")
+	}
+	if status.ConfigError != "url is required for sse transport" {
+		t.Errorf("ConfigError = %q, want %q", status.ConfigError, "url is required for sse transport")
+	}
+}
+
+func TestServerStatus_UserDisabledTakesPriority(t *testing.T) {
+	m := NewManager(testLogger())
+	m.servers["test"] = &serverConn{
+		name:         "test",
+		transport:    "stdio",
+		userDisabled: true,
+		lastError:    "some error",
+	}
+
+	status, ok := m.ServerInfo("test")
+	if !ok {
+		t.Fatal("expected server to be found")
+	}
+	if status.Status != "disabled" {
+		t.Errorf("Status = %q, want %q (userDisabled should take priority)", status.Status, "disabled")
 	}
 }

--- a/internal/tool/lifecycle.go
+++ b/internal/tool/lifecycle.go
@@ -215,6 +215,75 @@ func (lm *LifecycleManager) UpdateDisabledTools(serverName string, disabledTools
 	return nil
 }
 
+// DisableTool stops the MCP server process, marks it as user-disabled,
+// and persists enabled=false to TOML.
+func (lm *LifecycleManager) DisableTool(ctx context.Context, name string) error {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	info, ok := lm.toolMgr.ServerInfo(name)
+	if !ok {
+		return fmt.Errorf("tool %q not found", name)
+	}
+	if !info.Enabled {
+		return nil
+	}
+
+	cfg, cfgOK := lm.toolMgr.ServerToolConfig(name)
+	if !cfgOK {
+		return fmt.Errorf("tool %q config not found", name)
+	}
+
+	if err := lm.toolMgr.UnregisterServer(name); err != nil {
+		lm.logger.Warn("error stopping tool during disable", "name", name, "error", err)
+	}
+
+	lm.toolMgr.RegisterDisabled(name, cfg, "disabled by user", false)
+
+	if err := updateEnabledInConfig(lm.configPath, name, false); err != nil {
+		return fmt.Errorf("persisting disabled state for %q: %w", name, err)
+	}
+
+	lm.logger.Info("tool disabled", "name", name)
+	return nil
+}
+
+// EnableTool starts a previously disabled MCP server and persists
+// enabled=true to TOML.
+func (lm *LifecycleManager) EnableTool(ctx context.Context, name string) error {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+
+	info, ok := lm.toolMgr.ServerInfo(name)
+	if !ok {
+		return fmt.Errorf("tool %q not found", name)
+	}
+	// Already running — skip. Config-error and user-disabled servers
+	// report Enabled=false, so they fall through to the re-register path.
+	if info.Enabled && info.ConfigError == "" {
+		return nil
+	}
+
+	cfg, cfgOK := lm.toolMgr.ServerToolConfig(name)
+	if !cfgOK {
+		return fmt.Errorf("tool %q config not found", name)
+	}
+
+	_ = lm.toolMgr.UnregisterServer(name)
+
+	if err := lm.toolMgr.RegisterServer(ctx, name, cfg); err != nil {
+		lm.toolMgr.RegisterDisabled(name, cfg, err.Error(), false)
+		return fmt.Errorf("enabling tool %q: %w", name, err)
+	}
+
+	if err := updateEnabledInConfig(lm.configPath, name, true); err != nil {
+		return fmt.Errorf("persisting enabled state for %q: %w", name, err)
+	}
+
+	lm.logger.Info("tool enabled", "name", name)
+	return nil
+}
+
 // AddPlugin validates, optionally spawns, registers, and persists the
 // [plugins.<name>] section.
 // validatePluginConfig checks that a plugin config has valid type and required fields.

--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -53,6 +53,8 @@ type serverConn struct {
 	lastError    string    // most recent failure message
 	disabled     bool      // true when restarts exhausted
 	connecting   bool      // true while background init retries are in progress
+	userDisabled bool      // true when explicitly disabled by user
+	configError  string    // non-empty when auto-disabled due to config validation error
 
 	// Tool filtering — tools in disabledSet are excluded from the LLM payload.
 	disabledSet map[string]bool
@@ -102,6 +104,8 @@ type ServerStatus struct {
 	DisabledTools  []string         `json:"disabled_tools,omitempty"`
 	EnabledCount   int              `json:"enabled_count"`
 	TotalToolCount int              `json:"total_tool_count"`
+	Enabled        bool             `json:"enabled"`
+	ConfigError    string           `json:"config_error,omitempty"`
 }
 
 // OAuthStatusInfo is a non-sensitive view of OAuth state for API responses.
@@ -176,6 +180,32 @@ func (m *Manager) MarkDisabled(name string) {
 		sc.connecting = false
 		sc.disabled = true
 	}
+}
+
+// RegisterDisabled creates a placeholder entry for a tool that should not
+// spawn a process. The tool appears in listings with its disabled reason.
+// isConfigError distinguishes config validation failures from user-initiated disabling.
+func (m *Manager) RegisterDisabled(name string, cfg config.ToolConfig, reason string, isConfigError bool) {
+	transport := cfg.Transport
+	if transport == "" {
+		transport = "stdio"
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sc := &serverConn{
+		name:      name,
+		command:   cfg.Command,
+		args:      cfg.Args,
+		transport: transport,
+		url:       cfg.URL,
+		cfg:       cfg,
+	}
+	if isConfigError {
+		sc.configError = reason
+	} else {
+		sc.userDisabled = true
+	}
+	m.servers[name] = sc
 }
 
 // RegisterServer connects to an MCP server (stdio subprocess or remote SSE)
@@ -962,6 +992,10 @@ func (m *Manager) ServerInfo(name string) (ServerStatus, bool) {
 
 func serverConnStatus(sc *serverConn) string {
 	switch {
+	case sc.userDisabled:
+		return "disabled"
+	case sc.configError != "":
+		return "config_error"
 	case sc.disabled:
 		return "disabled"
 	case sc.session == nil && sc.cfg.Auth == "oauth":
@@ -1014,6 +1048,8 @@ func buildServerStatus(sc *serverConn, toolNames []string) ServerStatus {
 		DisabledTools:  disabledTools,
 		EnabledCount:   totalCount - disabledCount,
 		TotalToolCount: totalCount,
+		Enabled:        !sc.userDisabled && !sc.disabled && sc.configError == "",
+		ConfigError:    sc.configError,
 	}
 }
 
@@ -1109,8 +1145,8 @@ func (m *Manager) checkServers(ctx context.Context, maxAttempts int, cooldown ti
 		m.mu.RLock()
 		sc, ok := m.servers[name]
 		m.mu.RUnlock()
-		if !ok || sc.disabled || sc.transport == "" || sc.session == nil {
-			// Skip in-process servers, disabled servers, and OAuth-pending tools.
+		if !ok || sc.disabled || sc.userDisabled || sc.configError != "" || sc.transport == "" || sc.session == nil {
+			// Skip in-process, disabled, config-error, and OAuth-pending servers.
 			continue
 		}
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -183,6 +183,8 @@ export const api = {
   }),
   removeTool: name => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}`, { method: 'DELETE' }),
   restartTool: name => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}/restart`, { method: 'POST' }),
+  enableTool: name => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}/enable`, { method: 'POST' }),
+  disableTool: name => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}/disable`, { method: 'POST' }),
   toolHealth: name => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}/health`),
   toolDefs: name => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}/defs`),
   updateDisabledTools: (name, disabledTools) => apiFetch(`/api/v1/tools/${encodeURIComponent(name)}/disabled-tools`, {

--- a/web/src/pages/Tools.svelte
+++ b/web/src/pages/Tools.svelte
@@ -510,17 +510,47 @@
     }
   }
 
+  let togglingTool = null
+
+  async function enableTool(name) {
+    togglingTool = name
+    error = ''
+    try {
+      await api.enableTool(name)
+      await loadData()
+    } catch (e) {
+      error = e.message
+    } finally {
+      togglingTool = null
+    }
+  }
+
+  async function disableTool(name) {
+    togglingTool = name
+    error = ''
+    try {
+      await api.disableTool(name)
+      await loadData()
+    } catch (e) {
+      error = e.message
+    } finally {
+      togglingTool = null
+    }
+  }
+
   function statusDot(status) {
     if (status === 'connected') return 'green'
     if (status === 'pending_auth') return 'orange'
+    if (status === 'config_error') return 'red'
     if (status === 'error') return 'red'
-    if (status === 'disabled') return 'red'
+    if (status === 'disabled') return 'grey'
     return 'grey'
   }
 
   function statusLabel(t) {
+    if (t.status === 'config_error') return 'Config Error'
     if (t.status === 'error') return 'Error'
-    if (t.status === 'disabled') return `Disabled`
+    if (t.status === 'disabled') return 'Disabled'
     if (t.status === 'pending_auth') return 'Needs Auth'
     if (t.status === 'connected') return 'Connected'
     return t.status
@@ -539,10 +569,15 @@
   }
 
   function isErrorTool(t) {
-    return t.status === 'error' || t.status === 'disabled'
+    return t.status === 'error' || t.status === 'config_error'
   }
 
-  $: connectedTools = tools.filter(t => !isErrorTool(t))
+  function isDisabledTool(t) {
+    return t.status === 'disabled'
+  }
+
+  $: connectedTools = tools.filter(t => !isErrorTool(t) && !isDisabledTool(t))
+  $: disabledTools = tools.filter(t => isDisabledTool(t))
   $: errorTools = tools.filter(t => isErrorTool(t))
 
   onMount(loadData)
@@ -786,6 +821,40 @@
                       </button>
                     {/if}
                   {/if}
+                  <button class="btn-ghost btn-card" onclick={() => disableTool(t.name)} disabled={togglingTool === t.name}>
+                    {togglingTool === t.name ? 'Disabling...' : 'Disable'}
+                  </button>
+                  <button class="btn-ghost btn-card" onclick={() => openEditToolForm(t.name)}>Edit</button>
+                  <button class="btn-ghost btn-card" onclick={() => { confirmRemove = { kind: 'tool', name: t.name } }}>Remove</button>
+                </div>
+              </div>
+              {#if editingToolName === t.name}
+                <div class="tool-card-edit">
+                  <div class="inline-form">
+                    {@render toolFormFields()}
+                  </div>
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      {#if disabledTools.length > 0}
+        <h3 class="group-heading">Disabled</h3>
+        <div class="tool-cards">
+          {#each disabledTools as t}
+            <div class="tool-card">
+              <div class="tool-card-row">
+                <span class="status-dot grey"></span>
+                <span class="tool-name">{t.name}</span>
+                <span class="tool-endpoint mono">{toolEndpoint(t)}</span>
+                <span class="status-badge disabled">{statusLabel(t)}</span>
+                <span class="tool-count">{'—'}</span>
+                <div class="tool-actions">
+                  <button class="btn-primary btn-card" onclick={() => enableTool(t.name)} disabled={togglingTool === t.name}>
+                    {togglingTool === t.name ? 'Enabling...' : 'Enable'}
+                  </button>
                   <button class="btn-ghost btn-card" onclick={() => openEditToolForm(t.name)}>Edit</button>
                   <button class="btn-ghost btn-card" onclick={() => { confirmRemove = { kind: 'tool', name: t.name } }}>Remove</button>
                 </div>
@@ -830,6 +899,17 @@
                 <div class="tool-card-edit">
                   <div class="inline-form">
                     {@render toolFormFields()}
+                  </div>
+                </div>
+              {:else if t.config_error}
+                <div class="tool-error-detail">
+                  <div class="tool-error-icon">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5"/><path d="M8 4.5v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="8" cy="11" r="0.75" fill="currentColor"/></svg>
+                  </div>
+                  <div class="tool-error-content">
+                    <div class="tool-error-title">Configuration error</div>
+                    <code class="tool-error-msg">{t.config_error}</code>
+                    <p class="tool-error-hint">Fix the configuration in denkeeper.toml, then click Edit or use the Enable button to retry.</p>
                   </div>
                 </div>
               {:else if t.last_error}
@@ -1221,6 +1301,10 @@
     background: rgba(196, 58, 58, 0.1);
     color: var(--danger);
   }
+  .status-badge.disabled {
+    background: rgba(128, 128, 128, 0.1);
+    color: var(--text-muted);
+  }
 
   /* Shared settings card (OAuth, Connection settings) */
   .settings-card {
@@ -1455,6 +1539,11 @@
     opacity: 0.8;
     word-break: break-all;
     line-height: 1.5;
+  }
+  .tool-error-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 4px 0 0;
   }
   .btn-retry {
     align-self: flex-start;


### PR DESCRIPTION
## Summary

- Add server-level enable/disable toggle for MCP tool servers (API + UI + TOML persistence)
- Change config validation from fatal to non-fatal: invalid tools are warned about, auto-disabled, and the server starts with remaining valid tools
- Three distinct disabled states: `disabled` (health-exhausted), `config_error` (invalid config), `userDisabled` (explicit toggle)

## Changes

- `internal/config/config.go`: `Enabled *bool` on `ToolConfig`, `ToolWarnings` on `Config`, `IsEnabled()` helper, non-fatal `validateTools`
- `internal/tool/manager.go`: `userDisabled`/`configError` fields, `RegisterDisabled`, `ServerStatus.Enabled`/`ConfigError`
- `internal/tool/lifecycle.go`: `EnableTool`, `DisableTool` methods
- `internal/tool/config_writer.go`: persist `enabled=false`, `updateEnabledInConfig`
- `cmd/denkeeper/main.go`: skip disabled/invalid tools at startup
- `internal/api/server.go`: `POST /api/v1/tools/{name}/enable` and `/disable` endpoints
- `web/src/lib/api.js`: `enableTool`, `disableTool` API functions
- `web/src/pages/Tools.svelte`: 3-way grouping (connected/disabled/error), enable/disable buttons, config error display

## Test plan

- [x] All Go tests pass (`just hook`)
- [x] Config tests updated for non-fatal validation
- [x] New unit tests for `RegisterDisabled`, `updateEnabledInConfig`, `ServerStatus.Enabled`
- [x] Integration smoke tests for enable/disable 400 paths
- [x] UI tests pass (`just test-ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)