### PR TITLE
feat(llm): support Anthropic Claude subscription OAuth tokens

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,9 @@
 go = "1.26.4"
 hugo-extended = "latest"
 "golangci-lint" = "latest"
-swag = "latest"
+# Pinned: swag's JSON output formatting is version-sensitive, and the committed
+# OpenAPI spec (checked by TestOpenAPISpecMatchesAnnotations) must regenerate
+# byte-identically in CI. Bump deliberately, then run `just openapi` + commit.
+swag = "1.16.6"
 task = "3"
 "go:github.com/air-verse/air" = "latest"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ REST API (/api/v1/chat) ────┘                    ↕                  
 
 **Named provider instances**: `[[llm.providers]]` array allows multiple instances of the same provider type (e.g. two OpenAI-compatible endpoints). Each entry has `name`, `type` (`anthropic`/`openai`/`openrouter`/`ollama`), `api_key`, `base_url`, `organization`. Legacy `[llm.openai]` single-slot syntax is still supported and auto-converted. Per-agent `llm_provider` references instances by name.
 
+**Anthropic subscription OAuth**: anthropic-type providers support `auth = "oauth"` to authenticate with a Claude subscription token (minted by `claude setup-token`) instead of an API key. Set `oauth_token` in TOML, or supply it via `CLAUDE_CODE_OAUTH_TOKEN` / `DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN` (resolved in `resolveProviderOAuthTokens`). The provider sends `Authorization: Bearer <token>` + `anthropic-beta: oauth-2025-04-20` instead of `x-api-key` (see `anthropic.NewWithOptions` / `AuthOAuth`). `auth` defaults to `api_key`, is only valid on anthropic providers, and requires a token when `oauth` (validated in `validateProviderInstances`/`validateProviderAPIKeys`). The TOML writer omits `auth` when it's the default (backward compat). Subscription usage draws from the plan's monthly Agent SDK credit, separate from interactive limits (effective 2026-06-15). Connection test: `POST /api/v1/llm/providers/{name}/test` verifies credentials via ListModels and accepts optional unsaved-credential overrides (uses `Deps.ProviderFactory`).
+
 **Data directory**: All default paths (db, persona, skills) are derived from a single base directory. Set via `DENKEEPER_DATA_DIR` env var, `data_dir` in TOML, or defaults to `~/.denkeeper`. The Helm chart sets `DENKEEPER_DATA_DIR=/data` so everything lands on the writable PVC.
 
 **Wiring** happens in `cmd/denkeeper/main.go` — config drives everything. All behavior should be configurable via TOML, not hardcoded.
@@ -152,6 +154,7 @@ Key endpoints (all require auth unless noted):
 - `POST /api/v1/llm/providers` (scope `admin`) — create a named provider instance; body: `{name, type, api_key, base_url, organization}`
 - `PATCH /api/v1/llm/providers/{name}` (scope `admin`) — update provider config (API key, base URL, etc.)
 - `DELETE /api/v1/llm/providers/{name}` (scope `admin`) — remove a provider instance (rejects if referenced by agents or default_provider)
+- `POST /api/v1/llm/providers/{name}/test` (scope `admin`) — verify provider credentials via a live ListModels/HealthCheck probe; optional body `{auth, api_key, oauth_token, base_url}` overrides saved credentials so a freshly-pasted token can be tested before saving
 - `PATCH /api/v1/llm/config` (scope `admin`) — update global LLM config (default provider, model, etc.)
 - `GET /api/v1/auth/status` (scope `admin`) — auth config summary (password, OIDC, sessions, preferences)
 - `GET/DELETE /api/v1/auth/sessions` (scope `admin`) — session list + revoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & Development Commands
 
