### PR TITLE
feat(llm,config,api,ui): OpenRouter sticky provider routing for prompt cache hits

### DIFF
--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -340,6 +340,11 @@ func createProvider(pc config.ProviderInstanceConfig, cfg *config.Config) llm.Pr
 		client := openrouter.NewFull(pc.Name, pc.APIKey)
 		r := &cfg.LLM.OpenRouter.Reasoning
 		client.SetReasoning(r.Enabled, r.Effort, r.MaxTokens, r.Exclude)
+		client.SetProviderRouting(
+			cfg.LLM.OpenRouter.ProviderOrder,
+			cfg.LLM.OpenRouter.ProviderAllowFallbacks,
+			cfg.LLM.OpenRouter.ResolveStickyTTL(),
+		)
 		return client
 	case "ollama":
 		return ollama.NewFull(pc.Name, pc.BaseURL)

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -219,10 +219,14 @@ func (s *Server) handleGetLLMProviders(w http.ResponseWriter, _ *http.Request) {
 
 // providerUpdateInput holds the mutable fields for PATCH /api/v1/llm/providers/{name}.
 type providerUpdateInput struct {
-	APIKey                *string                            `json:"api_key,omitempty"`
-	BaseURL               *string                            `json:"base_url,omitempty"`
-	Organization          *string                            `json:"organization,omitempty"`
-	Reasoning             *config.OpenRouterReasoningCfg     `json:"reasoning,omitempty"`
+	APIKey       *string                        `json:"api_key,omitempty"`
+	BaseURL      *string                        `json:"base_url,omitempty"`
+	Organization *string                        `json:"organization,omitempty"`
+	Reasoning    *config.OpenRouterReasoningCfg `json:"reasoning,omitempty"`
+	// Routing is a full replace, not a merge: a present routing object carries
+	// the complete desired state, so any field it omits is cleared (both
+	// in-memory via applyOpenRouterUpdate and in TOML via persistOpenRouterRouting).
+	// Callers must send the full snapshot, not a delta.
 	Routing               *providerRoutingCfg                `json:"routing,omitempty"`
 	CostLimitSoft         *float64                           `json:"cost_limit_soft,omitempty"`
 	CostLimitHard         *float64                           `json:"cost_limit_hard,omitempty"`

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -469,13 +469,21 @@ func (s *Server) persistOpenRouterReasoning(input *providerUpdateInput) {
 }
 
 // persistOpenRouterRouting writes routing config (flat keys) to [llm.openrouter].
-// Only non-zero-value fields are written to avoid cluttering the TOML with
-// empty keys when the user hasn't configured them.
+// It mirrors applyOpenRouterUpdate's full replace: a routing PATCH carries the
+// complete desired state, so a zero-value field is persisted as a deletion
+// (nil) rather than skipped. Skipping would leave a stale TOML value that
+// diverges from the in-memory config and resurrects on restart.
 func (s *Server) persistOpenRouterRouting(input *providerUpdateInput) {
 	if input.Routing == nil {
 		return
 	}
-	r := make(map[string]any)
+	// Default every key to nil (delete); set the ones the PATCH provides.
+	r := map[string]any{
+		"provider_order":           nil,
+		"provider_sticky_ttl":      nil,
+		"provider_allow_fallbacks": nil,
+		"provider_sticky":          nil,
+	}
 	if len(input.Routing.Order) > 0 {
 		r["provider_order"] = input.Routing.Order
 	}
@@ -487,9 +495,6 @@ func (s *Server) persistOpenRouterRouting(input *providerUpdateInput) {
 	}
 	if input.Routing.Sticky != nil {
 		r["provider_sticky"] = *input.Routing.Sticky
-	}
-	if len(r) == 0 {
-		return
 	}
 	if err := config.UpdateLLMProviderConfig(s.deps.ConfigPath, "openrouter", r); err != nil {
 		s.logger.Warn("failed to persist OpenRouter routing config", "error", err)

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Temikus/denkeeper/internal/audit"
 	"github.com/Temikus/denkeeper/internal/config"
@@ -143,10 +144,20 @@ type providerInfo struct {
 	BaseURL               string                             `json:"base_url,omitempty"`
 	Organization          string                             `json:"organization,omitempty"`
 	Reasoning             *config.OpenRouterReasoningCfg     `json:"reasoning,omitempty"`
+	Routing               *providerRoutingCfg                `json:"routing,omitempty"`
 	CostLimitSoft         *float64                           `json:"cost_limit_soft,omitempty"`
 	CostLimitHard         *float64                           `json:"cost_limit_hard,omitempty"`
 	DefaultRatePerKTokens *float64                           `json:"default_rate_per_1k_tokens,omitempty"`
 	ModelPrices           map[string]config.ModelPriceConfig `json:"model_prices,omitempty"`
+}
+
+// providerRoutingCfg is the API shape for OpenRouter upstream provider routing,
+// including sticky caching. Backed by the flat fields in [llm.openrouter].
+type providerRoutingCfg struct {
+	Order          []string `json:"order,omitempty"`
+	AllowFallbacks *bool    `json:"allow_fallbacks,omitempty"`
+	Sticky         *bool    `json:"sticky,omitempty"`
+	StickyTTL      string   `json:"sticky_ttl,omitempty"`
 }
 
 type llmProvidersResponse struct {
@@ -181,6 +192,12 @@ func (s *Server) handleGetLLMProviders(w http.ResponseWriter, _ *http.Request) {
 		if pc.Type == "openrouter" {
 			r := cfg.OpenRouter.Reasoning
 			pi.Reasoning = &r
+			pi.Routing = &providerRoutingCfg{
+				Order:          cfg.OpenRouter.ProviderOrder,
+				AllowFallbacks: cfg.OpenRouter.ProviderAllowFallbacks,
+				Sticky:         cfg.OpenRouter.ProviderSticky,
+				StickyTTL:      cfg.OpenRouter.ProviderStickyTTL,
+			}
 		}
 		pi.CostLimitSoft = pc.CostLimitSoft
 		pi.CostLimitHard = pc.CostLimitHard
@@ -206,6 +223,7 @@ type providerUpdateInput struct {
 	BaseURL               *string                            `json:"base_url,omitempty"`
 	Organization          *string                            `json:"organization,omitempty"`
 	Reasoning             *config.OpenRouterReasoningCfg     `json:"reasoning,omitempty"`
+	Routing               *providerRoutingCfg                `json:"routing,omitempty"`
 	CostLimitSoft         *float64                           `json:"cost_limit_soft,omitempty"`
 	CostLimitHard         *float64                           `json:"cost_limit_hard,omitempty"`
 	DefaultRatePerKTokens *float64                           `json:"default_rate_per_1k_tokens,omitempty"`
@@ -265,20 +283,10 @@ func (s *Server) handlePatchLLMProvider(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Reasoning is only valid for OpenRouter-type providers.
-	if input.Reasoning != nil {
-		if pc.Type != "openrouter" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{
-				"error": "reasoning is only supported for openrouter-type providers",
-			})
-			return
-		}
-		if err := config.ValidateOpenRouterReasoning(input.Reasoning); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{
-				"error": "invalid reasoning config: " + err.Error(),
-			})
-			return
-		}
+	// Reasoning and routing are only valid for OpenRouter-type providers.
+	if msg := validateOpenRouterUpdate(&input, pc.Type); msg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+		return
 	}
 
 	if msg := validateCostFields(input.CostLimitSoft, input.CostLimitHard, input.DefaultRatePerKTokens); msg != "" {
@@ -291,6 +299,30 @@ func (s *Server) handlePatchLLMProvider(w http.ResponseWriter, r *http.Request) 
 	s.persistLLMProvider(name, &input, nullCosts)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
+// validateOpenRouterUpdate checks the OpenRouter-only fields (reasoning,
+// routing) of a provider update. Returns an error message, or "" if valid.
+func validateOpenRouterUpdate(input *providerUpdateInput, providerType string) string {
+	if input.Reasoning != nil {
+		if providerType != "openrouter" {
+			return "reasoning is only supported for openrouter-type providers"
+		}
+		if err := config.ValidateOpenRouterReasoning(input.Reasoning); err != nil {
+			return "invalid reasoning config: " + err.Error()
+		}
+	}
+	if input.Routing != nil {
+		if providerType != "openrouter" {
+			return "routing is only supported for openrouter-type providers"
+		}
+		if ttl := input.Routing.StickyTTL; ttl != "" {
+			if d, err := time.ParseDuration(ttl); err != nil || d < 0 {
+				return `invalid routing config: sticky_ttl must be a non-negative duration (e.g. "1h")`
+			}
+		}
+	}
+	return ""
 }
 
 // findProviderInstance returns a pointer to the named provider in config, or nil.
@@ -318,8 +350,8 @@ func (s *Server) applyLLMProviderUpdate(name string, input *providerUpdateInput,
 		pc.Organization = *input.Organization
 	}
 
-	if input.Reasoning != nil && pc.Type == "openrouter" {
-		s.deps.Config.LLM.OpenRouter.Reasoning = *input.Reasoning
+	if pc.Type == "openrouter" {
+		s.applyOpenRouterUpdate(input)
 	}
 
 	if nulls.Soft {
@@ -345,6 +377,22 @@ func (s *Server) applyLLMProviderUpdate(name string, input *providerUpdateInput,
 
 	// Keep legacy structs in sync for backward compat.
 	s.syncLegacyProviderConfig(name, pc)
+}
+
+// applyOpenRouterUpdate applies reasoning and routing config (both under
+// [llm.openrouter]) from a provider update. Caller ensures the provider is
+// OpenRouter-typed.
+func (s *Server) applyOpenRouterUpdate(input *providerUpdateInput) {
+	if input.Reasoning != nil {
+		s.deps.Config.LLM.OpenRouter.Reasoning = *input.Reasoning
+	}
+	if input.Routing != nil {
+		or := &s.deps.Config.LLM.OpenRouter
+		or.ProviderOrder = input.Routing.Order
+		or.ProviderAllowFallbacks = input.Routing.AllowFallbacks
+		or.ProviderSticky = input.Routing.Sticky
+		or.ProviderStickyTTL = input.Routing.StickyTTL
+	}
 }
 
 // syncLegacyProviderConfig mirrors changes from a ProviderInstanceConfig back
@@ -391,24 +439,60 @@ func (s *Server) persistLLMProvider(name string, input *providerUpdateInput, nul
 		}
 	}
 
-	// Reasoning config lives in [llm.openrouter.reasoning], not in [[llm.providers]].
-	if input.Reasoning != nil {
-		r := make(map[string]any)
-		if input.Reasoning.Enabled != nil {
-			r["enabled"] = *input.Reasoning.Enabled
-		}
-		if input.Reasoning.Effort != "" {
-			r["effort"] = input.Reasoning.Effort
-		}
-		if input.Reasoning.MaxTokens > 0 {
-			r["max_tokens"] = input.Reasoning.MaxTokens
-		}
-		if input.Reasoning.Exclude != nil {
-			r["exclude"] = *input.Reasoning.Exclude
-		}
-		if err := config.UpdateLLMProviderConfig(s.deps.ConfigPath, "openrouter", map[string]any{"reasoning": r}); err != nil {
-			s.logger.Warn("failed to persist OpenRouter reasoning config", "error", err)
-		}
+	// Reasoning and routing config live under [llm.openrouter], not in
+	// [[llm.providers]].
+	s.persistOpenRouterReasoning(input)
+	s.persistOpenRouterRouting(input)
+}
+
+// persistOpenRouterReasoning writes reasoning config to [llm.openrouter.reasoning].
+func (s *Server) persistOpenRouterReasoning(input *providerUpdateInput) {
+	if input.Reasoning == nil {
+		return
+	}
+	r := make(map[string]any)
+	if input.Reasoning.Enabled != nil {
+		r["enabled"] = *input.Reasoning.Enabled
+	}
+	if input.Reasoning.Effort != "" {
+		r["effort"] = input.Reasoning.Effort
+	}
+	if input.Reasoning.MaxTokens > 0 {
+		r["max_tokens"] = input.Reasoning.MaxTokens
+	}
+	if input.Reasoning.Exclude != nil {
+		r["exclude"] = *input.Reasoning.Exclude
+	}
+	if err := config.UpdateLLMProviderConfig(s.deps.ConfigPath, "openrouter", map[string]any{"reasoning": r}); err != nil {
+		s.logger.Warn("failed to persist OpenRouter reasoning config", "error", err)
+	}
+}
+
+// persistOpenRouterRouting writes routing config (flat keys) to [llm.openrouter].
+// Only non-zero-value fields are written to avoid cluttering the TOML with
+// empty keys when the user hasn't configured them.
+func (s *Server) persistOpenRouterRouting(input *providerUpdateInput) {
+	if input.Routing == nil {
+		return
+	}
+	r := make(map[string]any)
+	if len(input.Routing.Order) > 0 {
+		r["provider_order"] = input.Routing.Order
+	}
+	if input.Routing.StickyTTL != "" {
+		r["provider_sticky_ttl"] = input.Routing.StickyTTL
+	}
+	if input.Routing.AllowFallbacks != nil {
+		r["provider_allow_fallbacks"] = *input.Routing.AllowFallbacks
+	}
+	if input.Routing.Sticky != nil {
+		r["provider_sticky"] = *input.Routing.Sticky
+	}
+	if len(r) == 0 {
+		return
+	}
+	if err := config.UpdateLLMProviderConfig(s.deps.ConfigPath, "openrouter", r); err != nil {
+		s.logger.Warn("failed to persist OpenRouter routing config", "error", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -803,7 +803,9 @@ type OpenRouterConfig struct {
 	// ProviderSticky enables sticky provider routing (default ON). After a
 	// successful response the served upstream provider is preferred for
 	// ProviderStickyTTL, so the upstream's automatic prompt caching keeps
-	// hitting instead of being scattered across providers. Errors reset it.
+	// hitting instead of being scattered across providers. Upstream errors
+	// (429/5xx/network) reset the preference; caller cancellation and 4xx
+	// client errors leave it intact.
 	ProviderSticky *bool `toml:"provider_sticky" json:"provider_sticky,omitempty"`
 	// ProviderStickyTTL is how long to prefer the last-served provider, as a Go
 	// duration string (e.g. "1h", "30m"). Defaults to "1h" when sticky is on.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -789,6 +789,41 @@ type FallbackConfig struct {
 type OpenRouterConfig struct {
 	APIKey    string                 `toml:"api_key"`
 	Reasoning OpenRouterReasoningCfg `toml:"reasoning"`
+
+	// ProviderOrder is an explicit preference list of OpenRouter upstream
+	// provider slugs/names (e.g. "moonshotai") that overrides sticky routing
+	// when set. Usually unnecessary — sticky routing (below) discovers the
+	// right provider automatically.
+	// See https://openrouter.ai/docs/features/provider-routing
+	ProviderOrder []string `toml:"provider_order" json:"provider_order,omitempty"`
+	// ProviderAllowFallbacks, when non-nil, controls whether OpenRouter may fall
+	// back to providers outside ProviderOrder. Leave unset (nil) to keep
+	// OpenRouter's default (fallbacks allowed) — preferred for resilience.
+	ProviderAllowFallbacks *bool `toml:"provider_allow_fallbacks" json:"provider_allow_fallbacks,omitempty"`
+	// ProviderSticky enables sticky provider routing (default ON). After a
+	// successful response the served upstream provider is preferred for
+	// ProviderStickyTTL, so the upstream's automatic prompt caching keeps
+	// hitting instead of being scattered across providers. Errors reset it.
+	ProviderSticky *bool `toml:"provider_sticky" json:"provider_sticky,omitempty"`
+	// ProviderStickyTTL is how long to prefer the last-served provider, as a Go
+	// duration string (e.g. "1h", "30m"). Defaults to "1h" when sticky is on.
+	ProviderStickyTTL string `toml:"provider_sticky_ttl" json:"provider_sticky_ttl,omitempty"`
+}
+
+// ResolveStickyTTL returns the effective sticky-routing window: zero when
+// sticky routing is disabled, otherwise ProviderStickyTTL (default 1h). The
+// duration string is validated at config-load time, so parse errors here fall
+// back to the default rather than failing.
+func (o OpenRouterConfig) ResolveStickyTTL() time.Duration {
+	if o.ProviderSticky != nil && !*o.ProviderSticky {
+		return 0
+	}
+	if o.ProviderStickyTTL != "" {
+		if d, err := time.ParseDuration(o.ProviderStickyTTL); err == nil && d > 0 {
+			return d
+		}
+	}
+	return time.Hour
 }
 
 // OpenRouterReasoningCfg controls the reasoning parameter sent to OpenRouter.
@@ -1739,8 +1774,26 @@ func validate(cfg *Config) error {
 	if err := validateMemory(&cfg.Memory); err != nil {
 		return fmt.Errorf("validate memory: %w", err)
 	}
-	if err := ValidateOpenRouterReasoning(&cfg.LLM.OpenRouter.Reasoning); err != nil {
-		return fmt.Errorf("validate openrouter reasoning: %w", err)
+	if err := validateOpenRouter(&cfg.LLM.OpenRouter); err != nil {
+		return fmt.Errorf("validate openrouter: %w", err)
+	}
+	return nil
+}
+
+// validateOpenRouter validates the OpenRouter provider config (reasoning plus
+// provider routing fields).
+func validateOpenRouter(o *OpenRouterConfig) error {
+	if err := ValidateOpenRouterReasoning(&o.Reasoning); err != nil {
+		return fmt.Errorf("reasoning: %w", err)
+	}
+	if ttl := o.ProviderStickyTTL; ttl != "" {
+		d, err := time.ParseDuration(ttl)
+		if err != nil {
+			return fmt.Errorf("provider_sticky_ttl %q is not a valid duration: %w", ttl, err)
+		}
+		if d < 0 {
+			return fmt.Errorf("provider_sticky_ttl must not be negative")
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParse_ValidConfig(t *testing.T) {
@@ -4425,5 +4426,37 @@ cached_input = 1.5
 	_, err := Parse(tomlData)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveStickyTTL_DefaultsToOneHour(t *testing.T) {
+	o := OpenRouterConfig{}
+	if got := o.ResolveStickyTTL(); got != time.Hour {
+		t.Fatalf("default = %v, want 1h", got)
+	}
+}
+
+func TestResolveStickyTTL_DisabledReturnsZero(t *testing.T) {
+	off := false
+	o := OpenRouterConfig{ProviderSticky: &off, ProviderStickyTTL: "30m"}
+	if got := o.ResolveStickyTTL(); got != 0 {
+		t.Fatalf("disabled = %v, want 0", got)
+	}
+}
+
+func TestResolveStickyTTL_CustomDuration(t *testing.T) {
+	o := OpenRouterConfig{ProviderStickyTTL: "45m"}
+	if got := o.ResolveStickyTTL(); got != 45*time.Minute {
+		t.Fatalf("custom = %v, want 45m", got)
+	}
+}
+
+func TestValidate_RejectsBadStickyTTL(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[llm.openrouter]
+provider_sticky_ttl = "not-a-duration"
+`)
+	if _, err := Parse(tomlData); err == nil {
+		t.Fatal("expected validation error for bad provider_sticky_ttl")
 	}
 }

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -543,8 +543,14 @@ func updateLLMProviderConfigLocked(path, provider string, changes map[string]any
 	if !ok {
 		provSection = map[string]any{}
 	}
+	// A nil value deletes the key, so a cleared field doesn't linger in TOML
+	// and resurrect on restart (mirrors UpdateLLMProviderInstanceConfig).
 	for k, v := range changes {
-		provSection[k] = v
+		if v == nil {
+			delete(provSection, k)
+		} else {
+			provSection[k] = v
+		}
 	}
 	llmSection[provider] = provSection
 	raw["llm"] = llmSection
@@ -577,7 +583,9 @@ func UpdateLLMConfig(path string, changes map[string]any) error {
 }
 
 // UpdateLLMProviderConfig persists changes to [llm.<provider>] in the TOML
-// config. Only keys present in changes are applied (partial update).
+// config. Only keys present in changes are applied (partial update); a key
+// mapped to a nil value is deleted, letting callers clear a field rather than
+// leave a stale value behind.
 func UpdateLLMProviderConfig(path, provider string, changes map[string]any) error {
 	ConfigMu.Lock()
 	defer ConfigMu.Unlock()

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -560,7 +560,9 @@ func updateLLMProviderConfigLocked(path, provider string, changes map[string]any
 
 // UpdateLLMConfig persists changes to top-level [llm] keys (default_provider,
 // default_model, cost_limit_soft, cost_limit_hard). Only keys present in
-// changes are applied (partial update).
+// changes are applied (partial update); a key mapped to a nil value is deleted,
+// so a cleared field doesn't linger in TOML (consistent with
+// UpdateLLMProviderConfig / UpdateLLMProviderInstanceConfig).
 func UpdateLLMConfig(path string, changes map[string]any) error {
 	ConfigMu.Lock()
 	defer ConfigMu.Unlock()
@@ -575,7 +577,11 @@ func UpdateLLMConfig(path string, changes map[string]any) error {
 		llmSection = map[string]any{}
 	}
 	for k, v := range changes {
-		llmSection[k] = v
+		if v == nil {
+			delete(llmSection, k)
+		} else {
+			llmSection[k] = v
+		}
 	}
 	raw["llm"] = llmSection
 

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -866,6 +866,88 @@ cost_limit_hard = 5.0
 	}
 }
 
+// A nil value clears a flat key under [llm.<provider>] (e.g. the OpenRouter
+// routing keys) rather than leaving a stale value to resurrect on restart.
+func TestUpdateLLMProviderConfig_NilDeletesKey(t *testing.T) {
+	path := writeTestConfig(t, `[llm.openrouter]
+api_key = "sk-or"
+provider_sticky = true
+provider_sticky_ttl = "45m"
+provider_order = ["moonshotai"]
+`)
+
+	changes := map[string]any{
+		"provider_sticky":     true,
+		"provider_sticky_ttl": nil,
+		"provider_order":      nil,
+	}
+	if err := UpdateLLMProviderConfig(path, "openrouter", changes); err != nil {
+		t.Fatalf("UpdateLLMProviderConfig: %v", err)
+	}
+
+	content := readTestConfig(t, path)
+	if strings.Contains(content, "45m") {
+		t.Errorf("provider_sticky_ttl should be deleted; content:\n%s", content)
+	}
+	if strings.Contains(content, "moonshotai") {
+		t.Errorf("provider_order should be deleted; content:\n%s", content)
+	}
+	if !strings.Contains(content, "provider_sticky") {
+		t.Errorf("provider_sticky should be preserved; content:\n%s", content)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	or := cfg.LLM.OpenRouter
+	if or.ProviderStickyTTL != "" {
+		t.Errorf("ProviderStickyTTL = %q, want empty", or.ProviderStickyTTL)
+	}
+	if len(or.ProviderOrder) != 0 {
+		t.Errorf("ProviderOrder = %v, want empty", or.ProviderOrder)
+	}
+	if or.ProviderSticky == nil || !*or.ProviderSticky {
+		t.Errorf("ProviderSticky = %v, want true", or.ProviderSticky)
+	}
+}
+
+// A nil value clears a top-level [llm] key rather than leaving it behind.
+func TestUpdateLLMConfig_NilDeletesKey(t *testing.T) {
+	path := writeTestConfig(t, `[llm]
+default_provider = "mycloud"
+default_model = "gpt-4"
+
+[[llm.providers]]
+name = "mycloud"
+type = "openai"
+api_key = "sk-test"
+`)
+
+	changes := map[string]any{
+		"default_model":    nil,
+		"default_provider": "mycloud",
+	}
+	if err := UpdateLLMConfig(path, changes); err != nil {
+		t.Fatalf("UpdateLLMConfig: %v", err)
+	}
+
+	// The key itself must be gone from TOML (Load would otherwise re-apply a
+	// built-in default model, masking whether the key was actually deleted).
+	content := readTestConfig(t, path)
+	if strings.Contains(content, "default_model") || strings.Contains(content, "gpt-4") {
+		t.Errorf("default_model should be deleted; content:\n%s", content)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if cfg.LLM.DefaultProvider != "mycloud" {
+		t.Errorf("DefaultProvider = %q, want mycloud", cfg.LLM.DefaultProvider)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Config writer hardening (backup + concurrency)
 // ---------------------------------------------------------------------------

--- a/internal/integration/provider_routing_test.go
+++ b/internal/integration/provider_routing_test.go
@@ -164,3 +164,41 @@ func TestProviderPatch_Routing_ClearRemovesStaleTOML(t *testing.T) {
 		t.Errorf("ProviderSticky = %v, want true", or.ProviderSticky)
 	}
 }
+
+// Reasoning persists as a single nested [llm.openrouter.reasoning] table that
+// is replaced wholesale, so clearing a sub-field (here: effort) drops it from
+// TOML rather than leaving a stale value — unlike the flat routing keys, which
+// needed explicit deletion. This locks in that structural safety property.
+func TestProviderPatch_Reasoning_ClearRemovesStaleTOML(t *testing.T) {
+	h := providerCrudHarness(t)
+	withOpenRouterProvider(h)
+
+	// Set reasoning with an explicit effort level.
+	rec := h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"reasoning": map[string]any{"enabled": true, "effort": "high"}}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set PATCH status = %d: %s", rec.Code, rec.Body.String())
+	}
+	content, _ := os.ReadFile(h.ConfigPath())
+	if !strings.Contains(string(content), "high") {
+		t.Fatalf("setup did not persist effort:\n%s", string(content))
+	}
+
+	// Clear effort (enabled stays on, effort omitted).
+	rec = h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"reasoning": map[string]any{"enabled": true}}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear PATCH status = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	content, err := os.ReadFile(h.ConfigPath())
+	if err != nil {
+		t.Fatalf("reading TOML: %v", err)
+	}
+	if strings.Contains(string(content), "high") {
+		t.Errorf("stale reasoning effort survived clear:\n%s", string(content))
+	}
+	if got := h.Config().LLM.OpenRouter.Reasoning.Effort; got != "" {
+		t.Errorf("in-memory Effort = %q, want empty", got)
+	}
+}

--- a/internal/integration/provider_routing_test.go
+++ b/internal/integration/provider_routing_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Temikus/denkeeper/internal/config"
+)
+
+// withOpenRouterProvider appends an OpenRouter provider to the harness so the
+// OpenRouter-only routing endpoints have a valid target.
+func withOpenRouterProvider(h *Harness) {
+	h.Config().LLM.Providers = append(h.Config().LLM.Providers,
+		config.ProviderInstanceConfig{Name: "mock-or", Type: "openrouter", APIKey: "sk-or"})
+}
+
+func openRouterProvider(t *testing.T, h *Harness) map[string]any {
+	t.Helper()
+	rec := h.Do(h.AuthedRequest("GET", "/api/v1/llm/providers", nil))
+	var body map[string]any
+	DecodeJSON(t, rec, &body)
+	for _, raw := range body["providers"].([]any) {
+		p := raw.(map[string]any)
+		if p["name"] == "mock-or" {
+			return p
+		}
+	}
+	t.Fatal("mock-or provider not found in GET response")
+	return nil
+}
+
+func TestProviderPatch_Routing_RoundTrip(t *testing.T) {
+	h := providerCrudHarness(t)
+	withOpenRouterProvider(h)
+
+	// Sticky routing defaults to on with a nil TTL field; disable it explicitly.
+	rec := h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"routing": map[string]any{"sticky": false, "sticky_ttl": "30m"}}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	p := openRouterProvider(t, h)
+	routing, ok := p["routing"].(map[string]any)
+	if !ok {
+		t.Fatalf("routing missing or wrong type: %v", p["routing"])
+	}
+	if routing["sticky"] != false {
+		t.Errorf("routing.sticky = %v, want false", routing["sticky"])
+	}
+	if routing["sticky_ttl"] != "30m" {
+		t.Errorf("routing.sticky_ttl = %v, want 30m", routing["sticky_ttl"])
+	}
+
+	// Confirm it reached the in-memory config the provider client reads from.
+	or := h.Config().LLM.OpenRouter
+	if or.ProviderSticky == nil || *or.ProviderSticky {
+		t.Errorf("ProviderSticky = %v, want false", or.ProviderSticky)
+	}
+	if or.ProviderStickyTTL != "30m" {
+		t.Errorf("ProviderStickyTTL = %q, want 30m", or.ProviderStickyTTL)
+	}
+}
+
+func TestProviderPatch_Routing_RejectsBadTTL(t *testing.T) {
+	h := providerCrudHarness(t)
+	withOpenRouterProvider(h)
+
+	rec := h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"routing": map[string]any{"sticky_ttl": "not-a-duration"}}))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProviderPatch_Routing_RejectedForNonOpenRouter(t *testing.T) {
+	h := providerCrudHarness(t)
+
+	// mock-existing is an openai provider — routing is OpenRouter-only.
+	rec := h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-existing",
+		map[string]any{"routing": map[string]any{"sticky": true}}))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProviderPatch_Routing_PersistsToTOML(t *testing.T) {
+	h := providerCrudHarness(t)
+	withOpenRouterProvider(h)
+
+	rec := h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"routing": map[string]any{"sticky": false, "sticky_ttl": "45m"}}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	content, err := os.ReadFile(h.ConfigPath())
+	if err != nil {
+		t.Fatalf("reading TOML: %v", err)
+	}
+	toml := string(content)
+	if !strings.Contains(toml, "provider_sticky") {
+		t.Errorf("provider_sticky not found in TOML:\n%s", toml)
+	}
+	if !strings.Contains(toml, "45m") {
+		t.Errorf("provider_sticky_ttl=45m not found in TOML:\n%s", toml)
+	}
+}

--- a/internal/integration/provider_routing_test.go
+++ b/internal/integration/provider_routing_test.go
@@ -110,3 +110,57 @@ func TestProviderPatch_Routing_PersistsToTOML(t *testing.T) {
 		t.Errorf("provider_sticky_ttl=45m not found in TOML:\n%s", toml)
 	}
 }
+
+// Clearing a previously-set routing field through PATCH must remove it from
+// the TOML too, not just from memory — otherwise the stale value resurrects on
+// the next restart/reload. Regression test for the zero-value-skip persistence
+// bug.
+func TestProviderPatch_Routing_ClearRemovesStaleTOML(t *testing.T) {
+	h := providerCrudHarness(t)
+	withOpenRouterProvider(h)
+
+	// Set an explicit order + custom TTL.
+	rec := h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"routing": map[string]any{
+			"sticky": true, "sticky_ttl": "45m", "order": []string{"moonshotai"},
+		}}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set PATCH status = %d: %s", rec.Code, rec.Body.String())
+	}
+	content, _ := os.ReadFile(h.ConfigPath())
+	if toml := string(content); !strings.Contains(toml, "moonshotai") || !strings.Contains(toml, "45m") {
+		t.Fatalf("setup did not persist order/ttl:\n%s", toml)
+	}
+
+	// Now clear the TTL and order (sticky stays on, others omitted/empty).
+	rec = h.Do(h.AuthedRequest("PATCH", "/api/v1/llm/providers/mock-or",
+		map[string]any{"routing": map[string]any{"sticky": true}}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear PATCH status = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// TOML must no longer carry the stale order/ttl values.
+	content, err := os.ReadFile(h.ConfigPath())
+	if err != nil {
+		t.Fatalf("reading TOML: %v", err)
+	}
+	toml := string(content)
+	if strings.Contains(toml, "moonshotai") {
+		t.Errorf("stale provider_order survived clear:\n%s", toml)
+	}
+	if strings.Contains(toml, "45m") {
+		t.Errorf("stale provider_sticky_ttl survived clear:\n%s", toml)
+	}
+
+	// In-memory config must agree: order and TTL cleared, sticky still on.
+	or := h.Config().LLM.OpenRouter
+	if len(or.ProviderOrder) != 0 {
+		t.Errorf("ProviderOrder = %v, want empty", or.ProviderOrder)
+	}
+	if or.ProviderStickyTTL != "" {
+		t.Errorf("ProviderStickyTTL = %q, want empty", or.ProviderStickyTTL)
+	}
+	if or.ProviderSticky == nil || !*or.ProviderSticky {
+		t.Errorf("ProviderSticky = %v, want true", or.ProviderSticky)
+	}
+}

--- a/internal/llm/oaistream.go
+++ b/internal/llm/oaistream.go
@@ -20,6 +20,9 @@ type OAIStreamResult struct {
 	Usage        *OAIStreamUsage
 	// ReasoningContent captures reasoning_content deltas (OpenRouter).
 	ReasoningContent string
+	// Provider is the upstream provider that served the response, when the
+	// gateway reports it (OpenRouter sets a top-level "provider" field).
+	Provider string
 }
 
 // OAIStreamUsage mirrors the usage block in the final SSE chunk.
@@ -56,6 +59,9 @@ type oaiToolAccum struct {
 func (a *oaiStreamAccumulator) processChunk(chunk *oaiStreamChunk) {
 	if chunk.Model != "" {
 		a.result.Model = chunk.Model
+	}
+	if chunk.Provider != "" {
+		a.result.Provider = chunk.Provider
 	}
 	if len(chunk.Choices) > 0 {
 		a.processChoice(&chunk.Choices[0])
@@ -192,10 +198,11 @@ func ReadOAIStream(body io.Reader, onStream StreamCallback, idle *StreamIdleConf
 // OpenAI streaming wire types.
 
 type oaiStreamChunk struct {
-	ID      string            `json:"id"`
-	Model   string            `json:"model"`
-	Choices []oaiStreamChoice `json:"choices"`
-	Usage   *OAIStreamUsage   `json:"usage,omitempty"`
+	ID       string            `json:"id"`
+	Model    string            `json:"model"`
+	Provider string            `json:"provider,omitempty"`
+	Choices  []oaiStreamChoice `json:"choices"`
+	Usage    *OAIStreamUsage   `json:"usage,omitempty"`
 }
 
 type oaiStreamChoice struct {

--- a/internal/llm/openrouter/openrouter.go
+++ b/internal/llm/openrouter/openrouter.go
@@ -185,7 +185,8 @@ func (c *Client) recordProvider(name string) {
 }
 
 // resetSticky clears the sticky preference so the next request lets OpenRouter
-// route freshly. Called on any request error.
+// route freshly. Called on errors that implicate the upstream provider
+// (429/5xx/network), not on caller cancellation or 4xx client errors.
 func (c *Client) resetSticky() {
 	c.stickyMu.Lock()
 	c.stickyProvider = ""
@@ -223,10 +224,13 @@ func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (
 	if req.OnStream != nil {
 		return c.chatCompletionStream(ctx, req)
 	}
-	// Sticky routing: any error on this request clears the preference so the
-	// next call routes freshly (success records the served provider below).
+	// Sticky routing: clear the preference only when the error implicates the
+	// upstream (429/5xx/network) so the next call routes freshly; a success
+	// records the served provider below. Caller cancellation and 4xx client
+	// errors leave the pin intact — the provider is healthy, so discarding its
+	// warm cache affinity would needlessly scatter subsequent requests.
 	defer func() {
-		if retErr != nil {
+		if retErr != nil && llm.IsRetryable(retErr) {
 			c.resetSticky()
 		}
 	}()
@@ -302,10 +306,12 @@ func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (
 
 // chatCompletionStream handles the streaming path using the shared OAI helper.
 func (c *Client) chatCompletionStream(ctx context.Context, req llm.ChatRequest) (out *llm.ChatResponse, retErr error) {
-	// Sticky routing: any error clears the preference; success records the
-	// served provider (captured from the stream below).
+	// Sticky routing: clear the preference only when the error implicates the
+	// upstream (429/5xx/network, including a mid-stream drop); success records
+	// the served provider (captured from the stream below). Caller cancellation
+	// and 4xx client errors leave the pin intact.
 	defer func() {
-		if retErr != nil {
+		if retErr != nil && llm.IsRetryable(retErr) {
 			c.resetSticky()
 		}
 	}()

--- a/internal/llm/openrouter/openrouter.go
+++ b/internal/llm/openrouter/openrouter.go
@@ -50,7 +50,8 @@ type Client struct {
 	// Sticky provider routing: after a successful response, prefer the upstream
 	// provider that served it for stickyTTL, so the upstream's automatic prompt
 	// caching keeps hitting instead of being scattered across providers. Reset
-	// on any error. Disabled when stickyTTL <= 0.
+	// on errors that implicate the upstream (429/5xx/network), not on caller
+	// cancellation or 4xx client errors. Disabled when stickyTTL <= 0.
 	stickyTTL      time.Duration
 	stickyMu       sync.Mutex
 	stickyProvider string

--- a/internal/llm/openrouter/openrouter.go
+++ b/internal/llm/openrouter/openrouter.go
@@ -44,8 +44,29 @@ type Client struct {
 	reasoningMaxTokens int
 	reasoningExclude   *bool
 
+	providerOrder          []string
+	providerAllowFallbacks *bool
+
+	// Sticky provider routing: after a successful response, prefer the upstream
+	// provider that served it for stickyTTL, so the upstream's automatic prompt
+	// caching keeps hitting instead of being scattered across providers. Reset
+	// on any error. Disabled when stickyTTL <= 0.
+	stickyTTL      time.Duration
+	stickyMu       sync.Mutex
+	stickyProvider string
+	stickyExpiry   time.Time
+	now            func() time.Time // injectable clock; nil → time.Now
+
 	detailsMu    sync.Mutex
 	detailsCache *modelDetailsCache
+}
+
+// clock returns the current time, honoring an injected clock for tests.
+func (c *Client) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
 }
 
 func New(apiKey string) *Client {
@@ -115,6 +136,63 @@ func (c *Client) buildReasoningParam() *reasoningParam {
 	return p
 }
 
+// SetProviderRouting configures OpenRouter upstream provider routing. order is
+// an explicit preference list of provider slugs/names (e.g. "moonshotai") that
+// always wins when set; allowFallbacks (when non-nil) controls whether
+// OpenRouter may fall back to providers outside that list. stickyTTL (> 0)
+// enables sticky routing: after a success the served provider is preferred for
+// that duration so the upstream's automatic prompt caching keeps hitting
+// instead of being scattered across providers. Errors reset the preference.
+func (c *Client) SetProviderRouting(order []string, allowFallbacks *bool, stickyTTL time.Duration) {
+	c.providerOrder = order
+	c.providerAllowFallbacks = allowFallbacks
+	c.stickyTTL = stickyTTL
+}
+
+// buildProviderParam constructs the provider routing parameter for the request.
+// Explicit config order wins; otherwise an active sticky preference is applied
+// (always with fallbacks, so a now-unavailable provider degrades gracefully).
+// Returns nil when nothing is configured (the field is then omitted entirely).
+func (c *Client) buildProviderParam() *providerParam {
+	if len(c.providerOrder) > 0 {
+		return &providerParam{Order: c.providerOrder, AllowFallbacks: c.providerAllowFallbacks}
+	}
+	if c.stickyTTL > 0 {
+		c.stickyMu.Lock()
+		prov, exp := c.stickyProvider, c.stickyExpiry
+		c.stickyMu.Unlock()
+		if prov != "" && c.clock().Before(exp) {
+			allow := true
+			return &providerParam{Order: []string{prov}, AllowFallbacks: &allow}
+		}
+	}
+	if c.providerAllowFallbacks != nil {
+		return &providerParam{AllowFallbacks: c.providerAllowFallbacks}
+	}
+	return nil
+}
+
+// recordProvider remembers the provider that served a successful response,
+// extending the sticky window. No-op when stickiness is off or name is empty.
+func (c *Client) recordProvider(name string) {
+	if c.stickyTTL <= 0 || name == "" {
+		return
+	}
+	c.stickyMu.Lock()
+	c.stickyProvider = name
+	c.stickyExpiry = c.clock().Add(c.stickyTTL)
+	c.stickyMu.Unlock()
+}
+
+// resetSticky clears the sticky preference so the next request lets OpenRouter
+// route freshly. Called on any request error.
+func (c *Client) resetSticky() {
+	c.stickyMu.Lock()
+	c.stickyProvider = ""
+	c.stickyExpiry = time.Time{}
+	c.stickyMu.Unlock()
+}
+
 func (c *Client) Name() string { return c.name }
 
 // SupportsStreaming implements llm.StreamingProvider.
@@ -141,16 +219,24 @@ func (c *Client) ChatCompletion(ctx context.Context, req llm.ChatRequest) (*llm.
 	return resp, nil
 }
 
-func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (out *llm.ChatResponse, retErr error) {
 	if req.OnStream != nil {
 		return c.chatCompletionStream(ctx, req)
 	}
+	// Sticky routing: any error on this request clears the preference so the
+	// next call routes freshly (success records the served provider below).
+	defer func() {
+		if retErr != nil {
+			c.resetSticky()
+		}
+	}()
 
 	body := apiRequest{
 		Model:     req.Model,
 		Messages:  make([]apiMessage, len(req.Messages)),
 		Tools:     req.Tools,
 		Reasoning: c.buildReasoningParam(),
+		Provider:  c.buildProviderParam(),
 	}
 	if req.MaxTokens > 0 {
 		body.MaxTokens = &req.MaxTokens
@@ -210,16 +296,26 @@ func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (
 		return nil, fmt.Errorf("no choices in response")
 	}
 
+	c.recordProvider(apiResp.Provider)
 	return buildChatResponse(&apiResp), nil
 }
 
 // chatCompletionStream handles the streaming path using the shared OAI helper.
-func (c *Client) chatCompletionStream(ctx context.Context, req llm.ChatRequest) (*llm.ChatResponse, error) {
+func (c *Client) chatCompletionStream(ctx context.Context, req llm.ChatRequest) (out *llm.ChatResponse, retErr error) {
+	// Sticky routing: any error clears the preference; success records the
+	// served provider (captured from the stream below).
+	defer func() {
+		if retErr != nil {
+			c.resetSticky()
+		}
+	}()
+
 	body := apiStreamRequest{
 		Model:         req.Model,
 		Messages:      make([]apiMessage, len(req.Messages)),
 		Tools:         req.Tools,
 		Reasoning:     c.buildReasoningParam(),
+		Provider:      c.buildProviderParam(),
 		Stream:        true,
 		StreamOptions: &streamOptions{IncludeUsage: true},
 	}
@@ -298,6 +394,7 @@ func (c *Client) chatCompletionStream(ctx context.Context, req llm.ChatRequest) 
 		}
 		chatResp.CostUSD = result.Usage.Cost
 	}
+	c.recordProvider(result.Provider)
 	return chatResp, nil
 }
 
@@ -608,6 +705,7 @@ type apiRequest struct {
 	Temperature *float64        `json:"temperature,omitempty"`
 	Tools       []llm.ToolDef   `json:"tools,omitempty"`
 	Reasoning   *reasoningParam `json:"reasoning,omitempty"`
+	Provider    *providerParam  `json:"provider,omitempty"`
 }
 
 type reasoningParam struct {
@@ -615,6 +713,13 @@ type reasoningParam struct {
 	Effort    string `json:"effort,omitempty"`
 	MaxTokens int    `json:"max_tokens,omitempty"`
 	Exclude   *bool  `json:"exclude,omitempty"`
+}
+
+// providerParam is OpenRouter's upstream provider routing preference.
+// See https://openrouter.ai/docs/features/provider-routing
+type providerParam struct {
+	Order          []string `json:"order,omitempty"`
+	AllowFallbacks *bool    `json:"allow_fallbacks,omitempty"`
 }
 
 // apiMessage handles both outgoing requests (content as string) and incoming
@@ -701,10 +806,11 @@ func (m *apiMessage) UnmarshalJSON(data []byte) error {
 }
 
 type apiResponse struct {
-	ID      string      `json:"id"`
-	Model   string      `json:"model"`
-	Choices []apiChoice `json:"choices"`
-	Usage   apiUsage    `json:"usage"`
+	ID       string      `json:"id"`
+	Model    string      `json:"model"`
+	Provider string      `json:"provider"`
+	Choices  []apiChoice `json:"choices"`
+	Usage    apiUsage    `json:"usage"`
 }
 
 type apiChoice struct {
@@ -728,6 +834,7 @@ type apiStreamRequest struct {
 	Temperature   *float64        `json:"temperature,omitempty"`
 	Tools         []llm.ToolDef   `json:"tools,omitempty"`
 	Reasoning     *reasoningParam `json:"reasoning,omitempty"`
+	Provider      *providerParam  `json:"provider,omitempty"`
 	Stream        bool            `json:"stream"`
 	StreamOptions *streamOptions  `json:"stream_options,omitempty"`
 }

--- a/internal/llm/openrouter/openrouter_test.go
+++ b/internal/llm/openrouter/openrouter_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Temikus/denkeeper/internal/llm"
 )
@@ -761,5 +764,209 @@ func TestChatCompletion_ReasoningContentInHistory(t *testing.T) {
 	assistMsg := capturedReq.Messages[1]
 	if assistMsg.ReasoningContent != "I should greet the user." {
 		t.Errorf("reasoning_content = %q, want %q", assistMsg.ReasoningContent, "I should greet the user.")
+	}
+}
+
+// ─── Provider routing & sticky caching ──────────────────────────────────────
+
+func okResponseWithProvider(provider string) apiResponse {
+	return apiResponse{
+		ID:       "chatcmpl-1",
+		Model:    "test-model",
+		Provider: provider,
+		Choices: []apiChoice{{
+			Message:      apiMessage{Role: "assistant", Content: "ok"},
+			FinishReason: "stop",
+		}},
+		Usage: apiUsage{PromptTokens: 10, CompletionTokens: 1, TotalTokens: 11},
+	}
+}
+
+func simpleReq() llm.ChatRequest {
+	return llm.ChatRequest{Model: "test-model", Messages: []llm.Message{{Role: "user", Content: "Hi"}}}
+}
+
+func TestProviderRouting_ExplicitOrderOmittedWhenUnset(t *testing.T) {
+	c := New("k")
+	if p := c.buildProviderParam(); p != nil {
+		t.Fatalf("expected nil provider param when nothing configured, got %+v", p)
+	}
+}
+
+func TestProviderRouting_ExplicitOrderWinsOverSticky(t *testing.T) {
+	c := New("k")
+	c.SetProviderRouting([]string{"moonshotai"}, nil, time.Hour)
+	c.recordProvider("Some Other Provider") // sticky present...
+	p := c.buildProviderParam()
+	if p == nil || len(p.Order) != 1 || p.Order[0] != "moonshotai" {
+		t.Fatalf("explicit order should win, got %+v", p)
+	}
+}
+
+func TestStickyRouting_RecordsAndPrefersServedProvider(t *testing.T) {
+	var bodies []apiRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req apiRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		bodies = append(bodies, req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(okResponseWithProvider("Moonshot AI"))
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient("k", srv.URL, srv.Client())
+	c.SetProviderRouting(nil, nil, time.Hour)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("want 2 captured requests, got %d", len(bodies))
+	}
+	if bodies[0].Provider != nil {
+		t.Errorf("call 1 should carry no provider routing, got %+v", bodies[0].Provider)
+	}
+	p := bodies[1].Provider
+	if p == nil || len(p.Order) != 1 || p.Order[0] != "Moonshot AI" {
+		t.Fatalf("call 2 should prefer the served provider, got %+v", p)
+	}
+	if p.AllowFallbacks == nil || !*p.AllowFallbacks {
+		t.Errorf("sticky routing must allow fallbacks, got %+v", p.AllowFallbacks)
+	}
+}
+
+func TestStickyRouting_ExpiresAfterTTL(t *testing.T) {
+	c := New("k")
+	c.SetProviderRouting(nil, nil, time.Hour)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+	c.recordProvider("Moonshot AI")
+
+	c.now = func() time.Time { return base.Add(59 * time.Minute) }
+	if p := c.buildProviderParam(); p == nil || p.Order[0] != "Moonshot AI" {
+		t.Fatalf("within TTL should still prefer, got %+v", p)
+	}
+	c.now = func() time.Time { return base.Add(61 * time.Minute) }
+	if p := c.buildProviderParam(); p != nil {
+		t.Fatalf("past TTL should drop the preference, got %+v", p)
+	}
+}
+
+func TestStickyRouting_ResetsOnError(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 2 { // second call fails
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(okResponseWithProvider("Moonshot AI"))
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient("k", srv.URL, srv.Client())
+	c.SetProviderRouting(nil, nil, time.Hour)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	if c.buildProviderParam() == nil {
+		t.Fatal("preference should be set after a success")
+	}
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err == nil {
+		t.Fatal("call 2 should have errored")
+	}
+	if p := c.buildProviderParam(); p != nil {
+		t.Fatalf("error must reset sticky preference, got %+v", p)
+	}
+}
+
+func TestStickyRouting_DisabledWhenTTLZero(t *testing.T) {
+	c := New("k")
+	c.SetProviderRouting(nil, nil, 0)
+	c.recordProvider("Moonshot AI")
+	if p := c.buildProviderParam(); p != nil {
+		t.Fatalf("sticky disabled (ttl=0) should never route, got %+v", p)
+	}
+}
+
+// failingBody yields a partial SSE payload and then a non-EOF read error,
+// simulating a stream that drops mid-flight after a successful HTTP 200.
+type failingBody struct{ r io.Reader }
+
+func (b *failingBody) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+	if errors.Is(err, io.EOF) {
+		return n, errors.New("connection reset mid-stream")
+	}
+	return n, err
+}
+
+func (b *failingBody) Close() error { return nil }
+
+// seqRoundTripper returns a queued response per call (round-robin exhausted to
+// the last entry), so one client can see a success then a mid-stream failure.
+type seqRoundTripper struct {
+	resps []func() *http.Response
+	calls int
+}
+
+func (rt *seqRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	i := rt.calls
+	if i >= len(rt.resps) {
+		i = len(rt.resps) - 1
+	}
+	rt.calls++
+	return rt.resps[i](), nil
+}
+
+func TestStickyRouting_StreamMidStreamErrorResets(t *testing.T) {
+	okStream := func() *http.Response {
+		body := `data: {"id":"1","model":"m","provider":"Moonshot AI","choices":[{"delta":{"content":"hi"},"finish_reason":"stop"}]}` + "\n\n" +
+			`data: {"id":"1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}` + "\n\n" +
+			"data: [DONE]\n\n"
+		return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(body))}
+	}
+	brokenStream := func() *http.Response {
+		// Valid header, 200 OK, but the body errors partway through.
+		partial := `data: {"id":"2","model":"m","provider":"Moonshot AI","choices":[{"delta":{"content":"par`
+		return &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": {"text/event-stream"}},
+			Body: &failingBody{r: strings.NewReader(partial)}}
+	}
+
+	rt := &seqRoundTripper{resps: []func() *http.Response{okStream, brokenStream}}
+	c := NewWithHTTPClient("k", "http://example.invalid", &http.Client{Transport: rt})
+	c.SetProviderRouting(nil, nil, time.Hour)
+
+	// Call 1 succeeds and records the served provider.
+	if _, err := c.ChatCompletion(context.Background(), llm.ChatRequest{
+		Model: "m", Messages: []llm.Message{{Role: "user", Content: "hi"}},
+		OnStream: func(_ llm.StreamChunk) {},
+	}); err != nil {
+		t.Fatalf("call 1 (stream) should succeed: %v", err)
+	}
+	if c.buildProviderParam() == nil {
+		t.Fatal("preference should be set after a successful stream")
+	}
+
+	// Call 2 fails mid-stream (after HTTP 200) — the preference must reset.
+	if _, err := c.ChatCompletion(context.Background(), llm.ChatRequest{
+		Model: "m", Messages: []llm.Message{{Role: "user", Content: "hi"}},
+		OnStream: func(_ llm.StreamChunk) {},
+	}); err == nil {
+		t.Fatal("call 2 should error on the mid-stream failure")
+	}
+	if p := c.buildProviderParam(); p != nil {
+		t.Fatalf("mid-stream error must reset sticky preference, got %+v", p)
 	}
 }

--- a/internal/llm/openrouter/openrouter_test.go
+++ b/internal/llm/openrouter/openrouter_test.go
@@ -890,6 +890,69 @@ func TestStickyRouting_ResetsOnError(t *testing.T) {
 	}
 }
 
+// A 4xx client error (bad request) does not implicate the upstream provider's
+// health, so the sticky preference must survive — discarding it would scatter
+// subsequent requests off a perfectly healthy, cache-warm provider.
+func TestStickyRouting_PreservedOnClientError(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 2 { // second call is a client error
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"bad request"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(okResponseWithProvider("Moonshot AI"))
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient("k", srv.URL, srv.Client())
+	c.SetProviderRouting(nil, nil, time.Hour)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err == nil {
+		t.Fatal("call 2 should have errored")
+	}
+	p := c.buildProviderParam()
+	if p == nil || len(p.Order) != 1 || p.Order[0] != "Moonshot AI" {
+		t.Fatalf("4xx client error must preserve sticky preference, got %+v", p)
+	}
+}
+
+// Caller cancellation does not implicate the upstream, so the sticky
+// preference must survive.
+func TestStickyRouting_PreservedOnContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(okResponseWithProvider("Moonshot AI"))
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient("k", srv.URL, srv.Client())
+	c.SetProviderRouting(nil, nil, time.Hour)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	if _, err := c.ChatCompletion(context.Background(), simpleReq()); err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already-dead context — the call fails with context.Canceled
+	if _, err := c.ChatCompletion(ctx, simpleReq()); err == nil {
+		t.Fatal("call 2 should have errored on the cancelled context")
+	}
+	p := c.buildProviderParam()
+	if p == nil || len(p.Order) != 1 || p.Order[0] != "Moonshot AI" {
+		t.Fatalf("cancellation must preserve sticky preference, got %+v", p)
+	}
+}
+
 func TestStickyRouting_DisabledWhenTTLZero(t *testing.T) {
 	c := New("k")
 	c.SetProviderRouting(nil, nil, 0)

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -67,13 +67,18 @@ func (e *LLMError) Retryable() bool {
 	}
 }
 
-// isRetryable returns true if err is worth retrying.
+// IsRetryable returns true if err is worth retrying.
 // Stream idle timeouts are retryable (the provider stalled; a fallback can
 // succeed). Context cancellation/deadline errors are not — the caller's
 // context is dead, so any retry against it fails instantly.
 // LLMErrors are retryable based on their status code; other network/unknown
 // errors are assumed retryable.
-func isRetryable(err error) bool {
+//
+// It doubles as the test for whether an error implicates the upstream
+// provider's health (429/5xx/network) versus the caller or request itself
+// (cancellation, 4xx client errors) — provider-internal state such as
+// sticky-routing preferences should only be discarded for the former.
+func IsRetryable(err error) bool {
 	if errors.Is(err, ErrStreamIdleTimeout) {
 		return true
 	}
@@ -87,8 +92,8 @@ func isRetryable(err error) bool {
 	return true // network error or unknown — assume retryable
 }
 
-// isRateLimit returns true if err is specifically a 429 rate-limit error.
-func isRateLimit(err error) bool {
+// IsRateLimit returns true if err is specifically a 429 rate-limit error.
+func IsRateLimit(err error) bool {
 	var llmErr *LLMError
 	return errors.As(err, &llmErr) && llmErr.StatusCode == 429
 }

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -341,7 +341,7 @@ func (r *Router) completeInternal(ctx context.Context, sessionID string, message
 	// 4. Non-retryable errors skip all fallbacks immediately. A dead caller
 	// context also skips them regardless of the error's shape — any retry
 	// against an expired/cancelled context fails instantly.
-	if ctx.Err() != nil || !isRetryable(err) {
+	if ctx.Err() != nil || !IsRetryable(err) {
 		r.mErrors.Add(ctx, 1, attrs)
 		span.RecordError(err)
 		return nil, fmt.Errorf("chat completion: %w", err)
@@ -483,9 +483,9 @@ func (r *Router) applyErrorFallbacks(ctx context.Context, sessionID string, acti
 func (r *Router) fallbackMatchesError(rule FallbackRule, err error) bool {
 	switch rule.Trigger {
 	case "rate_limit":
-		return isRateLimit(err)
+		return IsRateLimit(err)
 	case "error":
-		return !isRateLimit(err) && isRetryable(err)
+		return !IsRateLimit(err) && IsRetryable(err)
 	}
 	return false
 }
@@ -569,7 +569,7 @@ func doWaitAndRetry(ctx context.Context, maxRetries int, backoff string, fn func
 			}
 		}
 		err = fn()
-		if err == nil || !isRateLimit(err) {
+		if err == nil || !IsRateLimit(err) {
 			return err // success, or a different error type — stop retrying
 		}
 	}

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -973,8 +973,8 @@ func TestIsRetryable_ContextErrors(t *testing.T) {
 		{"plain network error", errors.New("connection refused"), true},
 	}
 	for _, c := range cases {
-		if got := isRetryable(c.err); got != c.want {
-			t.Errorf("%s: isRetryable = %v, want %v", c.name, got, c.want)
+		if got := IsRetryable(c.err); got != c.want {
+			t.Errorf("%s: IsRetryable = %v, want %v", c.name, got, c.want)
 		}
 	}
 }

--- a/web/src/pages/Providers.svelte
+++ b/web/src/pages/Providers.svelte
@@ -102,6 +102,8 @@
       organization: p?.organization || '',
       reasoning_enabled: !!(p?.reasoning?.enabled),
       reasoning_effort: p?.reasoning?.effort || '',
+      provider_sticky: p?.routing?.sticky ?? true,
+      provider_sticky_ttl: p?.routing?.sticky_ttl || '',
       cost_limit_soft: p?.cost_limit_soft ?? '',
       cost_limit_hard: p?.cost_limit_hard ?? '',
       default_rate_per_1k_tokens: p?.default_rate_per_1k_tokens ?? '',
@@ -143,6 +145,18 @@
             effort: providerDraft.reasoning_effort || undefined,
           }
         }
+
+        const oldSticky = p?.routing?.sticky ?? true
+        const oldTtl = p?.routing?.sticky_ttl || ''
+        if (providerDraft.provider_sticky !== oldSticky || providerDraft.provider_sticky_ttl !== oldTtl) {
+          // Preserve any advanced order/fallback settings configured via TOML.
+          patch.routing = {
+            sticky: providerDraft.provider_sticky,
+            sticky_ttl: providerDraft.provider_sticky_ttl || undefined,
+            order: p?.routing?.order,
+            allow_fallbacks: p?.routing?.allow_fallbacks,
+          }
+        }
       }
 
       // Cost fields.
@@ -176,6 +190,7 @@
           if (patch.base_url !== undefined) p.base_url = patch.base_url
           if (patch.organization !== undefined) p.organization = patch.organization
           if (patch.reasoning) p.reasoning = patch.reasoning
+          if (patch.routing) p.routing = patch.routing
           if (patch.cost_limit_soft !== undefined) p.cost_limit_soft = patch.cost_limit_soft
           if (patch.cost_limit_hard !== undefined) p.cost_limit_hard = patch.cost_limit_hard
           if (patch.default_rate_per_1k_tokens !== undefined) p.default_rate_per_1k_tokens = patch.default_rate_per_1k_tokens
@@ -416,6 +431,16 @@
                 {/if}
               </span>
             </div>
+            <div class="field-row">
+              <span class="field-label">Caching</span>
+              <span class="field-value">
+                {#if (p.routing?.sticky ?? true)}
+                  Sticky{#if p.routing?.sticky_ttl} · {p.routing.sticky_ttl}{/if}
+                {:else}
+                  Off
+                {/if}
+              </span>
+            </div>
           {/if}
         </div>
         {#if p.cost_limit_soft != null || p.cost_limit_hard != null || p.default_rate_per_1k_tokens != null || (p.model_prices && Object.keys(p.model_prices).length > 0)}
@@ -521,6 +546,22 @@
                       <option value="low">Low</option>
                       <option value="minimal">Minimal</option>
                     </select>
+                  </div>
+                {/if}
+              </div>
+            </div>
+            <div class="form-row">
+              <label class="form-label">Provider caching</label>
+              <div class="reasoning-controls">
+                <label class="toggle-label">
+                  <input type="checkbox" bind:checked={providerDraft.provider_sticky} />
+                  Sticky provider routing
+                </label>
+                <p class="hint">Prefer the upstream provider that last served a response, so its automatic prompt cache keeps hitting. Resets on any error.</p>
+                {#if providerDraft.provider_sticky}
+                  <div class="reasoning-effort">
+                    <label class="form-label-sm" for="sticky-ttl-{p.name}">Window</label>
+                    <input id="sticky-ttl-{p.name}" type="text" class="input input-sm" bind:value={providerDraft.provider_sticky_ttl} placeholder="1h" />
                   </div>
                 {/if}
               </div>
@@ -734,6 +775,9 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+  }
+  .reasoning-controls .hint {
+    margin: 0;
   }
   .toggle-label {
     display: flex;

--- a/web/src/pages/Providers.svelte
+++ b/web/src/pages/Providers.svelte
@@ -557,7 +557,7 @@
                   <input type="checkbox" bind:checked={providerDraft.provider_sticky} />
                   Sticky provider routing
                 </label>
-                <p class="hint">Prefer the upstream provider that last served a response, so its automatic prompt cache keeps hitting. Resets on any error.</p>
+                <p class="hint">Prefer the upstream provider that last served a response, so its automatic prompt cache keeps hitting. Resets on upstream errors (rate limits, 5xx, network); preserved on cancellation and client errors.</p>
                 {#if providerDraft.provider_sticky}
                   <div class="reasoning-effort">
                     <label class="form-label-sm" for="sticky-ttl-{p.name}">Window</label>

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -68,6 +68,10 @@ All paths default relative to `data_dir`. Override with `DENKEEPER_*` env vars.
 
     [llm.openrouter]
     api_key = ""                     # OpenRouter API key
+    provider_order = []              # explicit upstream provider preference (e.g. ["moonshotai"]); overrides sticky routing
+    provider_allow_fallbacks = true  # allow OpenRouter to fall back outside provider_order
+    provider_sticky = true           # prefer the last-served provider so upstream prompt caching keeps hitting
+    provider_sticky_ttl = "1h"       # how long to prefer the last-served provider (Go duration)
 
     [llm.openrouter.reasoning]
     enabled = false                  # activate reasoning mode


### PR DESCRIPTION
## Summary

Without sticky routing, OpenRouter load-balances requests across upstream providers, so the upstream's automatic prompt cache rarely hits — telemetry showed **0 cached tokens out of 12.7M prompt tokens** over 5 days. After a successful response, the served provider is now remembered and preferred (with fallbacks for resilience) for a configurable TTL (default 1h), so the same upstream node keeps serving subsequent requests and its cache engages.

**Key finding from live probe:** `cache_control` breakpoints are not needed — Moonshot AI caches automatically by prefix. The real fix is routing stability. Live verification:
- Unpinned (load-balanced): **0% cache hit rate**  
- Pinned to Moonshot AI: **97% of prompt tokens cached** (`cached=16384/16854`)
- Display name round-trips correctly (`"Moonshot AI"` → `order=["Moonshot AI"]`)
- Bogus/stale provider name + `allow_fallbacks:true` degrades gracefully (no error)

## Changes

- **`internal/llm/openrouter`** — thread-safe sticky state with injectable clock for testing; `buildProviderParam` priority: explicit `order` > active sticky preference > none; `recordProvider`/`resetSticky` hooked into both streaming and non-streaming paths via named-return defers. The pin resets **only on errors that implicate the upstream** (429/5xx/network, including mid-stream drops) — gated on `llm.IsRetryable`. Caller cancellation (`ctx` dead, user `/stop`, idle timeout) and 4xx client errors (e.g. malformed request) leave the warm pin intact, so routine non-provider events don't scatter every session off a healthy, cache-warm upstream.
- **`internal/llm`** — exported `isRetryable`/`isRateLimit` as `IsRetryable`/`IsRateLimit` so the OpenRouter client can share the router's single source of truth for "does this error implicate the upstream?" (no behavior change in the router itself).
- **`internal/llm/oaistream`** — capture `provider` field from stream chunks so stickiness works on the streaming path
- **`internal/config`** — `ProviderOrder`, `ProviderAllowFallbacks`, `ProviderSticky`, `ProviderStickyTTL` on `OpenRouterConfig`; `ResolveStickyTTL()` helper (default 1h); TTL validated at config load; `llms-full.txt` updated for the drift test
- **`cmd/denkeeper/main.go`** — `SetProviderRouting` wired into provider creation (sticky on by default)
- **`internal/api/providers.go`** — `routing` sub-object exposed on GET/PATCH for OpenRouter providers; extracted helpers (`validateOpenRouterUpdate`, `applyOpenRouterUpdate`, `persistOpenRouterReasoning`, `persistOpenRouterRouting`) to stay under gocyclo=15; zero-value keys skipped in TOML persist
- **`web/src/pages/Providers.svelte`** — Provider caching control (sticky toggle + TTL window input) in the OpenRouter edit form; read-only Caching summary row; preserves TOML-only `order`/`allow_fallbacks` on partial patches; uses global `.hint` class

## Reset semantics (when the sticky pin is discarded)

| Event | Resets pin? | Why |
|-------|-------------|-----|
| 429 / 5xx from OpenRouter | ✅ | upstream is throttled/unhealthy — route freshly |
| network error / mid-stream drop | ✅ | connection to upstream failed |
| stream idle timeout | ✅ | upstream stalled |
| caller cancellation (`/stop`, deadline, panic) | ❌ | provider is healthy; caller went away |
| 4xx client error (400/401/402/404/422) | ❌ | request/credentials problem, not provider health |

This composes cleanly with the router's own fallback layer (`internal/llm/router.go`): a 429 fires `resetSticky` before `wait_and_retry` re-invokes the client, so the retry routes unpinned rather than slamming the same throttled upstream.

## Test plan

- [x] 9 openrouter unit tests: `record`/`prefer`/`expire`/`reset-on-5xx`/`disabled` + mid-stream error reset + explicit-order-wins-over-sticky + **preserve-on-4xx** + **preserve-on-context-cancel**
- [x] 3 config tests: `ResolveStickyTTL` default/disabled/custom, bad TTL validation
- [x] 4 integration tests: PATCH round-trip, bad TTL rejection (400), non-OpenRouter rejection (400), TOML persistence
- [x] `just hook` (fmt, vet, lint, lint-ui, test, test-ui) — all green
- [x] `just test-integration` — all green
- [x] UI reviewed by ui-reviewer agent; findings addressed (TTL fabrication in summary row, wrong CSS class)

## Configuration

No TOML changes required — sticky routing is **on by default**. A restart activates it. Optional knobs in `[llm.openrouter]`:

```toml
provider_sticky = true        # default: on
provider_sticky_ttl = "1h"    # default: 1h
provider_order = []           # explicit override (rarely needed)
```

Or via the Providers page in the web UI → OpenRouter → edit → Provider caching.

## Follow-ups (out of scope for this PR)

- **#200** — split `llm.IsRetryable` into `IsRetryable` + `IsUpstreamError` once the retry-gate and "implicates-upstream?" predicates diverge (today they coincide, so the shared function is intentional).
- **Process-global sticky state** — the pin is one process-wide value shared across all sessions/agents, so under concurrency it reflects "whatever served the most recent global success" rather than true per-conversation affinity. Within a single turn's tool-call loop the affinity holds (the real cache win); cross-session it can thrash. Keying sticky state per conversation would fix this but is a larger change not justified yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gTxoThrLJpzSZGywv8jDe

