### PR TITLE
fix(tools): use exported config symbols in updateEnabledInConfig

### DIFF
--- a/internal/tool/config_writer.go
+++ b/internal/tool/config_writer.go
@@ -134,10 +134,10 @@ func updateDisabledToolsInConfig(path, name string, disabledTools []string) erro
 // updateEnabledInConfig persists only the enabled field for a specific tool
 // server without touching any other config fields.
 func updateEnabledInConfig(path, name string, enabled bool) error {
-	configMu.Lock()
-	defer configMu.Unlock()
+	config.ConfigMu.Lock()
+	defer config.ConfigMu.Unlock()
 
-	raw, err := readRawConfig(path)
+	raw, err := config.ReadRawConfig(path)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func updateEnabledInConfig(path, name string, enabled bool) error {
 	tools[name] = entry
 	raw["tools"] = tools
 
-	return writeRawConfig(path, raw)
+	return config.WriteRawConfig(path, raw)
 }
 
 // removeToolFromConfig reads the TOML config at path, removes [tools.<name>],


### PR DESCRIPTION
## Summary

- The `updateEnabledInConfig` function added in #119 referenced old local symbols (`configMu`, `readRawConfig`, `writeRawConfig`) that were moved to the `config` package as exported symbols in a prior refactoring
- Fixes the CI build failure caused by the merge

## Test plan

- [x] `go build ./internal/tool/...` compiles
- [x] `TestUpdateEnabledInConfig` and `TestToolConfigToMap` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)