-This project uses [just](https://github.com/casey/just) as the user-facing command runner, [Task](https://taskfile.dev) (`Taskfile.yml`) underneath for per-target fingerprint caching, and [mise](https://mise.jdx.dev) for tool versioning (Go 1.26.2). `just` recipes for `build`, `test`, `lint`, `vet`, `fmt-check`, `lint-ui`, `build-ui`, `test-ui`, `openapi`, and `hook` delegate to `mise x -- task <name>`; Task skips any step whose declared sources/inputs haven't changed. Cache lives in `.task/` (gitignored). Bust a single step with `mise x -- task <name> --force`; bust the whole hook chain with `JUST_HOOK_FORCE=1 just hook`.
+**Always drive this project through `just`.** [just](https://github.com/casey/just) (`justfile`) is the command runner — every build/test/lint task has a `just <recipe>`, and that is the interface you should use. [Task](https://taskfile.dev) (`Taskfile.yml`) sits underneath providing per-target fingerprint caching, and [mise](https://mise.jdx.dev) handles tool versioning (Go 1.26.2), but you should not invoke `task` or `mise x -- task` directly — call the `just` recipe instead. `just` recipes for `build`, `test`, `lint`, `vet`, `fmt-check`, `lint-ui`, `build-ui`, `test-ui`, `openapi`, and `hook` skip any step whose declared sources/inputs haven't changed (cache in `.task/`, gitignored). Bust the whole hook chain with `JUST_HOOK_FORCE=1 just hook`. If a task you need isn't exposed as a recipe, add one to the `justfile` rather than reaching for `mise`/`task`.
 
 ```bash
 just build                    # Build binary → pkg/bin/denkeeper

--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -333,7 +333,13 @@ func initLLMClients(cfg *config.Config) llmClients {
 func createProvider(pc config.ProviderInstanceConfig, cfg *config.Config) llm.Provider {
 	switch pc.Type {
 	case "anthropic":
-		return anthropicllm.NewFull(pc.Name, pc.APIKey, pc.BaseURL)
+		return anthropicllm.NewWithOptions(anthropicllm.Options{
+			Name:       pc.Name,
+			APIKey:     pc.APIKey,
+			BaseURL:    pc.BaseURL,
+			Auth:       pc.Auth,
+			OAuthToken: pc.OAuthToken,
+		})
 	case "openai":
 		return openaillm.NewFull(pc.Name, pc.APIKey, pc.BaseURL, pc.Organization)
 	case "openrouter":
@@ -1501,10 +1507,13 @@ func startAPIWithMCP(ctx context.Context, cfg *config.Config, a startAPIWithMCPA
 		ConfigPath:        a.path,
 		ModelLister:       a.dispatcher.ListModels,
 		ModelDetailLister: a.dispatcher.ListModelDetails,
-		OAuthDeps:         a.oauthDeps,
-		MCPHandler:        mcpSrv.Handler(),
-		ReloadFunc:        buildReloadFunc(a.path, cfg, a.dispatcher, a.logger),
-		RestartFunc:       selfRestartFunc,
+		ProviderFactory: func(pc config.ProviderInstanceConfig) llm.Provider {
+			return createProvider(pc, cfg)
+		},
+		OAuthDeps:   a.oauthDeps,
+		MCPHandler:  mcpSrv.Handler(),
+		ReloadFunc:  buildReloadFunc(a.path, cfg, a.dispatcher, a.logger),
+		RestartFunc: selfRestartFunc,
 		AgentFactory: func(ac config.AgentInstanceConfig) (*agent.Engine, []agent.Binding, error) {
 			return buildAgentEngine(ctx, ac, a.abc)
 		},

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Personal AI agent management API — multi-agent routing, LLM providers, tools, approvals, and more.",
+        "description": "Personal AI agent management API \u2014 multi-agent routing, LLM providers, tools, approvals, and more.",
         "title": "Denkeeper API",
         "contact": {
             "name": "Denkeeper",
@@ -335,7 +335,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires agents:read scope",
+                        "description": "Forbidden \u2014 requires agents:read scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -430,7 +430,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires agents:write scope",
+                        "description": "Forbidden \u2014 requires agents:write scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3157,6 +3157,69 @@
                 }
             }
         },
+        "/llm/providers/{name}/test": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Verifies provider credentials by listing models. Accepts optional credential overrides to test before saving.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "providers"
+                ],
+                "summary": "Test LLM provider connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Provider name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional credential overrides",
+                        "name": "body",
+                        "in": "body",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.providerTestInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/models": {
             "get": {
                 "security": [
@@ -3267,7 +3330,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires admin scope",
+                        "description": "Forbidden \u2014 requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3307,7 +3370,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires admin scope",
+                        "description": "Forbidden \u2014 requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3379,7 +3442,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Triggers an emergency stop — cancels all in-flight requests and pauses the scheduler.",
+                "description": "Triggers an emergency stop \u2014 cancels all in-flight requests and pauses the scheduler.",
                 "tags": [
                     "safety"
                 ],
@@ -3861,7 +3924,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires admin scope",
+                        "description": "Forbidden \u2014 requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3928,7 +3991,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires admin scope",
+                        "description": "Forbidden \u2014 requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3974,7 +4037,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires admin scope",
+                        "description": "Forbidden \u2014 requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4038,7 +4101,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden — requires admin scope",
+                        "description": "Forbidden \u2014 requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4564,7 +4627,7 @@
                 }
             },
             "post": {
-                "description": "Creates the first API key during initial setup. Returns 409 once any active key exists. No authentication required — the endpoint locks itself after first use.",
+                "description": "Creates the first API key during initial setup. Returns 409 once any active key exists. No authentication required \u2014 the endpoint locks itself after first use.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4635,7 +4698,7 @@
         },
         "/setup/account": {
             "post": {
-                "description": "Creates an admin account (password login) verified by a one-time setup PIN displayed in server logs at startup. No authentication required — the endpoint self-disables after successful use.",
+                "description": "Creates an admin account (password login) verified by a one-time setup PIN displayed in server logs at startup. No authentication required \u2014 the endpoint self-disables after successful use.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5902,7 +5965,7 @@
                     "type": "string"
                 },
                 "callback_data": {
-                    "description": "CallbackData is the base prefix embedded in Telegram inline button data.\nFormat: \"appr:{id}\" — buttons append \":approve\" or \":deny\".",
+                    "description": "CallbackData is the base prefix embedded in Telegram inline button data.\nFormat: \"appr:{id}\" \u2014 buttons append \":approve\" or \":deny\".",
                     "type": "string"
                 },
                 "conversation_id": {
@@ -6065,7 +6128,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "description": "\"soft\" | \"hard\" — required for cost_limit",
+                    "description": "\"soft\" | \"hard\" \u2014 required for cost_limit",
                     "type": "string"
                 },
                 "threshold": {
@@ -6546,10 +6609,16 @@
                 "api_key": {
                     "type": "string"
                 },
+                "auth": {
+                    "type": "string"
+                },
                 "base_url": {
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "oauth_token": {
                     "type": "string"
                 },
                 "organization": {
@@ -6566,6 +6635,9 @@
                 "api_key_set": {
                     "type": "boolean"
                 },
+                "auth": {
+                    "type": "string"
+                },
                 "base_url": {
                     "type": "string"
                 },
@@ -6574,6 +6646,9 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "oauth_token_set": {
+                    "type": "boolean"
                 },
                 "organization": {
                     "type": "string"
@@ -6586,13 +6661,36 @@
                 }
             }
         },
+        "internal_api.providerTestInput": {
+            "type": "object",
+            "properties": {
+                "api_key": {
+                    "type": "string"
+                },
+                "auth": {
+                    "type": "string"
+                },
+                "base_url": {
+                    "type": "string"
+                },
+                "oauth_token": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_api.providerUpdateInput": {
             "type": "object",
             "properties": {
                 "api_key": {
                     "type": "string"
                 },
+                "auth": {
+                    "type": "string"
+                },
                 "base_url": {
+                    "type": "string"
+                },
+                "oauth_token": {
                     "type": "string"
                 },
                 "organization": {

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Personal AI agent management API \u2014 multi-agent routing, LLM providers, tools, approvals, and more.",
+        "description": "Personal AI agent management API — multi-agent routing, LLM providers, tools, approvals, and more.",
         "title": "Denkeeper API",
         "contact": {
             "name": "Denkeeper",
@@ -335,7 +335,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires agents:read scope",
+                        "description": "Forbidden — requires agents:read scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -430,7 +430,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires agents:write scope",
+                        "description": "Forbidden — requires agents:write scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2316,26 +2316,21 @@
                 }
             }
         },
-        "/costs": {
+        "/health": {
             "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns cost tracking data with per-agent and per-session breakdown",
+                "description": "Returns server health status. When ready=true is set, also verifies that at least one agent is registered and returns 503 if not.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "costs"
+                    "health"
                 ],
-                "summary": "Get cost tracking data",
+                "summary": "Health check",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Filter by agent name",
-                        "name": "agent",
+                        "description": "Set to 'true' to check agent readiness",
+                        "name": "ready",
                         "in": "query"
                     }
                 ],
@@ -2346,23 +2341,9 @@
                             "type": "object",
                             "additionalProperties": true
                         }
-                    }
-                }
-            }
-        },
-        "/health": {
-            "get": {
-                "description": "Returns server health status",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "health"
-                ],
-                "summary": "Health check",
-                "responses": {
-                    "200": {
-                        "description": "OK",
+                    },
+                    "503": {
+                        "description": "No agents registered (only when ready=true)",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -3164,7 +3145,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Verifies provider credentials by listing models. Accepts optional credential overrides to test before saving.",
+                "description": "Verifies provider credentials by listing models, or for OAuth providers by sending a minimal message (the path actual chat uses). Accepts optional credential overrides to test before saving.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3187,7 +3168,6 @@
                         "description": "Optional credential overrides",
                         "name": "body",
                         "in": "body",
-                        "required": false,
                         "schema": {
                             "$ref": "#/definitions/internal_api.providerTestInput"
                         }
@@ -3330,7 +3310,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires admin scope",
+                        "description": "Forbidden — requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3370,7 +3350,56 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires admin scope",
+                        "description": "Forbidden — requires admin scope",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to persist",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/onboarding/wizard-complete": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Persists wizard_completed=true to the TOML config so the post-auth setup wizard is not shown again.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "onboarding"
+                ],
+                "summary": "Mark setup wizard complete",
+                "responses": {
+                    "204": {
+                        "description": "Wizard marked complete"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3442,7 +3471,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Triggers an emergency stop \u2014 cancels all in-flight requests and pauses the scheduler.",
+                "description": "Triggers an emergency stop — cancels all in-flight requests and pauses the scheduler.",
                 "tags": [
                     "safety"
                 ],
@@ -3924,7 +3953,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires admin scope",
+                        "description": "Forbidden — requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -3991,7 +4020,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires admin scope",
+                        "description": "Forbidden — requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4037,7 +4066,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires admin scope",
+                        "description": "Forbidden — requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4101,7 +4130,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden \u2014 requires admin scope",
+                        "description": "Forbidden — requires admin scope",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -4627,7 +4656,7 @@
                 }
             },
             "post": {
-                "description": "Creates the first API key during initial setup. Returns 409 once any active key exists. No authentication required \u2014 the endpoint locks itself after first use.",
+                "description": "Creates the first API key during initial setup. Returns 409 once any active key exists. No authentication required — the endpoint locks itself after first use.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4698,7 +4727,7 @@
         },
         "/setup/account": {
             "post": {
-                "description": "Creates an admin account (password login) verified by a one-time setup PIN displayed in server logs at startup. No authentication required \u2014 the endpoint self-disables after successful use.",
+                "description": "Creates an admin account (password login) verified by a one-time setup PIN displayed in server logs at startup. No authentication required — the endpoint self-disables after successful use.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5582,6 +5611,192 @@
                 }
             }
         },
+        "/tools/{name}/disable": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Stops an MCP tool server and marks it as disabled.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tools"
+                ],
+                "summary": "Disable a tool server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tool server name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Disabled tool server",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_tool.ServerStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Disable failed",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Tool not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Tool management not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tools/{name}/disabled-tools": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates the set of disabled MCP tools for a specific tool server. Disabled tools are excluded from the LLM tool payload. No MCP server reconnect is performed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tools"
+                ],
+                "summary": "Update disabled tools",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tool server name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Disabled tools list",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated server status",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_tool.ServerStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Tool management not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tools/{name}/enable": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Starts a previously disabled MCP tool server and persists the change.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tools"
+                ],
+                "summary": "Enable a tool server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tool server name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Enabled tool server",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_tool.ServerStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Enable failed",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Tool not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Tool management not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/tools/{name}/health": {
             "get": {
                 "security": [
@@ -5845,7 +6060,16 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Tool not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Restart failed",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -5965,7 +6189,7 @@
                     "type": "string"
                 },
                 "callback_data": {
-                    "description": "CallbackData is the base prefix embedded in Telegram inline button data.\nFormat: \"appr:{id}\" \u2014 buttons append \":approve\" or \":deny\".",
+                    "description": "CallbackData is the base prefix embedded in Telegram inline button data.\nFormat: \"appr:{id}\" — buttons append \":approve\" or \":deny\".",
                     "type": "string"
                 },
                 "conversation_id": {
@@ -6128,7 +6352,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "description": "\"soft\" | \"hard\" \u2014 required for cost_limit",
+                    "description": "\"soft\" | \"hard\" — required for cost_limit",
                     "type": "string"
                 },
                 "threshold": {
@@ -6138,6 +6362,20 @@
                 "trigger": {
                     "description": "\"error\" | \"rate_limit\" | \"cost_limit\"",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_config.ModelPriceConfig": {
+            "type": "object",
+            "properties": {
+                "cached_input": {
+                    "type": "number"
+                },
+                "input": {
+                    "type": "number"
+                },
+                "output": {
+                    "type": "number"
                 }
             }
         },
@@ -6165,6 +6403,9 @@
         "github_com_Temikus_denkeeper_internal_configmcp.ScheduleUpdateInput": {
             "type": "object",
             "properties": {
+                "agent": {
+                    "type": "string"
+                },
                 "channel": {
                     "type": "string"
                 },
@@ -6257,6 +6498,21 @@
                 "command": {
                     "type": "string"
                 },
+                "config_error": {
+                    "type": "string"
+                },
+                "disabled_tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "enabled_count": {
+                    "type": "integer"
+                },
                 "last_error": {
                     "type": "string"
                 },
@@ -6278,6 +6534,9 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "total_tool_count": {
+                    "type": "integer"
                 },
                 "transport": {
                     "type": "string"
@@ -6399,6 +6658,24 @@
                 "name": {
                     "type": "string"
                 },
+                "nudge_memory_interval": {
+                    "type": "integer"
+                },
+                "nudge_skill_interval": {
+                    "type": "integer"
+                },
+                "review_max_iterations": {
+                    "type": "integer"
+                },
+                "review_timeout": {
+                    "type": "string"
+                },
+                "reviewer_model": {
+                    "type": "string"
+                },
+                "reviewer_provider": {
+                    "type": "string"
+                },
                 "session_tier": {
                     "type": "string"
                 },
@@ -6406,17 +6683,26 @@
                     "description": "empty string to clear",
                     "type": "string"
                 },
+                "supervisor_body_excerpt_len": {
+                    "type": "integer"
+                },
                 "supervisor_context_messages": {
                     "type": "integer"
                 },
                 "supervisor_timeout": {
                     "type": "string"
+                },
+                "supervisor_tool_desc_len": {
+                    "type": "integer"
                 }
             }
         },
         "internal_api.agentCreateInput": {
             "type": "object",
             "properties": {
+                "create_supervisor": {
+                    "$ref": "#/definitions/internal_api.companionSupervisorInput"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -6496,7 +6782,7 @@
             "type": "object",
             "properties": {
                 "agent": {
-                    "description": "optional; defaults to \"default\"",
+                    "description": "optional; defaults to fallback agent",
                     "type": "string"
                 },
                 "channel": {
@@ -6528,6 +6814,23 @@
                     "type": "string"
                 },
                 "session_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_api.companionSupervisorInput": {
+            "type": "object",
+            "properties": {
+                "context_messages": {
+                    "type": "integer"
+                },
+                "llm_model": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "timeout": {
                     "type": "string"
                 }
             }
@@ -6586,6 +6889,9 @@
                     "items": {
                         "$ref": "#/definitions/internal_api.onboardingStep"
                     }
+                },
+                "wizard_completed": {
+                    "type": "boolean"
                 }
             }
         },
@@ -6615,6 +6921,21 @@
                 "base_url": {
                     "type": "string"
                 },
+                "cost_limit_hard": {
+                    "type": "number"
+                },
+                "cost_limit_soft": {
+                    "type": "number"
+                },
+                "default_rate_per_1k_tokens": {
+                    "type": "number"
+                },
+                "model_prices": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_config.ModelPriceConfig"
+                    }
+                },
                 "name": {
                     "type": "string"
                 },
@@ -6641,8 +6962,23 @@
                 "base_url": {
                     "type": "string"
                 },
+                "cost_limit_hard": {
+                    "type": "number"
+                },
+                "cost_limit_soft": {
+                    "type": "number"
+                },
+                "default_rate_per_1k_tokens": {
+                    "type": "number"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "model_prices": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_config.ModelPriceConfig"
+                    }
                 },
                 "name": {
                     "type": "string"
@@ -6689,6 +7025,21 @@
                 },
                 "base_url": {
                     "type": "string"
+                },
+                "cost_limit_hard": {
+                    "type": "number"
+                },
+                "cost_limit_soft": {
+                    "type": "number"
+                },
+                "default_rate_per_1k_tokens": {
+                    "type": "number"
+                },
+                "model_prices": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_config.ModelPriceConfig"
+                    }
                 },
                 "oauth_token": {
                     "type": "string"
@@ -6760,6 +7111,24 @@
                 "listen": {
                     "type": "string"
                 },
+                "mcp_server_chat_timeout": {
+                    "type": "string"
+                },
+                "mcp_server_enabled": {
+                    "type": "boolean"
+                },
+                "mcp_server_endpoint": {
+                    "type": "string"
+                },
+                "mcp_server_session_timeout": {
+                    "type": "string"
+                },
+                "mcp_server_stateless": {
+                    "type": "boolean"
+                },
+                "mcp_server_transport": {
+                    "type": "string"
+                },
                 "rate_limit": {
                     "type": "number"
                 },
@@ -6787,6 +7156,21 @@
             "type": "object",
             "properties": {
                 "external_url": {
+                    "type": "string"
+                },
+                "mcp_server_chat_timeout": {
+                    "type": "string"
+                },
+                "mcp_server_enabled": {
+                    "type": "boolean"
+                },
+                "mcp_server_session_timeout": {
+                    "type": "string"
+                },
+                "mcp_server_stateless": {
+                    "type": "boolean"
+                },
+                "mcp_server_transport": {
                     "type": "string"
                 },
                 "timezone": {

--- a/internal/api/openapi_drift_test.go
+++ b/internal/api/openapi_drift_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestOpenAPISpecMatchesAnnotations regenerates the OpenAPI spec from the swag
+// annotations and fails if it diverges from the committed
+// internal/api/docs/swagger.json. This guards against the generated spec drifting
+// out of sync with the handler @-annotations — run `just openapi` to regenerate
+// and commit the result after changing any annotation.
+//
+// swag emits no volatile metadata into swagger.json (object keys are sorted and
+// there is no embedded timestamp), so a byte-for-byte comparison is stable; the
+// generation timestamp only lives in docs.go, which `just openapi` deletes.
+func TestOpenAPISpecMatchesAnnotations(t *testing.T) {
+	swag, err := exec.LookPath("swag")
+	if err != nil {
+		// In CI swag is provided by mise (.mise.toml); a missing binary there is
+		// a real problem, not a reason to silently skip the drift gate.
+		if os.Getenv("CI") != "" {
+			t.Fatal("swag not found on PATH in CI — it must be installed via mise (.mise.toml)")
+		}
+		t.Skip("swag not on PATH; run through `just test` (mise provides swag) to enable this check")
+	}
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	apiDir := filepath.Dir(thisFile) // internal/api
+	repoRoot := filepath.Join(apiDir, "..", "..")
+	committedPath := filepath.Join(apiDir, "docs", "swagger.json")
+
+	outDir := t.TempDir()
+	cmd := exec.Command(swag, "init",
+		"-g", "internal/api/server.go",
+		"-o", outDir,
+		"--parseDependency", "--parseInternal",
+	)
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("swag init failed: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outDir, "swagger.json"))
+	if err != nil {
+		t.Fatalf("reading regenerated spec: %v", err)
+	}
+	want, err := os.ReadFile(committedPath)
+	if err != nil {
+		t.Fatalf("reading committed spec %s: %v", committedPath, err)
+	}
+
+	if string(got) != string(want) {
+		t.Errorf("OpenAPI spec is out of date with the swag annotations — run `just openapi` and commit internal/api/docs/swagger.json")
+	}
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -397,7 +397,7 @@ func (s *Server) handleTestLLMProvider(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
-	ok, models, err := testProviderConnection(ctx, provider, test.IsOAuth(), anthropicProbeModel(s.deps.Config.LLM.DefaultModel))
+	ok, models, err := testProviderConnection(ctx, provider, test.IsOAuth())
 	if !ok {
 		writeJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": providerTestError(err)})
 		return
@@ -426,23 +426,11 @@ func applyProviderTestOverrides(pc *config.ProviderInstanceConfig, in *providerT
 	}
 }
 
-// defaultProbeModel is the fallback model for an OAuth connection probe when no
-// global default model is configured.
+// defaultProbeModel is a small, broadly-available model used for an OAuth
+// connection probe only when the credential's model list can't be enumerated.
+// The Messages API requires a model field, so a model-less probe isn't possible;
+// probeModelFor prefers a model the credential actually advertises over this.
 const defaultProbeModel = "claude-3-5-haiku-latest"
-
-// anthropicProbeModel returns a bare Anthropic model id suitable for a Messages
-// API probe, stripping any router-style "provider/" prefix from the configured
-// default model (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
-func anthropicProbeModel(defaultModel string) string {
-	m := defaultModel
-	if idx := strings.LastIndex(m, "/"); idx >= 0 {
-		m = m[idx+1:]
-	}
-	if m == "" {
-		return defaultProbeModel
-	}
-	return m
-}
 
 // testProviderConnection probes a provider's credentials. OAuth providers are
 // probed against the Messages API with a minimal completion: a subscription
@@ -451,9 +439,9 @@ func anthropicProbeModel(defaultModel string) string {
 // ListModels (which both validates credentials and yields a count); otherwise
 // they fall back to HealthCheck. The returned count is -1 when no model list was
 // obtained.
-func testProviderConnection(ctx context.Context, provider llm.Provider, oauth bool, probeModel string) (ok bool, models int, err error) {
+func testProviderConnection(ctx context.Context, provider llm.Provider, oauth bool) (ok bool, models int, err error) {
 	if oauth {
-		if cerr := testChatProbe(ctx, provider, probeModel); cerr != nil {
+		if cerr := testChatProbe(ctx, provider, probeModelFor(ctx, provider)); cerr != nil {
 			return false, 0, cerr
 		}
 		return true, -1, nil
@@ -469,6 +457,28 @@ func testProviderConnection(ctx context.Context, provider llm.Provider, oauth bo
 		return false, 0, herr
 	}
 	return true, -1, nil
+}
+
+// probeModelFor picks a model for an OAuth Messages-API probe. It asks the
+// provider which models the credential can access and prefers the cheapest
+// (haiku) tier, so the probe never depends on the configured default model —
+// which may be an OpenRouter-style id or a model this subscription can't reach.
+// Falls back to a small default model only when the list can't be retrieved.
+func probeModelFor(ctx context.Context, provider llm.Provider) string {
+	lister, ok := provider.(llm.ModelLister)
+	if !ok {
+		return defaultProbeModel
+	}
+	list, err := lister.ListModels(ctx)
+	if err != nil || len(list) == 0 {
+		return defaultProbeModel
+	}
+	for _, m := range list {
+		if strings.Contains(strings.ToLower(m), "haiku") {
+			return m
+		}
+	}
+	return list[0]
 }
 
 // testChatProbe sends a 1-token completion to verify credentials are accepted by

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Temikus/denkeeper/internal/audit"
@@ -347,7 +348,7 @@ type providerTestInput struct {
 
 // handleTestLLMProvider godoc
 // @Summary Test LLM provider connection
-// @Description Verifies provider credentials by listing models. Accepts optional credential overrides to test before saving.
+// @Description Verifies provider credentials by listing models, or for OAuth providers by sending a minimal message (the path actual chat uses). Accepts optional credential overrides to test before saving.
 // @Tags providers
 // @Accept json
 // @Produce json
@@ -396,7 +397,7 @@ func (s *Server) handleTestLLMProvider(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 
-	ok, models, err := testProviderConnection(ctx, provider)
+	ok, models, err := testProviderConnection(ctx, provider, test.IsOAuth(), anthropicProbeModel(s.deps.Config.LLM.DefaultModel))
 	if !ok {
 		writeJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": providerTestError(err)})
 		return
@@ -425,10 +426,38 @@ func applyProviderTestOverrides(pc *config.ProviderInstanceConfig, in *providerT
 	}
 }
 
-// testProviderConnection probes a provider. It prefers ListModels (which both
-// validates credentials and yields a count); otherwise it falls back to
-// HealthCheck. The returned count is -1 when only a health check was performed.
-func testProviderConnection(ctx context.Context, provider llm.Provider) (ok bool, models int, err error) {
+// defaultProbeModel is the fallback model for an OAuth connection probe when no
+// global default model is configured.
+const defaultProbeModel = "claude-3-5-haiku-latest"
+
+// anthropicProbeModel returns a bare Anthropic model id suitable for a Messages
+// API probe, stripping any router-style "provider/" prefix from the configured
+// default model (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
+func anthropicProbeModel(defaultModel string) string {
+	m := defaultModel
+	if idx := strings.LastIndex(m, "/"); idx >= 0 {
+		m = m[idx+1:]
+	}
+	if m == "" {
+		return defaultProbeModel
+	}
+	return m
+}
+
+// testProviderConnection probes a provider's credentials. OAuth providers are
+// probed against the Messages API with a minimal completion: a subscription
+// token accepted by /v1/models can still be rejected by /v1/messages, so listing
+// models alone would give false confidence. Non-OAuth providers prefer
+// ListModels (which both validates credentials and yields a count); otherwise
+// they fall back to HealthCheck. The returned count is -1 when no model list was
+// obtained.
+func testProviderConnection(ctx context.Context, provider llm.Provider, oauth bool, probeModel string) (ok bool, models int, err error) {
+	if oauth {
+		if cerr := testChatProbe(ctx, provider, probeModel); cerr != nil {
+			return false, 0, cerr
+		}
+		return true, -1, nil
+	}
 	if lister, isLister := provider.(llm.ModelLister); isLister {
 		list, lerr := lister.ListModels(ctx)
 		if lerr != nil {
@@ -440,6 +469,17 @@ func testProviderConnection(ctx context.Context, provider llm.Provider) (ok bool
 		return false, 0, herr
 	}
 	return true, -1, nil
+}
+
+// testChatProbe sends a 1-token completion to verify credentials are accepted by
+// the Messages API — the endpoint actual chat uses.
+func testChatProbe(ctx context.Context, provider llm.Provider, model string) error {
+	_, err := provider.ChatCompletion(ctx, llm.ChatRequest{
+		Model:     model,
+		Messages:  []llm.Message{{Role: "user", Content: "ping"}},
+		MaxTokens: 1,
+	})
+	return err
 }
 
 // providerTestError renders a user-facing message for a failed connection test,

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Temikus/denkeeper/internal/audit"
 	"github.com/Temikus/denkeeper/internal/config"
@@ -84,6 +87,24 @@ func validateBaseURL(raw string) string {
 	return ""
 }
 
+// validateProviderAuth checks the auth mode for a provider. typ is the provider
+// type and token is the OAuth token (empty string when not supplied). Returns an
+// error message string, or "" if valid. An empty auth means the default api_key.
+func validateProviderAuth(auth, typ, token string) string {
+	if !config.ValidAuthMode(auth) {
+		return "invalid auth: must be one of: api_key, oauth"
+	}
+	if auth == config.AuthModeOAuth {
+		if typ != "anthropic" {
+			return "auth \"oauth\" is only supported for anthropic-type providers"
+		}
+		if token == "" {
+			return "oauth_token is required when auth is \"oauth\" (generate one with `claude setup-token`)"
+		}
+	}
+	return ""
+}
+
 // nullCostFields tracks which cost fields were explicitly set to null in the JSON body.
 type nullCostFields struct {
 	Soft bool
@@ -140,6 +161,8 @@ type providerInfo struct {
 	Type                  string                             `json:"type"`
 	Enabled               bool                               `json:"enabled"`
 	APIKeySet             bool                               `json:"api_key_set"`
+	Auth                  string                             `json:"auth"`
+	OAuthTokenSet         bool                               `json:"oauth_token_set"`
 	BaseURL               string                             `json:"base_url,omitempty"`
 	Organization          string                             `json:"organization,omitempty"`
 	Reasoning             *config.OpenRouterReasoningCfg     `json:"reasoning,omitempty"`
@@ -170,13 +193,23 @@ func (s *Server) handleGetLLMProviders(w http.ResponseWriter, _ *http.Request) {
 
 	providers := make([]providerInfo, 0, len(cfg.Providers))
 	for _, pc := range cfg.Providers {
+		auth := pc.Auth
+		if auth == "" {
+			auth = config.AuthModeAPIKey
+		}
+		enabled := pc.APIKey != "" || pc.Type == "ollama"
+		if pc.IsOAuth() {
+			enabled = pc.OAuthToken != ""
+		}
 		pi := providerInfo{
-			Name:         pc.Name,
-			Type:         pc.Type,
-			Enabled:      pc.APIKey != "" || pc.Type == "ollama",
-			APIKeySet:    pc.APIKey != "",
-			BaseURL:      pc.BaseURL,
-			Organization: pc.Organization,
+			Name:          pc.Name,
+			Type:          pc.Type,
+			Enabled:       enabled,
+			APIKeySet:     pc.APIKey != "",
+			Auth:          auth,
+			OAuthTokenSet: pc.OAuthToken != "",
+			BaseURL:       pc.BaseURL,
+			Organization:  pc.Organization,
 		}
 		if pc.Type == "openrouter" {
 			r := cfg.OpenRouter.Reasoning
@@ -203,6 +236,8 @@ func (s *Server) handleGetLLMProviders(w http.ResponseWriter, _ *http.Request) {
 // providerUpdateInput holds the mutable fields for PATCH /api/v1/llm/providers/{name}.
 type providerUpdateInput struct {
 	APIKey                *string                            `json:"api_key,omitempty"`
+	Auth                  *string                            `json:"auth,omitempty"`
+	OAuthToken            *string                            `json:"oauth_token,omitempty"`
 	BaseURL               *string                            `json:"base_url,omitempty"`
 	Organization          *string                            `json:"organization,omitempty"`
 	Reasoning             *config.OpenRouterReasoningCfg     `json:"reasoning,omitempty"`
@@ -286,11 +321,153 @@ func (s *Server) handlePatchLLMProvider(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Validate the auth mode against the resulting state (auth/token may be set
+	// in this patch or already present on the provider).
+	if msg := validatePatchedProviderAuth(pc, &input); msg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+		return
+	}
+
 	// Apply to in-memory config and persist.
 	s.applyLLMProviderUpdate(name, &input, nullCosts)
 	s.persistLLMProvider(name, &input, nullCosts)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
+// providerTestInput optionally overrides saved credentials for a connection
+// test, so a freshly-pasted token can be verified before it is persisted. All
+// fields are optional; absent fields fall back to the saved provider config.
+type providerTestInput struct {
+	Auth       *string `json:"auth,omitempty"`
+	APIKey     *string `json:"api_key,omitempty"`
+	OAuthToken *string `json:"oauth_token,omitempty"`
+	BaseURL    *string `json:"base_url,omitempty"`
+}
+
+// handleTestLLMProvider godoc
+// @Summary Test LLM provider connection
+// @Description Verifies provider credentials by listing models. Accepts optional credential overrides to test before saving.
+// @Tags providers
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param name path string true "Provider name"
+// @Param body body providerTestInput false "Optional credential overrides"
+// @Success 200 {object} map[string]any
+// @Failure 400 {object} map[string]string
+// @Failure 502 {object} map[string]any
+// @Router /llm/providers/{name}/test [post]
+func (s *Server) handleTestLLMProvider(w http.ResponseWriter, r *http.Request) {
+	if s.deps.ProviderFactory == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "provider testing not available"})
+		return
+	}
+
+	name := r.PathValue("name")
+	pc := s.findProviderInstance(name)
+	if pc == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown provider: " + name})
+		return
+	}
+
+	// Apply optional overrides onto a copy so the test can validate unsaved creds.
+	test := *pc
+	if body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20)); len(body) > 0 {
+		var in providerTestInput
+		if err := json.Unmarshal(body, &in); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+			return
+		}
+		applyProviderTestOverrides(&test, &in)
+	}
+
+	if msg := validateProviderAuth(test.Auth, test.Type, test.OAuthToken); msg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+		return
+	}
+
+	provider := s.deps.ProviderFactory(test)
+	if provider == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "could not construct provider client"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	ok, models, err := testProviderConnection(ctx, provider)
+	if !ok {
+		writeJSON(w, http.StatusBadGateway, map[string]any{"ok": false, "error": providerTestError(err)})
+		return
+	}
+
+	resp := map[string]any{"ok": true}
+	if models >= 0 {
+		resp["models"] = models
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// applyProviderTestOverrides mutates pc with any non-nil fields from in.
+func applyProviderTestOverrides(pc *config.ProviderInstanceConfig, in *providerTestInput) {
+	if in.Auth != nil {
+		pc.Auth = *in.Auth
+	}
+	if in.APIKey != nil {
+		pc.APIKey = *in.APIKey
+	}
+	if in.OAuthToken != nil {
+		pc.OAuthToken = *in.OAuthToken
+	}
+	if in.BaseURL != nil {
+		pc.BaseURL = *in.BaseURL
+	}
+}
+
+// testProviderConnection probes a provider. It prefers ListModels (which both
+// validates credentials and yields a count); otherwise it falls back to
+// HealthCheck. The returned count is -1 when only a health check was performed.
+func testProviderConnection(ctx context.Context, provider llm.Provider) (ok bool, models int, err error) {
+	if lister, isLister := provider.(llm.ModelLister); isLister {
+		list, lerr := lister.ListModels(ctx)
+		if lerr != nil {
+			return false, 0, lerr
+		}
+		return true, len(list), nil
+	}
+	if herr := provider.HealthCheck(ctx); herr != nil {
+		return false, 0, herr
+	}
+	return true, -1, nil
+}
+
+// providerTestError renders a user-facing message for a failed connection test,
+// surfacing the upstream API status/message when available.
+func providerTestError(err error) string {
+	if err == nil {
+		return "connection failed"
+	}
+	var llmErr *llm.LLMError
+	if errors.As(err, &llmErr) {
+		return llmErr.Message
+	}
+	return err.Error()
+}
+
+// validatePatchedProviderAuth validates the auth mode that would result from
+// applying a PATCH to an existing provider, accounting for fields not present in
+// the patch (which retain their current values).
+func validatePatchedProviderAuth(pc *config.ProviderInstanceConfig, input *providerUpdateInput) string {
+	auth := pc.Auth
+	if input.Auth != nil {
+		auth = *input.Auth
+	}
+	token := pc.OAuthToken
+	if input.OAuthToken != nil {
+		token = *input.OAuthToken
+	}
+	return validateProviderAuth(auth, pc.Type, token)
 }
 
 // findProviderInstance returns a pointer to the named provider in config, or nil.
@@ -310,6 +487,12 @@ func (s *Server) applyLLMProviderUpdate(name string, input *providerUpdateInput,
 	}
 	if input.APIKey != nil {
 		pc.APIKey = *input.APIKey
+	}
+	if input.Auth != nil {
+		pc.Auth = *input.Auth
+	}
+	if input.OAuthToken != nil {
+		pc.OAuthToken = *input.OAuthToken
 	}
 	if input.BaseURL != nil {
 		pc.BaseURL = *input.BaseURL
@@ -355,6 +538,8 @@ func (s *Server) syncLegacyProviderConfig(name string, pc *config.ProviderInstan
 	case "anthropic":
 		s.deps.Config.LLM.Anthropic.APIKey = pc.APIKey
 		s.deps.Config.LLM.Anthropic.BaseURL = pc.BaseURL
+		s.deps.Config.LLM.Anthropic.Auth = pc.Auth
+		s.deps.Config.LLM.Anthropic.OAuthToken = pc.OAuthToken
 	case "openrouter":
 		s.deps.Config.LLM.OpenRouter.APIKey = pc.APIKey
 	case "openai":
@@ -374,6 +559,22 @@ func (s *Server) persistLLMProvider(name string, input *providerUpdateInput, nul
 	changes := make(map[string]any)
 	if input.APIKey != nil {
 		changes["api_key"] = *input.APIKey
+	}
+	if input.Auth != nil {
+		// "api_key" is the default; persist it as a deletion so the key is
+		// omitted from TOML (backward-compat), and write "oauth" explicitly.
+		if *input.Auth == config.AuthModeOAuth {
+			changes["auth"] = config.AuthModeOAuth
+		} else {
+			changes["auth"] = nil
+		}
+	}
+	if input.OAuthToken != nil {
+		if *input.OAuthToken == "" {
+			changes["oauth_token"] = nil
+		} else {
+			changes["oauth_token"] = *input.OAuthToken
+		}
 	}
 	if input.BaseURL != nil {
 		changes["base_url"] = *input.BaseURL
@@ -520,6 +721,8 @@ type providerCreateInput struct {
 	Name                  string                             `json:"name"`
 	Type                  string                             `json:"type"`
 	APIKey                string                             `json:"api_key,omitempty"`
+	Auth                  string                             `json:"auth,omitempty"`
+	OAuthToken            string                             `json:"oauth_token,omitempty"`
 	BaseURL               string                             `json:"base_url,omitempty"`
 	Organization          string                             `json:"organization,omitempty"`
 	CostLimitSoft         *float64                           `json:"cost_limit_soft,omitempty"`
@@ -589,16 +792,26 @@ func (s *Server) handleCreateLLMProvider(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if msg := validateProviderAuth(input.Auth, input.Type, input.OAuthToken); msg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+		return
+	}
+
 	if msg := validateCostFields(input.CostLimitSoft, input.CostLimitHard, input.DefaultRatePerKTokens); msg != "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
 		return
 	}
 
 	// Persist to TOML — source of truth.
-	if err := config.AddLLMProviderToConfig(
-		s.deps.ConfigPath, input.Name, input.Type,
-		input.APIKey, input.BaseURL, input.Organization,
-	); err != nil {
+	if err := config.AddLLMProviderToConfig(s.deps.ConfigPath, config.ProviderInstanceConfig{
+		Name:         input.Name,
+		Type:         input.Type,
+		APIKey:       input.APIKey,
+		BaseURL:      input.BaseURL,
+		Organization: input.Organization,
+		Auth:         input.Auth,
+		OAuthToken:   input.OAuthToken,
+	}); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error": "persisting provider to config: " + err.Error(),
 		})
@@ -612,6 +825,8 @@ func (s *Server) handleCreateLLMProvider(w http.ResponseWriter, r *http.Request)
 		Name:                  input.Name,
 		Type:                  input.Type,
 		APIKey:                input.APIKey,
+		Auth:                  input.Auth,
+		OAuthToken:            input.OAuthToken,
 		BaseURL:               input.BaseURL,
 		Organization:          input.Organization,
 		CostLimitSoft:         input.CostLimitSoft,

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -505,6 +505,17 @@ func (s *Server) applyLLMProviderUpdate(name string, input *providerUpdateInput,
 		s.deps.Config.LLM.OpenRouter.Reasoning = *input.Reasoning
 	}
 
+	applyProviderCostUpdate(pc, input, nulls)
+
+	s.syncProviderCostTracker(name, pc.CostLimitSoft, pc.CostLimitHard)
+
+	// Keep legacy structs in sync for backward compat.
+	s.syncLegacyProviderConfig(name, pc)
+}
+
+// applyProviderCostUpdate applies cost-limit and pricing fields from input to
+// pc, honoring explicit-null requests in nulls.
+func applyProviderCostUpdate(pc *config.ProviderInstanceConfig, input *providerUpdateInput, nulls nullCostFields) {
 	if nulls.Soft {
 		pc.CostLimitSoft = nil
 	} else if input.CostLimitSoft != nil {
@@ -523,11 +534,6 @@ func (s *Server) applyLLMProviderUpdate(name string, input *providerUpdateInput,
 	if input.ModelPrices != nil {
 		pc.ModelPrices = input.ModelPrices
 	}
-
-	s.syncProviderCostTracker(name, pc.CostLimitSoft, pc.CostLimitHard)
-
-	// Keep legacy structs in sync for backward compat.
-	s.syncLegacyProviderConfig(name, pc)
 }
 
 // syncLegacyProviderConfig mirrors changes from a ProviderInstanceConfig back
@@ -594,22 +600,28 @@ func (s *Server) persistLLMProvider(name string, input *providerUpdateInput, nul
 
 	// Reasoning config lives in [llm.openrouter.reasoning], not in [[llm.providers]].
 	if input.Reasoning != nil {
-		r := make(map[string]any)
-		if input.Reasoning.Enabled != nil {
-			r["enabled"] = *input.Reasoning.Enabled
-		}
-		if input.Reasoning.Effort != "" {
-			r["effort"] = input.Reasoning.Effort
-		}
-		if input.Reasoning.MaxTokens > 0 {
-			r["max_tokens"] = input.Reasoning.MaxTokens
-		}
-		if input.Reasoning.Exclude != nil {
-			r["exclude"] = *input.Reasoning.Exclude
-		}
-		if err := config.UpdateLLMProviderConfig(s.deps.ConfigPath, "openrouter", map[string]any{"reasoning": r}); err != nil {
-			s.logger.Warn("failed to persist OpenRouter reasoning config", "error", err)
-		}
+		s.persistProviderReasoning(input.Reasoning)
+	}
+}
+
+// persistProviderReasoning writes OpenRouter reasoning config to disk. Reasoning
+// lives in [llm.openrouter.reasoning], not in [[llm.providers]].
+func (s *Server) persistProviderReasoning(reasoning *config.OpenRouterReasoningCfg) {
+	r := make(map[string]any)
+	if reasoning.Enabled != nil {
+		r["enabled"] = *reasoning.Enabled
+	}
+	if reasoning.Effort != "" {
+		r["effort"] = reasoning.Effort
+	}
+	if reasoning.MaxTokens > 0 {
+		r["max_tokens"] = reasoning.MaxTokens
+	}
+	if reasoning.Exclude != nil {
+		r["exclude"] = *reasoning.Exclude
+	}
+	if err := config.UpdateLLMProviderConfig(s.deps.ConfigPath, "openrouter", map[string]any{"reasoning": r}); err != nil {
+		s.logger.Warn("failed to persist OpenRouter reasoning config", "error", err)
 	}
 }
 

--- a/internal/api/providers_test.go
+++ b/internal/api/providers_test.go
@@ -225,13 +225,15 @@ func TestPatchLLMProvider_OAuthOnNonAnthropicRejected(t *testing.T) {
 func TestTestLLMProvider_OAuthProbesMessagesAPI(t *testing.T) {
 	cfg := testConfig(allScopesKey())
 	deps := testDeps()
-	deps.Config.LLM.DefaultModel = "anthropic/claude-sonnet-4-20250514"
+	// A default model the subscription may not have access to — the probe must
+	// not depend on it.
+	deps.Config.LLM.DefaultModel = "anthropic/claude-opus-4-1-20250805"
 	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
 		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "tok"},
 	}
-	// ListModels would succeed with two models; the OAuth probe must NOT use it —
-	// it must exercise the Messages API (ChatCompletion) instead.
-	mock := &modelListerProvider{models: []string{"claude-opus-4-8", "claude-sonnet-4-6"}}
+	// The OAuth probe must exercise the Messages API (ChatCompletion), picking a
+	// model the credential advertises (cheapest haiku tier), not the default.
+	mock := &modelListerProvider{models: []string{"claude-opus-4-8", "claude-haiku-4-5", "claude-sonnet-4-6"}}
 	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider { return mock }
 	srv := New(cfg, deps, testLogger())
 
@@ -254,13 +256,39 @@ func TestTestLLMProvider_OAuthProbesMessagesAPI(t *testing.T) {
 	if mock.chatCalls != 1 {
 		t.Errorf("ChatCompletion calls = %d, want 1 (OAuth must probe the Messages API)", mock.chatCalls)
 	}
-	// Router-style prefix must be stripped to a bare Anthropic model id.
-	if mock.chatModel != "claude-sonnet-4-20250514" {
-		t.Errorf("probe model = %q, want %q", mock.chatModel, "claude-sonnet-4-20250514")
+	// Probe must use a credential-advertised model, preferring the haiku tier —
+	// never the configured default.
+	if mock.chatModel != "claude-haiku-4-5" {
+		t.Errorf("probe model = %q, want %q (cheapest advertised, not the default)", mock.chatModel, "claude-haiku-4-5")
 	}
 	// The /v1/models count must not be surfaced for an OAuth probe.
 	if resp.Models != 0 {
 		t.Errorf("models = %d, want 0 (not surfaced for OAuth probe)", resp.Models)
+	}
+}
+
+func TestTestLLMProvider_OAuthProbeFallsBackWhenNoModelList(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "tok"},
+	}
+	// Empty model list — the probe falls back to a small default model rather
+	// than failing or depending on config.
+	mock := &modelListerProvider{models: nil}
+	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider { return mock }
+	srv := New(cfg, deps, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-sub/test", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if mock.chatModel != defaultProbeModel {
+		t.Errorf("probe model = %q, want fallback %q", mock.chatModel, defaultProbeModel)
 	}
 }
 

--- a/internal/api/providers_test.go
+++ b/internal/api/providers_test.go
@@ -16,14 +16,25 @@ import (
 )
 
 // modelListerProvider is a mock llm.Provider that also implements ModelLister,
-// used to exercise the provider connection-test endpoint.
+// used to exercise the provider connection-test endpoint. chatErr drives the
+// ChatCompletion probe used for OAuth providers; listErr drives ListModels /
+// HealthCheck used for API-key providers. chatModel records the model id the
+// probe was called with.
 type modelListerProvider struct {
-	models  []string
-	listErr error
+	models    []string
+	listErr   error
+	chatErr   error
+	chatCalls int
+	chatModel string
 }
 
 func (m *modelListerProvider) Name() string { return "anthropic" }
-func (m *modelListerProvider) ChatCompletion(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+func (m *modelListerProvider) ChatCompletion(_ context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+	m.chatCalls++
+	m.chatModel = req.Model
+	if m.chatErr != nil {
+		return nil, m.chatErr
+	}
 	return &llm.ChatResponse{}, nil
 }
 func (m *modelListerProvider) HealthCheck(_ context.Context) error { return m.listErr }
@@ -211,15 +222,17 @@ func TestPatchLLMProvider_OAuthOnNonAnthropicRejected(t *testing.T) {
 	}
 }
 
-func TestTestLLMProvider_Success(t *testing.T) {
+func TestTestLLMProvider_OAuthProbesMessagesAPI(t *testing.T) {
 	cfg := testConfig(allScopesKey())
 	deps := testDeps()
+	deps.Config.LLM.DefaultModel = "anthropic/claude-sonnet-4-20250514"
 	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
 		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "tok"},
 	}
-	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider {
-		return &modelListerProvider{models: []string{"claude-opus-4-8", "claude-sonnet-4-6"}}
-	}
+	// ListModels would succeed with two models; the OAuth probe must NOT use it —
+	// it must exercise the Messages API (ChatCompletion) instead.
+	mock := &modelListerProvider{models: []string{"claude-opus-4-8", "claude-sonnet-4-6"}}
+	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider { return mock }
 	srv := New(cfg, deps, testLogger())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-sub/test", bytes.NewReader([]byte("{}")))
@@ -235,8 +248,50 @@ func TestTestLLMProvider_Success(t *testing.T) {
 		Models int  `json:"models"`
 	}
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.OK {
+		t.Errorf("resp = %+v, want ok", resp)
+	}
+	if mock.chatCalls != 1 {
+		t.Errorf("ChatCompletion calls = %d, want 1 (OAuth must probe the Messages API)", mock.chatCalls)
+	}
+	// Router-style prefix must be stripped to a bare Anthropic model id.
+	if mock.chatModel != "claude-sonnet-4-20250514" {
+		t.Errorf("probe model = %q, want %q", mock.chatModel, "claude-sonnet-4-20250514")
+	}
+	// The /v1/models count must not be surfaced for an OAuth probe.
+	if resp.Models != 0 {
+		t.Errorf("models = %d, want 0 (not surfaced for OAuth probe)", resp.Models)
+	}
+}
+
+func TestTestLLMProvider_APIKeyUsesListModels(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-key", Type: "anthropic", APIKey: "sk-ant-x"},
+	}
+	mock := &modelListerProvider{models: []string{"claude-opus-4-8", "claude-sonnet-4-6"}}
+	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider { return mock }
+	srv := New(cfg, deps, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-key/test", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		OK     bool `json:"ok"`
+		Models int  `json:"models"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if !resp.OK || resp.Models != 2 {
 		t.Errorf("resp = %+v, want ok with 2 models", resp)
+	}
+	if mock.chatCalls != 0 {
+		t.Errorf("ChatCompletion calls = %d, want 0 (API-key test must list models, not chat)", mock.chatCalls)
 	}
 }
 
@@ -247,7 +302,7 @@ func TestTestLLMProvider_Failure(t *testing.T) {
 		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "bad"},
 	}
 	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider {
-		return &modelListerProvider{listErr: &llm.LLMError{StatusCode: 401, Message: "invalid token"}}
+		return &modelListerProvider{chatErr: &llm.LLMError{StatusCode: 401, Message: "invalid token"}}
 	}
 	srv := New(cfg, deps, testLogger())
 

--- a/internal/api/providers_test.go
+++ b/internal/api/providers_test.go
@@ -1,0 +1,311 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/llm"
+)
+
+// modelListerProvider is a mock llm.Provider that also implements ModelLister,
+// used to exercise the provider connection-test endpoint.
+type modelListerProvider struct {
+	models  []string
+	listErr error
+}
+
+func (m *modelListerProvider) Name() string { return "anthropic" }
+func (m *modelListerProvider) ChatCompletion(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	return &llm.ChatResponse{}, nil
+}
+func (m *modelListerProvider) HealthCheck(_ context.Context) error { return m.listErr }
+func (m *modelListerProvider) ListModels(_ context.Context) ([]string, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.models, nil
+}
+
+func writeTempConfigFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return path
+}
+
+func TestCreateLLMProvider_OAuth(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.ConfigPath = writeTempConfigFile(t, "[llm]\ndefault_provider = \"anthropic\"\n")
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{
+		"name":        "claude-sub",
+		"type":        "anthropic",
+		"auth":        "oauth",
+		"oauth_token": "sk-ant-oat01-secret",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// In-memory config updated with oauth.
+	var found *config.ProviderInstanceConfig
+	for i := range srv.deps.Config.LLM.Providers {
+		if srv.deps.Config.LLM.Providers[i].Name == "claude-sub" {
+			found = &srv.deps.Config.LLM.Providers[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("provider not added to in-memory config")
+	}
+	if !found.IsOAuth() || found.OAuthToken != "sk-ant-oat01-secret" {
+		t.Errorf("provider = %+v, want oauth with token", found)
+	}
+
+	// Persisted to TOML.
+	persisted, _ := os.ReadFile(deps.ConfigPath)
+	if !strings.Contains(string(persisted), "sk-ant-oat01-secret") {
+		t.Errorf("token not persisted to TOML:\n%s", persisted)
+	}
+}
+
+func TestCreateLLMProvider_OAuthRequiresToken(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.ConfigPath = writeTempConfigFile(t, "[llm]\n")
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"name": "claude-sub", "type": "anthropic", "auth": "oauth"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "oauth_token is required") {
+		t.Errorf("unexpected error body: %s", rec.Body.String())
+	}
+}
+
+func TestCreateLLMProvider_OAuthRejectedForNonAnthropic(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.ConfigPath = writeTempConfigFile(t, "[llm]\n")
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{
+		"name": "gw", "type": "openai", "auth": "oauth", "oauth_token": "x",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "only supported for anthropic") {
+		t.Errorf("unexpected error body: %s", rec.Body.String())
+	}
+}
+
+func TestGetLLMProviders_MasksOAuthToken(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "sk-ant-oat01-secret"},
+	}
+	srv := New(cfg, deps, testLogger())
+
+	req := authedRequest(http.MethodGet, "/api/v1/llm/providers")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	bodyStr := rec.Body.String()
+	if strings.Contains(bodyStr, "sk-ant-oat01-secret") {
+		t.Errorf("response leaked oauth token:\n%s", bodyStr)
+	}
+
+	var resp llmProvidersResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	var p *providerInfo
+	for i := range resp.Providers {
+		if resp.Providers[i].Name == "claude-sub" {
+			p = &resp.Providers[i]
+		}
+	}
+	if p == nil {
+		t.Fatal("claude-sub provider missing from response")
+	}
+	if p.Auth != "oauth" || !p.OAuthTokenSet || !p.Enabled {
+		t.Errorf("provider info = %+v, want auth=oauth, token set, enabled", p)
+	}
+}
+
+func TestPatchLLMProvider_SwitchToOAuth(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "anthropic", Type: "anthropic", APIKey: "sk-ant-key"},
+	}
+	deps.ConfigPath = writeTempConfigFile(t, "[[llm.providers]]\nname = \"anthropic\"\ntype = \"anthropic\"\napi_key = \"sk-ant-key\"\n")
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"auth": "oauth", "oauth_token": "sk-ant-oat01-new"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/llm/providers/anthropic", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	p := srv.deps.Config.LLM.Providers[0]
+	if !p.IsOAuth() || p.OAuthToken != "sk-ant-oat01-new" {
+		t.Errorf("provider = %+v, want oauth with new token", p)
+	}
+}
+
+func TestPatchLLMProvider_OAuthOnNonAnthropicRejected(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "gw", Type: "openai", APIKey: "sk-x"},
+	}
+	deps.ConfigPath = writeTempConfigFile(t, "[llm]\n")
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"auth": "oauth", "oauth_token": "x"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/llm/providers/gw", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTestLLMProvider_Success(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "tok"},
+	}
+	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider {
+		return &modelListerProvider{models: []string{"claude-opus-4-8", "claude-sonnet-4-6"}}
+	}
+	srv := New(cfg, deps, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-sub/test", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		OK     bool `json:"ok"`
+		Models int  `json:"models"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.OK || resp.Models != 2 {
+		t.Errorf("resp = %+v, want ok with 2 models", resp)
+	}
+}
+
+func TestTestLLMProvider_Failure(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "bad"},
+	}
+	deps.ProviderFactory = func(config.ProviderInstanceConfig) llm.Provider {
+		return &modelListerProvider{listErr: &llm.LLMError{StatusCode: 401, Message: "invalid token"}}
+	}
+	srv := New(cfg, deps, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-sub/test", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid token") {
+		t.Errorf("expected upstream message surfaced; body: %s", rec.Body.String())
+	}
+}
+
+func TestTestLLMProvider_Override(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "saved"},
+	}
+	var gotToken string
+	deps.ProviderFactory = func(pc config.ProviderInstanceConfig) llm.Provider {
+		gotToken = pc.OAuthToken
+		return &modelListerProvider{models: []string{"m"}}
+	}
+	srv := New(cfg, deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"oauth_token": "unsaved-draft"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-sub/test", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if gotToken != "unsaved-draft" {
+		t.Errorf("factory got token %q, want override 'unsaved-draft'", gotToken)
+	}
+}
+
+func TestTestLLMProvider_Unavailable(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	deps.Config.LLM.Providers = []config.ProviderInstanceConfig{
+		{Name: "claude-sub", Type: "anthropic", Auth: config.AuthModeOAuth, OAuthToken: "tok"},
+	}
+	// No ProviderFactory configured.
+	srv := New(cfg, deps, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm/providers/claude-sub/test", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,6 +65,7 @@ type Deps struct {
 	SetupPIN          string                                                                   // one-time PIN for account setup (empty = disabled)
 	ModelLister       func(ctx context.Context) []string                                       // returns available LLM models; nil = endpoint returns 503
 	ModelDetailLister func(ctx context.Context, providerFilter string) []llm.ModelInfo         // returns enriched model metadata; nil = endpoint returns 503
+	ProviderFactory   func(config.ProviderInstanceConfig) llm.Provider                         // builds a live provider client for connection tests; nil = test endpoint returns 503
 	AuditStore        audit.Store                                                              // nil = audit endpoints return 503
 	Auditor           audit.Emitter                                                            // nil = no audit events from schedule delivery
 	OAuthDeps         *OAuthDeps                                                               // nil = OAuth tool endpoints return 503
@@ -280,6 +281,7 @@ func New(cfg config.APIConfig, deps Deps, logger *slog.Logger) *Server {
 	mux.HandleFunc("POST /api/v1/llm/providers", s.RequireScope("admin", s.handleCreateLLMProvider))
 	mux.HandleFunc("PATCH /api/v1/llm/providers/{name}", s.RequireScope("admin", s.handlePatchLLMProvider))
 	mux.HandleFunc("DELETE /api/v1/llm/providers/{name}", s.RequireScope("admin", s.handleDeleteLLMProvider))
+	mux.HandleFunc("POST /api/v1/llm/providers/{name}/test", s.RequireScope("admin", s.handleTestLLMProvider))
 	mux.HandleFunc("PATCH /api/v1/llm/config", s.RequireScope("admin", s.handlePatchLLMConfig))
 
 	// Server config endpoints (require admin scope).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -720,10 +720,26 @@ type ProviderInstanceConfig struct {
 	BaseURL      string `toml:"base_url"     json:"base_url,omitempty"`
 	Organization string `toml:"organization" json:"organization,omitempty"` // openai-specific
 
+	// Auth selects the authentication scheme. "" / "api_key" use the X-Api-Key
+	// header (the default). "oauth" authenticates with a Claude subscription
+	// token (anthropic only) via the Authorization: Bearer header. See AuthMode*.
+	Auth string `toml:"auth" json:"auth,omitempty"`
+	// OAuthToken is a Claude subscription OAuth token (sk-ant-oat...) minted by
+	// `claude setup-token`. Only used when Auth == "oauth". Never serialized to
+	// JSON — it is a subscription credential. May also be supplied via the
+	// CLAUDE_CODE_OAUTH_TOKEN environment variable.
+	OAuthToken string `toml:"oauth_token" json:"-"`
+
 	CostLimitSoft         *float64                    `toml:"cost_limit_soft"            json:"cost_limit_soft,omitempty"`
 	CostLimitHard         *float64                    `toml:"cost_limit_hard"            json:"cost_limit_hard,omitempty"`
 	DefaultRatePerKTokens *float64                    `toml:"default_rate_per_1k_tokens" json:"default_rate_per_1k_tokens,omitempty"`
 	ModelPrices           map[string]ModelPriceConfig `toml:"model_prices"               json:"model_prices,omitempty"`
+}
+
+// IsOAuth reports whether this provider authenticates with a Claude
+// subscription OAuth token rather than a static API key.
+func (p ProviderInstanceConfig) IsOAuth() bool {
+	return p.Auth == AuthModeOAuth
 }
 
 // ProviderNames returns the names of all configured provider instances.
@@ -751,6 +767,10 @@ type AnthropicConfig struct {
 	APIKey string `toml:"api_key"`
 	// BaseURL overrides the default API endpoint. Useful for Bedrock/Vertex proxies.
 	BaseURL string `toml:"base_url"`
+	// Auth selects the authentication scheme: "" / "api_key" (default) or "oauth".
+	Auth string `toml:"auth"`
+	// OAuthToken is a Claude subscription token (sk-ant-oat...) used when Auth == "oauth".
+	OAuthToken string `toml:"oauth_token"`
 }
 
 // OpenAIConfig configures the OpenAI-compatible LLM provider.
@@ -980,6 +1000,7 @@ func applyDefaults(cfg *Config) {
 	applyLLMDefaults(cfg)
 	applyEnvOverrides(cfg)
 	synthesizeLegacyProviders(cfg)
+	resolveProviderOAuthTokens(cfg)
 	migrateCostsToProviders(cfg, userSetSoft, userCostSoft, userSetHard, userCostHard)
 	expandEnvVars(cfg)
 	applyMiscDefaults(cfg)
@@ -1015,34 +1036,60 @@ func migrateCostsToProviders(cfg *Config, userSetSoft bool, softVal float64, use
 // if no [[llm.providers]] entry with the same name already exists. This allows users
 // to migrate incrementally from the old single-slot syntax to the new array syntax.
 func synthesizeLegacyProviders(cfg *Config) {
-	add := func(name, typ, apiKey, baseURL, org string) {
-		if cfg.LLM.HasProvider(name) {
+	add := func(p ProviderInstanceConfig) {
+		if cfg.LLM.HasProvider(p.Name) {
 			return
 		}
-		cfg.LLM.Providers = append(cfg.LLM.Providers, ProviderInstanceConfig{
-			Name:         name,
-			Type:         typ,
-			APIKey:       apiKey,
-			BaseURL:      baseURL,
-			Organization: org,
-		})
+		cfg.LLM.Providers = append(cfg.LLM.Providers, p)
 	}
 
 	// Always synthesize entries for legacy provider sections. Even if the API key
 	// is missing, we need the entry so validation can produce a clear "requires
 	// api_key" error rather than "provider not found". The key check happens in
 	// validateProviderAPIKeys.
-	if cfg.LLM.Anthropic.APIKey != "" || IsProviderReferenced(cfg, "anthropic") {
-		add("anthropic", "anthropic", cfg.LLM.Anthropic.APIKey, cfg.LLM.Anthropic.BaseURL, "")
+	if cfg.LLM.Anthropic.APIKey != "" || cfg.LLM.Anthropic.OAuthToken != "" ||
+		cfg.LLM.Anthropic.Auth == AuthModeOAuth || IsProviderReferenced(cfg, "anthropic") {
+		add(ProviderInstanceConfig{
+			Name:       "anthropic",
+			Type:       "anthropic",
+			APIKey:     cfg.LLM.Anthropic.APIKey,
+			BaseURL:    cfg.LLM.Anthropic.BaseURL,
+			Auth:       cfg.LLM.Anthropic.Auth,
+			OAuthToken: cfg.LLM.Anthropic.OAuthToken,
+		})
 	}
 	if cfg.LLM.OpenRouter.APIKey != "" || IsProviderReferenced(cfg, "openrouter") {
-		add("openrouter", "openrouter", cfg.LLM.OpenRouter.APIKey, "", "")
+		add(ProviderInstanceConfig{Name: "openrouter", Type: "openrouter", APIKey: cfg.LLM.OpenRouter.APIKey})
 	}
 	if cfg.LLM.OpenAI.APIKey != "" || IsProviderReferenced(cfg, "openai") {
-		add("openai", "openai", cfg.LLM.OpenAI.APIKey, cfg.LLM.OpenAI.BaseURL, cfg.LLM.OpenAI.Organization)
+		add(ProviderInstanceConfig{
+			Name: "openai", Type: "openai", APIKey: cfg.LLM.OpenAI.APIKey,
+			BaseURL: cfg.LLM.OpenAI.BaseURL, Organization: cfg.LLM.OpenAI.Organization,
+		})
 	}
 	if cfg.LLM.Ollama.BaseURL != "" || IsProviderReferenced(cfg, "ollama") {
-		add("ollama", "ollama", "", cfg.LLM.Ollama.BaseURL, "")
+		add(ProviderInstanceConfig{Name: "ollama", Type: "ollama", BaseURL: cfg.LLM.Ollama.BaseURL})
+	}
+}
+
+// resolveProviderOAuthTokens fills in the OAuth token for anthropic providers
+// configured with auth = "oauth" but no token in TOML, from the environment.
+// CLAUDE_CODE_OAUTH_TOKEN is the variable `claude setup-token` documents, so
+// users who already export it (e.g. for Claude Code) get it picked up for free;
+// DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN is the Denkeeper-namespaced alias.
+func resolveProviderOAuthTokens(cfg *Config) {
+	token := os.Getenv("DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN")
+	if token == "" {
+		token = os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")
+	}
+	if token == "" {
+		return
+	}
+	for i := range cfg.LLM.Providers {
+		p := &cfg.LLM.Providers[i]
+		if p.Type == "anthropic" && p.IsOAuth() && p.OAuthToken == "" {
+			p.OAuthToken = token
+		}
 	}
 }
 
@@ -1290,6 +1337,7 @@ func applyEnvOverrides(cfg *Config) {
 	envOverrideInt("DENKEEPER_LLM_OPENROUTER_REASONING_MAX_TOKENS", &cfg.LLM.OpenRouter.Reasoning.MaxTokens)
 	envOverride("DENKEEPER_LLM_ANTHROPIC_API_KEY", &cfg.LLM.Anthropic.APIKey)
 	envOverride("DENKEEPER_LLM_ANTHROPIC_BASE_URL", &cfg.LLM.Anthropic.BaseURL)
+	envOverride("DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN", &cfg.LLM.Anthropic.OAuthToken)
 	envOverride("DENKEEPER_LLM_OLLAMA_BASE_URL", &cfg.LLM.Ollama.BaseURL)
 	envOverride("DENKEEPER_LLM_OPENAI_API_KEY", &cfg.LLM.OpenAI.APIKey)
 	envOverride("DENKEEPER_LLM_OPENAI_BASE_URL", &cfg.LLM.OpenAI.BaseURL)
@@ -1598,6 +1646,27 @@ func ValidProviderType(typ string) bool {
 	return validProviderTypes[typ]
 }
 
+// Provider authentication modes.
+const (
+	// AuthModeAPIKey authenticates with a static API key via the X-Api-Key
+	// header. This is the default for every provider type.
+	AuthModeAPIKey = "api_key"
+	// AuthModeOAuth authenticates with a Claude subscription OAuth token via the
+	// Authorization: Bearer header. Anthropic provider only.
+	AuthModeOAuth = "oauth"
+)
+
+// validAuthModes is the set of recognized provider authentication modes.
+var validAuthModes = map[string]bool{
+	AuthModeAPIKey: true, AuthModeOAuth: true,
+}
+
+// ValidAuthMode reports whether mode is a recognized provider auth mode.
+// The empty string is accepted and treated as the default (api_key).
+func ValidAuthMode(mode string) bool {
+	return mode == "" || validAuthModes[mode]
+}
+
 // resourceNameRe is the shared pattern for agent, provider, and channel names:
 // lowercase alphanumeric with hyphens, 1-64 chars.
 var resourceNameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
@@ -1623,6 +1692,12 @@ func validateProviderInstances(cfg *Config) error {
 		}
 		if !validProviderTypes[p.Type] {
 			return fmt.Errorf("config: llm.providers[%d] %q: invalid type %q — must be one of: anthropic, openai, openrouter, ollama", i, p.Name, p.Type)
+		}
+		if !ValidAuthMode(p.Auth) {
+			return fmt.Errorf("config: llm.providers[%d] %q: invalid auth %q — must be one of: api_key, oauth", i, p.Name, p.Auth)
+		}
+		if p.Auth == AuthModeOAuth && p.Type != "anthropic" {
+			return fmt.Errorf("config: llm.providers[%d] %q: auth = \"oauth\" is only supported for type \"anthropic\" (got %q)", i, p.Name, p.Type)
 		}
 		if seen[p.Name] {
 			return fmt.Errorf("config: llm.providers[%d]: duplicate provider name %q", i, p.Name)
@@ -1662,7 +1737,16 @@ func validateProviderAPIKeys(cfg *Config) error {
 	}
 
 	for _, p := range cfg.LLM.Providers {
-		if referenced[p.Name] && providerNeedsAPIKey(p.Type) && p.APIKey == "" {
+		if !referenced[p.Name] {
+			continue
+		}
+		if p.IsOAuth() {
+			if p.OAuthToken == "" {
+				return fmt.Errorf("config: provider %q (auth oauth) requires an oauth_token — generate one with `claude setup-token` or set CLAUDE_CODE_OAUTH_TOKEN", p.Name)
+			}
+			continue
+		}
+		if providerNeedsAPIKey(p.Type) && p.APIKey == "" {
 			return fmt.Errorf("config: provider %q (type %s) requires an api_key", p.Name, p.Type)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1077,6 +1077,12 @@ func synthesizeLegacyProviders(cfg *Config) {
 // CLAUDE_CODE_OAUTH_TOKEN is the variable `claude setup-token` documents, so
 // users who already export it (e.g. for Claude Code) get it picked up for free;
 // DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN is the Denkeeper-namespaced alias.
+//
+// Ordering note: this runs before expandEnvVars in applyDefaults. That is
+// intentional — a token sourced from the environment here is a literal secret
+// and must NOT be fed back through ${VAR} expansion. A token written in TOML as
+// "${SOME_VAR}" is left untouched here (we only fill empties) and expanded later
+// by expandEnvVars. Do not reorder these two passes.
 func resolveProviderOAuthTokens(cfg *Config) {
 	token := os.Getenv("DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN")
 	if token == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2058,6 +2058,155 @@ api_key = "sk-ant-test"
 	}
 }
 
+func TestParse_AnthropicOAuth_Valid(t *testing.T) {
+	tomlData := []byte(`
+[telegram]
+token = "tg-token"
+allowed_users = [111222333]
+
+[llm]
+default_provider = "claude-sub"
+
+[[llm.providers]]
+name = "claude-sub"
+type = "anthropic"
+auth = "oauth"
+oauth_token = "sk-ant-oat01-token"
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error for anthropic oauth config: %v", err)
+	}
+	p := cfg.LLM.Providers[0]
+	if !p.IsOAuth() {
+		t.Errorf("expected provider to be OAuth, auth = %q", p.Auth)
+	}
+	if p.OAuthToken != "sk-ant-oat01-token" {
+		t.Errorf("oauth_token = %q, want sk-ant-oat01-token", p.OAuthToken)
+	}
+}
+
+func TestParse_AnthropicOAuth_MissingToken(t *testing.T) {
+	tomlData := []byte(`
+[telegram]
+token = "tg-token"
+allowed_users = [111222333]
+
+[llm]
+default_provider = "claude-sub"
+
+[[llm.providers]]
+name = "claude-sub"
+type = "anthropic"
+auth = "oauth"
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for oauth provider without token")
+	}
+	if !strings.Contains(err.Error(), "requires an oauth_token") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParse_OAuth_RejectedForNonAnthropic(t *testing.T) {
+	tomlData := []byte(`
+[telegram]
+token = "tg-token"
+allowed_users = [111222333]
+
+[llm]
+default_provider = "gw"
+
+[[llm.providers]]
+name = "gw"
+type = "openai"
+auth = "oauth"
+oauth_token = "sk-ant-oat01-token"
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for oauth on openai provider")
+	}
+	if !strings.Contains(err.Error(), "only supported for type \"anthropic\"") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParse_InvalidAuthMode(t *testing.T) {
+	tomlData := []byte(`
+[telegram]
+token = "tg-token"
+allowed_users = [111222333]
+
+[llm]
+default_provider = "claude-sub"
+
+[[llm.providers]]
+name = "claude-sub"
+type = "anthropic"
+auth = "bogus"
+oauth_token = "x"
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for invalid auth mode")
+	}
+	if !strings.Contains(err.Error(), "invalid auth") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParse_AnthropicOAuth_TokenFromEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-fromenv")
+	tomlData := []byte(`
+[telegram]
+token = "tg-token"
+allowed_users = [111222333]
+
+[llm]
+default_provider = "claude-sub"
+
+[[llm.providers]]
+name = "claude-sub"
+type = "anthropic"
+auth = "oauth"
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LLM.Providers[0].OAuthToken != "sk-ant-oat01-fromenv" {
+		t.Errorf("oauth_token = %q, want value from env", cfg.LLM.Providers[0].OAuthToken)
+	}
+}
+
+func TestParse_AnthropicOAuth_LegacySection(t *testing.T) {
+	tomlData := []byte(`
+[telegram]
+token = "tg-token"
+allowed_users = [111222333]
+
+[llm]
+default_provider = "anthropic"
+
+[llm.anthropic]
+auth = "oauth"
+oauth_token = "sk-ant-oat01-legacy"
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.LLM.HasProvider("anthropic") {
+		t.Fatal("expected synthesized anthropic provider")
+	}
+	p := cfg.LLM.Providers[0]
+	if !p.IsOAuth() || p.OAuthToken != "sk-ant-oat01-legacy" {
+		t.Errorf("synthesized provider = %+v, want oauth with legacy token", p)
+	}
+}
+
 func TestParse_DiscordOnly_DefaultAgentAdapters(t *testing.T) {
 	// When only discord is configured, the synthesized default agent should
 	// have "discord" in its adapters list (not "telegram").

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -511,19 +511,27 @@ func rawProviders(raw map[string]any) []any {
 	}
 }
 
-func providerToMap(name, typ, apiKey, baseURL, organization string) map[string]any {
+func providerToMap(p ProviderInstanceConfig) map[string]any {
 	m := map[string]any{
-		"name": name,
-		"type": typ,
+		"name": p.Name,
+		"type": p.Type,
 	}
-	if apiKey != "" {
-		m["api_key"] = apiKey
+	if p.APIKey != "" {
+		m["api_key"] = p.APIKey
 	}
-	if baseURL != "" {
-		m["base_url"] = baseURL
+	if p.BaseURL != "" {
+		m["base_url"] = p.BaseURL
 	}
-	if organization != "" {
-		m["organization"] = organization
+	if p.Organization != "" {
+		m["organization"] = p.Organization
+	}
+	// Only "oauth" is persisted; "api_key" is the default and omitted for
+	// backward compatibility (matches how enabled=true is omitted elsewhere).
+	if p.Auth == AuthModeOAuth {
+		m["auth"] = p.Auth
+	}
+	if p.OAuthToken != "" {
+		m["oauth_token"] = p.OAuthToken
 	}
 	return m
 }
@@ -634,7 +642,7 @@ func UpdateLLMProviderInstanceConfig(path, name string, changes map[string]any) 
 }
 
 // AddLLMProviderToConfig appends a [[llm.providers]] entry to the TOML config.
-func AddLLMProviderToConfig(path, name, typ, apiKey, baseURL, organization string) error {
+func AddLLMProviderToConfig(path string, p ProviderInstanceConfig) error {
 	ConfigMu.Lock()
 	defer ConfigMu.Unlock()
 
@@ -643,7 +651,7 @@ func AddLLMProviderToConfig(path, name, typ, apiKey, baseURL, organization strin
 		return err
 	}
 
-	entry := providerToMap(name, typ, apiKey, baseURL, organization)
+	entry := providerToMap(p)
 
 	llmSection, ok := raw["llm"].(map[string]any)
 	if !ok {

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -763,6 +763,87 @@ func TestRemoveAgentFromConfig_LastEntry(t *testing.T) {
 // LLM provider config persistence
 // ---------------------------------------------------------------------------
 
+func TestAddLLMProviderToConfig_OAuthRoundTrip(t *testing.T) {
+	path := writeTestConfig(t, `[llm]
+default_provider = "claude-sub"
+`)
+
+	err := AddLLMProviderToConfig(path, ProviderInstanceConfig{
+		Name:       "claude-sub",
+		Type:       "anthropic",
+		Auth:       AuthModeOAuth,
+		OAuthToken: "sk-ant-oat01-token",
+	})
+	if err != nil {
+		t.Fatalf("AddLLMProviderToConfig: %v", err)
+	}
+
+	content := readTestConfig(t, path)
+	if !strings.Contains(content, "auth") || !strings.Contains(content, "oauth") {
+		t.Errorf("expected auth key persisted; content:\n%s", content)
+	}
+	if !strings.Contains(content, "sk-ant-oat01-token") {
+		t.Errorf("expected oauth_token persisted; content:\n%s", content)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	p := cfg.LLM.Providers[0]
+	if !p.IsOAuth() || p.OAuthToken != "sk-ant-oat01-token" {
+		t.Errorf("round-tripped provider = %+v, want oauth with token", p)
+	}
+}
+
+func TestAddLLMProviderToConfig_APIKeyOmitsAuth(t *testing.T) {
+	path := writeTestConfig(t, `[llm]
+default_provider = "anthropic"
+`)
+	err := AddLLMProviderToConfig(path, ProviderInstanceConfig{
+		Name:   "anthropic",
+		Type:   "anthropic",
+		APIKey: "sk-ant-key",
+	})
+	if err != nil {
+		t.Fatalf("AddLLMProviderToConfig: %v", err)
+	}
+	content := readTestConfig(t, path)
+	if strings.Contains(content, "auth") {
+		t.Errorf("auth key should be omitted for default api_key mode; content:\n%s", content)
+	}
+}
+
+func TestUpdateLLMProviderInstanceConfig_OAuthTokenDeleted(t *testing.T) {
+	path := writeTestConfig(t, `[llm]
+default_provider = "claude-sub"
+
+[[llm.providers]]
+name = "claude-sub"
+type = "anthropic"
+auth = "oauth"
+oauth_token = "sk-ant-oat01-old"
+`)
+	changes := map[string]any{
+		"auth":        nil,
+		"oauth_token": nil,
+		"api_key":     "sk-ant-newkey",
+	}
+	if err := UpdateLLMProviderInstanceConfig(path, "claude-sub", changes); err != nil {
+		t.Fatalf("UpdateLLMProviderInstanceConfig: %v", err)
+	}
+	content := readTestConfig(t, path)
+	if strings.Contains(content, "oauth_token") {
+		t.Errorf("oauth_token should be deleted; content:\n%s", content)
+	}
+	if strings.Contains(content, "oauth") {
+		t.Errorf("auth should be deleted; content:\n%s", content)
+	}
+	if !strings.Contains(content, "sk-ant-newkey") {
+		t.Errorf("api_key should be set; content:\n%s", content)
+	}
+}
+
 func TestUpdateLLMProviderInstanceConfig_NilDeletesKey(t *testing.T) {
 	path := writeTestConfig(t, `[llm]
 default_provider = "mycloud"

--- a/internal/llm/anthropic/anthropic.go
+++ b/internal/llm/anthropic/anthropic.go
@@ -27,14 +27,37 @@ const (
 	defaultBaseURL   = "https://api.anthropic.com"
 	anthropicVersion = "2023-06-01"
 	messagesEndpoint = "/v1/messages"
+
+	// AuthAPIKey authenticates with a static API key via the X-Api-Key header.
+	AuthAPIKey = "api_key"
+	// AuthOAuth authenticates with a Claude subscription OAuth token (minted by
+	// `claude setup-token`) via the Authorization: Bearer header.
+	AuthOAuth = "oauth"
+
+	// oauthBeta is the anthropic-beta value required when authenticating with a
+	// subscription OAuth token. Centralized so it can be bumped in one place.
+	oauthBeta = "oauth-2025-04-20"
 )
 
 // Client implements llm.Provider against the Anthropic Messages API.
 type Client struct {
-	name    string
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	name     string
+	apiKey   string
+	authMode string // AuthAPIKey (default) or AuthOAuth
+	oauth    string // OAuth subscription token, used when authMode == AuthOAuth
+	baseURL  string
+	http     *http.Client
+}
+
+// Options configures a Client. Used by NewWithOptions for callers that need to
+// select the authentication mode (e.g. subscription OAuth).
+type Options struct {
+	Name       string
+	APIKey     string
+	BaseURL    string
+	Auth       string // AuthAPIKey (default) or AuthOAuth
+	OAuthToken string // required when Auth == AuthOAuth
+	HTTPClient *http.Client
 }
 
 // New creates a Client with the given API key and default base URL.
@@ -69,10 +92,41 @@ func NewWithHTTPClient(apiKey, baseURL string, httpClient *http.Client) *Client 
 		baseURL = defaultBaseURL
 	}
 	return &Client{
-		name:    "anthropic",
-		apiKey:  apiKey,
-		baseURL: baseURL,
-		http:    httpClient,
+		name:     "anthropic",
+		apiKey:   apiKey,
+		authMode: AuthAPIKey,
+		baseURL:  baseURL,
+		http:     httpClient,
+	}
+}
+
+// NewWithOptions creates a Client from an Options struct, allowing the caller to
+// select the authentication mode. This is the constructor used for subscription
+// OAuth; the simpler New/NewFull constructors cover the common API-key case.
+func NewWithOptions(opts Options) *Client {
+	name := opts.Name
+	if name == "" {
+		name = "anthropic"
+	}
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	auth := opts.Auth
+	if auth == "" {
+		auth = AuthAPIKey
+	}
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		name:     name,
+		apiKey:   opts.APIKey,
+		authMode: auth,
+		oauth:    opts.OAuthToken,
+		baseURL:  baseURL,
+		http:     httpClient,
 	}
 }
 
@@ -394,10 +448,18 @@ func (c *Client) readStreamResponse(body io.Reader, onStream llm.StreamCallback,
 }
 
 // setHeaders attaches the required Anthropic authentication and versioning headers.
+// In OAuth mode the subscription token is sent as a Bearer credential alongside
+// the required anthropic-beta opt-in; otherwise the static API key is sent via
+// the X-Api-Key header.
 func (c *Client) setHeaders(r *http.Request) {
-	r.Header.Set("x-api-key", c.apiKey)
 	r.Header.Set("anthropic-version", anthropicVersion)
 	r.Header.Set("content-type", "application/json")
+	if c.authMode == AuthOAuth {
+		r.Header.Set("authorization", "Bearer "+c.oauth)
+		r.Header.Set("anthropic-beta", oauthBeta)
+		return
+	}
+	r.Header.Set("x-api-key", c.apiKey)
 }
 
 // buildRequest converts an llm.ChatRequest into the Anthropic API wire format.

--- a/internal/llm/anthropic/anthropic_test.go
+++ b/internal/llm/anthropic/anthropic_test.go
@@ -344,6 +344,87 @@ func TestName(t *testing.T) {
 	}
 }
 
+func TestSetHeaders_OAuthMode_UsesBearerAndBeta(t *testing.T) {
+	var gotAuth, gotBeta, gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("authorization")
+		gotBeta = r.Header.Get("anthropic-beta")
+		gotAPIKey = r.Header.Get("x-api-key")
+		resp := apiResponse{Content: []contentBlock{{Type: "text", Text: "ok"}}, Usage: apiUsage{InputTokens: 1, OutputTokens: 1}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(Options{
+		Name:       "sub",
+		Auth:       AuthOAuth,
+		OAuthToken: "sk-ant-oat01-secret",
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	})
+	if _, err := client.ChatCompletion(context.Background(), llm.ChatRequest{
+		Model:    "claude-opus-4-8",
+		Messages: []llm.Message{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotAuth != "Bearer sk-ant-oat01-secret" {
+		t.Errorf("authorization = %q, want Bearer sk-ant-oat01-secret", gotAuth)
+	}
+	if gotBeta != oauthBeta {
+		t.Errorf("anthropic-beta = %q, want %q", gotBeta, oauthBeta)
+	}
+	if gotAPIKey != "" {
+		t.Errorf("x-api-key = %q, want empty in OAuth mode", gotAPIKey)
+	}
+}
+
+func TestSetHeaders_APIKeyMode_UsesXApiKey(t *testing.T) {
+	var gotAuth, gotBeta, gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("authorization")
+		gotBeta = r.Header.Get("anthropic-beta")
+		gotAPIKey = r.Header.Get("x-api-key")
+		resp := apiResponse{Content: []contentBlock{{Type: "text", Text: "ok"}}, Usage: apiUsage{InputTokens: 1, OutputTokens: 1}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithOptions(Options{APIKey: "test-key", BaseURL: server.URL, HTTPClient: server.Client()})
+	if _, err := client.ChatCompletion(context.Background(), llm.ChatRequest{
+		Model:    "claude-opus-4-8",
+		Messages: []llm.Message{{Role: "user", Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotAPIKey != "test-key" {
+		t.Errorf("x-api-key = %q, want test-key", gotAPIKey)
+	}
+	if gotAuth != "" {
+		t.Errorf("authorization = %q, want empty in API-key mode", gotAuth)
+	}
+	if gotBeta != "" {
+		t.Errorf("anthropic-beta = %q, want empty in API-key mode", gotBeta)
+	}
+}
+
+func TestNewWithOptions_Defaults(t *testing.T) {
+	c := NewWithOptions(Options{})
+	if c.Name() != "anthropic" {
+		t.Errorf("Name() = %q, want anthropic", c.Name())
+	}
+	if c.authMode != AuthAPIKey {
+		t.Errorf("authMode = %q, want %q", c.authMode, AuthAPIKey)
+	}
+	if c.baseURL != defaultBaseURL {
+		t.Errorf("baseURL = %q, want %q", c.baseURL, defaultBaseURL)
+	}
+}
+
 func TestChatCompletion_TextAndToolUse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		resp := apiResponse{

--- a/justfile
+++ b/justfile
@@ -234,6 +234,10 @@ scan tool="all":
 llms-check:
     @mise x -- go test ./internal/config/ -run TestLLMsFullTxt -race -count=1
 
+# Check the committed OpenAPI spec matches the swag annotations (regenerate + diff)
+openapi-check:
+    @mise x -- go test ./internal/api/ -run TestOpenAPISpecMatchesAnnotations -count=1
+
 # Count lines of Go code (source and test separately)
 loc:
     @echo "Source:"

--- a/web/src/__tests__/pages/Providers.test.js
+++ b/web/src/__tests__/pages/Providers.test.js
@@ -304,6 +304,115 @@ describe('Providers page', () => {
     })
   })
 
+  test('add form shows auth toggle only for anthropic', async () => {
+    render(Providers)
+    await waitFor(() => expect(screen.getByTestId('add-provider-btn')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('add-provider-btn'))
+    await waitFor(() => expect(screen.getByTestId('provider-type-select')).toBeInTheDocument())
+
+    // Default type is openai — no auth toggle.
+    expect(screen.queryByText('Claude subscription (OAuth)')).not.toBeInTheDocument()
+
+    // Switch to anthropic — toggle appears.
+    await fireEvent.change(screen.getByTestId('provider-type-select'), { target: { value: 'anthropic' } })
+    await waitFor(() => {
+      expect(screen.getByText('Claude subscription (OAuth)')).toBeInTheDocument()
+    })
+  })
+
+  test('selecting OAuth reveals token field and billing banner, hides API key', async () => {
+    render(Providers)
+    await waitFor(() => expect(screen.getByTestId('add-provider-btn')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('add-provider-btn'))
+    await waitFor(() => expect(screen.getByTestId('provider-type-select')).toBeInTheDocument())
+
+    await fireEvent.change(screen.getByTestId('provider-type-select'), { target: { value: 'anthropic' } })
+    const oauthRadio = await screen.findByDisplayValue('oauth')
+    await fireEvent.click(oauthRadio)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-oauth-input')).toBeInTheDocument()
+      expect(screen.getByText(/Subscription billing/)).toBeInTheDocument()
+      expect(screen.getByText(/claude setup-token/)).toBeInTheDocument()
+      // API key field hidden in OAuth mode.
+      expect(screen.queryByLabelText('API Key')).not.toBeInTheDocument()
+    })
+  })
+
+  test('create OAuth provider posts auth and oauth_token', async () => {
+    let postBody = null
+    server.use(
+      http.post('/api/v1/llm/providers', async ({ request }) => {
+        postBody = await request.json()
+        return HttpResponse.json({ name: 'claude-sub', status: 'created' }, { status: 201 })
+      })
+    )
+    render(Providers)
+    await waitFor(() => expect(screen.getByTestId('add-provider-btn')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('add-provider-btn'))
+    await waitFor(() => expect(screen.getByTestId('provider-type-select')).toBeInTheDocument())
+
+    await fireEvent.input(screen.getByTestId('provider-name-input'), { target: { value: 'claude-sub' } })
+    await fireEvent.change(screen.getByTestId('provider-type-select'), { target: { value: 'anthropic' } })
+    const oauthRadio = await screen.findByDisplayValue('oauth')
+    await fireEvent.click(oauthRadio)
+    await fireEvent.input(screen.getByTestId('provider-oauth-input'), { target: { value: 'sk-ant-oat01-xyz' } })
+    await fireEvent.click(screen.getByTestId('provider-save-btn'))
+
+    await waitFor(() => {
+      expect(postBody).not.toBeNull()
+      expect(postBody.auth).toBe('oauth')
+      expect(postBody.oauth_token).toBe('sk-ant-oat01-xyz')
+      expect(postBody.api_key).toBeUndefined()
+    })
+  })
+
+  test('create OAuth provider blocks when token missing', async () => {
+    render(Providers)
+    await waitFor(() => expect(screen.getByTestId('add-provider-btn')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('add-provider-btn'))
+    await waitFor(() => expect(screen.getByTestId('provider-type-select')).toBeInTheDocument())
+
+    await fireEvent.input(screen.getByTestId('provider-name-input'), { target: { value: 'claude-sub' } })
+    await fireEvent.change(screen.getByTestId('provider-type-select'), { target: { value: 'anthropic' } })
+    const oauthRadio = await screen.findByDisplayValue('oauth')
+    await fireEvent.click(oauthRadio)
+    await fireEvent.click(screen.getByTestId('provider-save-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Paste a subscription token')
+    })
+  })
+
+  test('test connection button reports success', async () => {
+    render(Providers)
+    await waitFor(() => expect(screen.getByText('Anthropic')).toBeInTheDocument())
+
+    const testButtons = screen.getAllByTestId('test-provider-btn')
+    await fireEvent.click(testButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connected — 5 models available/)).toBeInTheDocument()
+    })
+  })
+
+  test('test connection button reports failure', async () => {
+    server.use(
+      http.post('/api/v1/llm/providers/:name/test', () =>
+        HttpResponse.json({ ok: false, error: 'invalid token' }, { status: 502 })
+      )
+    )
+    render(Providers)
+    await waitFor(() => expect(screen.getByText('Anthropic')).toBeInTheDocument())
+
+    const testButtons = screen.getAllByTestId('test-provider-btn')
+    await fireEvent.click(testButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid token/)).toBeInTheDocument()
+    })
+  })
+
   test('confirm delete calls DELETE and refreshes list', async () => {
     let deleteCalled = false
     server.use(

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -242,6 +242,10 @@ export const api = {
     body: JSON.stringify(data),
   }),
   deleteLLMProvider: (name) => apiFetch(`/api/v1/llm/providers/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+  testLLMProvider: (name, data) => apiFetch(`/api/v1/llm/providers/${encodeURIComponent(name)}/test`, {
+    method: 'POST',
+    body: JSON.stringify(data || {}),
+  }),
   updateLLMConfig: (data) => apiFetch('/api/v1/llm/config', {
     method: 'PATCH',
     body: JSON.stringify(data),

--- a/web/src/pages/Providers.svelte
+++ b/web/src/pages/Providers.svelte
@@ -98,6 +98,8 @@
     const p = data.providers.find(x => x.name === name)
     providerDraft = {
       api_key: '',
+      auth: p?.auth || 'api_key',
+      oauth_token: '',
       base_url: p?.base_url || '',
       organization: p?.organization || '',
       reasoning_enabled: !!(p?.reasoning?.enabled),
@@ -122,6 +124,19 @@
     try {
       const p = data.providers.find(x => x.name === editingProvider)
       const patch = {}
+
+      // Auth mode (anthropic only). When switching to/within OAuth, carry the
+      // token; switching back to API key clears the stored token.
+      if (p?.type === 'anthropic') {
+        const oldAuth = p?.auth || 'api_key'
+        if (providerDraft.auth !== oldAuth) {
+          patch.auth = providerDraft.auth
+          if (providerDraft.auth === 'api_key') patch.oauth_token = ''
+        }
+        if (providerDraft.auth === 'oauth' && providerDraft.oauth_token) {
+          patch.oauth_token = providerDraft.oauth_token
+        }
+      }
 
       if (providerDraft.api_key) {
         patch.api_key = providerDraft.api_key
@@ -173,6 +188,9 @@
         if (p) {
           if (patch.api_key) p.api_key_set = true
           if (patch.api_key) p.enabled = true
+          if (patch.auth !== undefined) p.auth = patch.auth
+          if (patch.oauth_token) { p.oauth_token_set = true; p.enabled = true }
+          if (patch.oauth_token === '') p.oauth_token_set = false
           if (patch.base_url !== undefined) p.base_url = patch.base_url
           if (patch.organization !== undefined) p.organization = patch.organization
           if (patch.reasoning) p.reasoning = patch.reasoning
@@ -205,15 +223,22 @@
   let formName = $state('')
   let formType = $state('openai')
   let formAPIKey = $state('')
+  let formAuth = $state('api_key')
+  let formOAuthToken = $state('')
   let formBaseURL = $state('')
   let formOrganization = $state('')
   let formSaving = $state(false)
   let formError = $state('')
 
+  // True when the add form / draft is configured for Claude subscription OAuth.
+  let formIsOAuth = $derived(formType === 'anthropic' && formAuth === 'oauth')
+
   function openAddForm() {
     formName = ''
     formType = 'openai'
     formAPIKey = ''
+    formAuth = 'api_key'
+    formOAuthToken = ''
     formBaseURL = ''
     formOrganization = ''
     formError = ''
@@ -233,10 +258,19 @@
       formError = 'Name must be lowercase alphanumeric with hyphens only'
       return
     }
+    if (formIsOAuth && !formOAuthToken.trim()) {
+      formError = 'Paste a subscription token, or switch to API key authentication'
+      return
+    }
     formSaving = true
     try {
       const body = { name, type: formType }
-      if (formAPIKey) body.api_key = formAPIKey
+      if (formIsOAuth) {
+        body.auth = 'oauth'
+        body.oauth_token = formOAuthToken.trim()
+      } else if (formAPIKey) {
+        body.api_key = formAPIKey
+      }
       if (formBaseURL) body.base_url = formBaseURL
       if (formOrganization && formType === 'openai') body.organization = formOrganization
       await api.createLLMProvider(body)
@@ -270,6 +304,38 @@
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Connection test
+  // ---------------------------------------------------------------------------
+  let testing = $state(null)      // name of provider currently being tested
+  let testResult = $state(null)   // { name, ok, message }
+
+  async function testProvider(name) {
+    testing = name
+    testResult = null
+    try {
+      const p = data.providers.find(x => x.name === name)
+      // When editing, send the draft credentials as overrides so an unsaved
+      // token can be verified before committing it.
+      const body = {}
+      if (editingProvider === name) {
+        if (p?.type === 'anthropic') body.auth = providerDraft.auth
+        if (providerDraft.api_key) body.api_key = providerDraft.api_key
+        if (providerDraft.oauth_token) body.oauth_token = providerDraft.oauth_token
+        if (providerDraft.base_url !== (p?.base_url || '')) body.base_url = providerDraft.base_url
+      }
+      const res = await api.testLLMProvider(name, body)
+      const msg = (res && res.models != null)
+        ? `Connected — ${res.models} model${res.models === 1 ? '' : 's'} available`
+        : 'Connected'
+      testResult = { name, ok: true, message: msg }
+    } catch (e) {
+      testResult = { name, ok: false, message: e.message }
+    } finally {
+      testing = null
+    }
+  }
+
   onMount(fetchData)
 </script>
 
@@ -278,6 +344,22 @@
   <button class="btn btn-sm btn-primary" onclick={openAddForm} data-testid="add-provider-btn">+ Add Provider</button>
 </div>
 <ErrorBanner message={error} />
+
+{#snippet oauthHelp()}
+  <div class="oauth-help">
+    <p class="oauth-step">
+      Generate a token by running <code>claude setup-token</code> in your terminal
+      (requires Claude Code and a Pro, Max, Team, or Enterprise plan), then paste it above.
+    </p>
+    <div class="oauth-banner" role="note">
+      <strong>Subscription billing.</strong> Usage authenticated this way draws from your plan's
+      monthly Agent&nbsp;SDK credit (e.g. Max&nbsp;5× = $100/mo), separate from your interactive
+      chat limits. When the credit is exhausted, usage bills at standard API rates.
+      Effective June&nbsp;15,&nbsp;2026.
+      <a href="https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan" target="_blank" rel="noopener noreferrer">Learn more ↗</a>
+    </div>
+  </div>
+{/snippet}
 
 {#if showAddForm}
 <div class="inline-panel" data-testid="provider-form">
@@ -297,11 +379,27 @@
       {/each}
     </select>
   </div>
-  {#if formType !== 'ollama'}
+  {#if formType === 'anthropic'}
+    <div class="form-row">
+      <span class="form-label" id="new-provider-auth-label">Authentication</span>
+      <div class="auth-toggle" role="radiogroup" aria-labelledby="new-provider-auth-label">
+        <label class="auth-option"><input type="radio" bind:group={formAuth} value="api_key" disabled={formSaving} /> API key</label>
+        <label class="auth-option"><input type="radio" bind:group={formAuth} value="oauth" disabled={formSaving} /> Claude subscription (OAuth)</label>
+      </div>
+    </div>
+  {/if}
+  {#if formType !== 'ollama' && !formIsOAuth}
     <div class="form-row">
       <label class="form-label" for="new-provider-apikey">API Key</label>
       <input id="new-provider-apikey" type="password" class="input" bind:value={formAPIKey} disabled={formSaving} placeholder="Enter API key" />
     </div>
+  {/if}
+  {#if formIsOAuth}
+    <div class="form-row">
+      <label class="form-label" for="new-provider-oauth">Subscription token</label>
+      <input id="new-provider-oauth" type="password" class="input" bind:value={formOAuthToken} disabled={formSaving} placeholder="sk-ant-oat..." data-testid="provider-oauth-input" />
+    </div>
+    {@render oauthHelp()}
   {/if}
   {#if formType !== 'openrouter'}
     <div class="form-row">
@@ -387,7 +485,18 @@
 
       {#if editingProvider !== p.name}
         <div class="provider-fields">
-          {#if p.type !== 'ollama'}
+          {#if p.type === 'anthropic'}
+            <div class="field-row">
+              <span class="field-label">Auth Method</span>
+              <span class="field-value">{p.auth === 'oauth' ? 'Claude subscription (OAuth)' : 'API key'}</span>
+            </div>
+          {/if}
+          {#if p.type === 'anthropic' && p.auth === 'oauth'}
+            <div class="field-row">
+              <span class="field-label">Token</span>
+              <span class="field-value">{p.oauth_token_set ? 'Configured' : 'Not set'}</span>
+            </div>
+          {:else if p.type !== 'ollama'}
             <div class="field-row">
               <span class="field-label">API Key</span>
               <span class="field-value">{p.api_key_set ? 'Configured' : 'Not set'}</span>
@@ -447,9 +556,17 @@
           </div>
         {/if}
         <div class="card-actions">
+          <button class="btn btn-sm" onclick={() => testProvider(p.name)} disabled={testing === p.name} data-testid="test-provider-btn">
+            {testing === p.name ? 'Testing…' : 'Test connection'}
+          </button>
           <button class="btn btn-sm" onclick={() => startEditProvider(p.name)}>Edit</button>
           <button class="btn btn-sm btn-danger-text" onclick={() => { confirmDelete = p.name; deleteError = '' }} data-testid="delete-provider-btn">Delete</button>
         </div>
+        {#if testResult && testResult.name === p.name}
+          <div class="test-result" class:ok={testResult.ok} class:fail={!testResult.ok} role="status">
+            {testResult.ok ? '✓' : '✗'} {testResult.message}
+          </div>
+        {/if}
         {#if confirmDelete === p.name}
           <div class="delete-confirm" data-testid="delete-confirm">
             <span>Delete provider <strong>{p.name}</strong>?</span>
@@ -466,7 +583,16 @@
         {/if}
       {:else}
         <div class="edit-form">
-          {#if p.type !== 'ollama'}
+          {#if p.type === 'anthropic'}
+            <div class="form-row">
+              <span class="form-label" id="auth-label-{p.name}">Authentication</span>
+              <div class="auth-toggle" role="radiogroup" aria-labelledby="auth-label-{p.name}">
+                <label class="auth-option"><input type="radio" bind:group={providerDraft.auth} value="api_key" /> API key</label>
+                <label class="auth-option"><input type="radio" bind:group={providerDraft.auth} value="oauth" /> Claude subscription (OAuth)</label>
+              </div>
+            </div>
+          {/if}
+          {#if p.type !== 'ollama' && !(p.type === 'anthropic' && providerDraft.auth === 'oauth')}
             <div class="form-row">
               <label class="form-label" for="api-key-{p.name}">API Key</label>
               <input
@@ -477,6 +603,20 @@
                 placeholder={p.api_key_set ? '(leave blank to keep current)' : 'Enter API key'}
               />
             </div>
+          {/if}
+          {#if p.type === 'anthropic' && providerDraft.auth === 'oauth'}
+            <div class="form-row">
+              <label class="form-label" for="oauth-{p.name}">Subscription token</label>
+              <input
+                id="oauth-{p.name}"
+                type="password"
+                class="input"
+                bind:value={providerDraft.oauth_token}
+                placeholder={p.oauth_token_set ? '(leave blank to keep current)' : 'sk-ant-oat...'}
+                data-testid="provider-oauth-edit-input"
+              />
+            </div>
+            {@render oauthHelp()}
           {/if}
           {#if hasEditableBaseURL(p)}
             <div class="form-row">
@@ -566,9 +706,17 @@
             <button class="btn btn-sm" onclick={() => { providerDraft.model_prices = [...providerDraft.model_prices, { model: '', input: '', output: '', cached_input: '' }] }}>Add Override</button>
           </div>
           <div class="restart-note">Changes to provider settings require a restart to take effect.</div>
+          {#if testResult && testResult.name === p.name}
+            <div class="test-result" class:ok={testResult.ok} class:fail={!testResult.ok} role="status">
+              {testResult.ok ? '✓' : '✗'} {testResult.message}
+            </div>
+          {/if}
           <div class="config-actions">
             <button class="btn btn-primary" onclick={saveProvider} disabled={savingProvider}>
               {savingProvider ? 'Saving...' : 'Save'}
+            </button>
+            <button class="btn" onclick={() => testProvider(p.name)} disabled={testing === p.name || savingProvider} data-testid="test-provider-edit-btn">
+              {testing === p.name ? 'Testing…' : 'Test connection'}
             </button>
             <button class="btn" onclick={cancelEditProvider} disabled={savingProvider}>Cancel</button>
           </div>
@@ -896,4 +1044,64 @@
   .model-prices-row + .model-prices-row {
     border-top: 1px solid var(--border);
   }
+
+  /* Auth method toggle */
+  .auth-toggle {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+  .auth-option {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text);
+    cursor: pointer;
+  }
+  .auth-option input[type="radio"] {
+    cursor: pointer;
+  }
+
+  /* OAuth setup help + billing banner */
+  .oauth-help {
+    margin-bottom: 10px;
+  }
+  .oauth-step {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.5;
+    margin: 0 0 8px;
+  }
+  .oauth-step code {
+    font-family: monospace;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1px 5px;
+    font-size: 12px;
+    color: var(--text);
+  }
+  .oauth-banner {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text);
+    background: color-mix(in srgb, var(--accent) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+    border-radius: var(--radius);
+    padding: 10px 12px;
+  }
+  .oauth-banner a {
+    color: var(--accent);
+    white-space: nowrap;
+  }
+
+  /* Connection test result */
+  .test-result {
+    margin-top: 8px;
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .test-result.ok { color: var(--success); }
+  .test-result.fail { color: var(--danger, #d32f2f); }
 </style>

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -276,7 +276,7 @@ export const handlers = [
     cost_limit_soft: 0.5,
     cost_limit_hard: 1.0,
     providers: [
-      { name: 'anthropic', type: 'anthropic', enabled: false, api_key_set: false, cost_limit_soft: 5.0, cost_limit_hard: 10.0 },
+      { name: 'anthropic', type: 'anthropic', enabled: false, api_key_set: false, auth: 'api_key', oauth_token_set: false, cost_limit_soft: 5.0, cost_limit_hard: 10.0 },
       { name: 'openrouter', type: 'openrouter', enabled: true, api_key_set: true },
       { name: 'openai', type: 'openai', enabled: false, api_key_set: false },
       { name: 'ollama', type: 'ollama', enabled: true, api_key_set: false, base_url: 'http://localhost:11434' },
@@ -285,6 +285,7 @@ export const handlers = [
   http.post('/api/v1/llm/providers', () => HttpResponse.json({ name: 'new-provider', status: 'created' }, { status: 201 })),
   http.patch('/api/v1/llm/providers/:name', () => HttpResponse.json({ status: 'updated' })),
   http.delete('/api/v1/llm/providers/:name', () => new HttpResponse(null, { status: 204 })),
+  http.post('/api/v1/llm/providers/:name/test', () => HttpResponse.json({ ok: true, models: 5 })),
 
   // Server config
   http.get('/api/v1/server/config', () => HttpResponse.json({

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -82,7 +82,9 @@ Named provider instances (array). Multiple instances of the same type allowed.
     [[llm.providers]]
     name = "my-anthropic"            # unique provider name
     type = "anthropic"               # "anthropic", "openai", "openrouter", "ollama"
-    api_key = ""                     # API key (required except ollama)
+    api_key = ""                     # API key (required except ollama / oauth)
+    auth = ""                        # "" / "api_key" (default) or "oauth" (anthropic only)
+    oauth_token = ""                 # Claude subscription token from `claude setup-token` (auth = "oauth")
     base_url = ""                    # API endpoint override
     organization = ""                # OpenAI organization ID (openai type only)
     cost_limit_soft = 5.00           # per-provider soft cost limit (USD per session)


### PR DESCRIPTION
## Summary

Adds an opt-in `auth = "oauth"` mode to anthropic-type LLM providers so denkeeper can authenticate with a **Claude subscription token** (minted by `claude setup-token`) instead of a Console API key. In OAuth mode the provider sends `Authorization: Bearer <token>` plus the `anthropic-beta: oauth-2025-04-20` header rather than `x-api-key`.

This reflects Anthropic's **June 15, 2026** policy change permitting third-party apps to authenticate with a Claude subscription, metered against a separate **monthly Agent SDK credit** (Pro $20 / Max 5× $100 / Max 20× $200 / Team $20–$100 / Enterprise varies), with overflow billed at standard API rates.

### ⚠️ Compliance caveat (why this is opt-in)
The credit policy is framed around usage "through the Agent SDK." Denkeeper calls the Messages API over **raw HTTP**, not the official Agent SDK, so eligibility/credit-billing for this path is **not empirically verified**. The feature is therefore strictly opt-in (`auth = "oauth"`), existing API-key setups are untouched, and the web UI surfaces the billing/terms context. Recommend confirming against a real `setup-token` before relying on it.

Sources: [Claude Code Authentication](https://code.claude.com/docs/en/authentication) · [Use the Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan)

## Changes

**Provider client** (`internal/llm/anthropic`)
- New `NewWithOptions`/`Options` constructor with an auth mode; `setHeaders` branches between `x-api-key` and Bearer + beta header. Existing constructors unchanged.

**Config** (`internal/config`)
- `ProviderInstanceConfig` gains `auth` and `oauth_token` (json-hidden secret).
- Token resolvable from TOML, `CLAUDE_CODE_OAUTH_TOKEN`, or `DENKEEPER_LLM_ANTHROPIC_OAUTH_TOKEN` (`resolveProviderOAuthTokens`). The resolve→`expandEnvVars` ordering is now documented as a deliberate invariant (env-sourced tokens must not be re-expanded).
- Validation: `oauth` only on anthropic and requires a token; `auth` defaults to `api_key` and is omitted from TOML when default (backward compat). Legacy `[llm.anthropic]` section supports it too.

**REST API** (`internal/api`)
- `providerInfo` exposes `auth` + `oauth_token_set` (token never echoed).
- Create/PATCH accept `auth`/`oauth_token` with validation.
- **New** `POST /api/v1/llm/providers/{name}/test` (scope `admin`) — verifies credentials, accepting optional unsaved-credential overrides so a freshly-pasted token can be tested before saving (backed by new `Deps.ProviderFactory`).
  - **OAuth providers are probed against the Messages API** (a minimal 1-token completion), not just `GET /v1/models`: a subscription token accepted by `/v1/models` can still be rejected by `/v1/messages`, so listing models alone would give false confidence. The probe **discovers an available model** from the credential's own model list (preferring the cheapest haiku tier) so the test never depends on the configured default model — which may be an OpenRouter-style id or a model the subscription can't reach. API-key providers keep listing models (no token spend).

**Web UI** (`web/src/pages/Providers.svelte`)
- Auth-method toggle for anthropic, subscription-token field, `claude setup-token` setup guidance, billing/terms banner, and a **Test connection** button with success/failure feedback.

**Tooling / docs**
- **OpenAPI drift gate**: `TestOpenAPISpecMatchesAnnotations` regenerates the spec from the swag annotations and fails on divergence (`just openapi-check`); `swag` pinned to `1.16.6` in `.mise.toml` for reproducible output. `swagger.json` regenerated from annotations (the prior copy had been hand-edited and drifted).
- `CLAUDE.md`, `website/static/llms-full.txt` updated. Build guidance reframed to drive everything through `just` (mise/Task are the layer underneath).

## Testing
- Go: full suite + `-race`; integration suite (`-tags integration`). New coverage: provider header modes, config validation/env/round-trip, REST create/patch/test + token masking, OAuth Messages-API probe + model discovery + fallback, OpenAPI drift, Providers UI flows.
- Web: full Vitest suite.
- `just hook` (fmt-check, vet, lint, lint-ui, test, test-ui) green; `golangci-lint` clean (two gocyclo violations from the initial draft were refactored out).

### Review follow-ups addressed in this PR
- `gocyclo` violations in `applyLLMProviderUpdate`/`persistLLMProvider` extracted into helpers.
- Connection test now exercises the real `/v1/messages` path for OAuth (was `/v1/models` only) and self-selects an available probe model.
- `swagger.json` regenerated from annotations + a drift check added so it can't silently diverge again.

### Still worth a human check before relying on OAuth
- Confirm a real `setup-token` authenticates an end-to-end chat (not just the connection test) and that subscription-credit billing actually applies to this raw-HTTP path.

https://claude.ai/code/session_01VcrS2MSye34rDyURFxxVpL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcrS2MSye34rDyURFxxVpL)_
