### PR TITLE
feat(configmcp): surface persistent lifetime cost in get_cost_summary

### DIFF
--- a/internal/configmcp/handlers.go
+++ b/internal/configmcp/handlers.go
@@ -1261,7 +1261,7 @@ func (s *Server) handleSetFallback(ctx context.Context, req *mcp.CallToolRequest
 func (s *Server) registerCostTools() {
 	s.mcpServer.AddTool(&mcp.Tool{
 		Name:        "get_cost_summary",
-		Description: "Return current cost tracking data: global cost, per-session costs, budget limit, and per-tool/per-skill usage stats (call counts, error counts, average duration). Optional 'days' restricts the tool/skill stats to the last N days.",
+		Description: "Return cost tracking data. global_cost/session_costs come from the in-memory tracker — spend since the last restart, and they drive live budget enforcement. lifetime_cost/by_model/by_tool/by_skill come from persistent storage (lifetime, or the last N days when 'days' is set, and are global across all agents). by_model carries per-model cost/token totals; by_tool/by_skill carry call counts, error counts, and average duration.",
 		InputSchema: json.RawMessage(`{"type": "object", "properties": {"days": {"type": "integer", "description": "Restrict per-tool/per-skill stats to the last N days (0 or absent = all time)"}}}`),
 	}, s.handleGetCostSummary)
 }
@@ -1288,6 +1288,8 @@ func (s *Server) handleGetCostSummary(ctx context.Context, req *mcp.CallToolRequ
 			// Cost data is still useful on its own — report the failure inline.
 			data.TelemetryError = err.Error()
 		} else {
+			data.ByModel = summary.ByModel
+			data.LifetimeCost = sumModelCost(summary.ByModel)
 			data.ByTool = summary.ByTool
 			data.BySkill = summary.BySkill
 		}
@@ -1298,6 +1300,15 @@ func (s *Server) handleGetCostSummary(ctx context.Context, req *mcp.CallToolRequ
 		return toolError("marshaling cost summary: " + err.Error()), nil
 	}
 	return toolText(string(out)), nil
+}
+
+// sumModelCost returns the total persistent spend across all per-model entries.
+func sumModelCost(models []agent.ModelCostSummary) float64 {
+	var total float64
+	for i := range models {
+		total += models[i].TotalCost
+	}
+	return total
 }
 
 // --------------------------------------------------------------------------

--- a/internal/configmcp/server.go
+++ b/internal/configmcp/server.go
@@ -156,11 +156,20 @@ type Deps struct {
 
 // CostSummaryData holds the data returned by the get_cost_summary tool.
 type CostSummaryData struct {
+	// GlobalCost and SessionCosts come from the in-memory CostTracker and
+	// reflect spend since the last restart only — they drive live budget
+	// enforcement. For persistent lifetime spend, use LifetimeCost/ByModel.
 	GlobalCost    float64            `json:"global_cost"`
 	MaxPerSession float64            `json:"max_per_session"`
 	SessionCosts  map[string]float64 `json:"session_costs"`
 
-	// ByTool and BySkill are populated from TelemetrySummary when available.
+	// LifetimeCost is the persistent total spend (sum of ByModel costs),
+	// lifetime or last-N-days when the 'days' filter is set. Unlike
+	// GlobalCost it survives restarts.
+	LifetimeCost float64 `json:"lifetime_cost,omitempty"`
+	// ByModel, ByTool and BySkill are populated from TelemetrySummary when
+	// available and reflect persistent storage (global across agents).
+	ByModel []agent.ModelCostSummary  `json:"by_model,omitempty"`
 	ByTool  []agent.ToolUsageSummary  `json:"by_tool,omitempty"`
 	BySkill []agent.SkillUsageSummary `json:"by_skill,omitempty"`
 	// TelemetryError is set when the telemetry lookup failed; cost fields

--- a/internal/configmcp/server_test.go
+++ b/internal/configmcp/server_test.go
@@ -1477,6 +1477,78 @@ func TestGetCostSummary_WithTelemetry(t *testing.T) {
 	}
 }
 
+func TestGetCostSummary_SurfacesLifetimeCost(t *testing.T) {
+	// Regression: the persistent lifetime spend (sum of ByModel costs) must be
+	// surfaced separately from the transient in-memory GlobalCost. The bug was
+	// that the handler fetched ByModel but discarded it, so the agent only saw
+	// the since-restart number.
+	session, _ := newTestServer(t, func(d *configmcp.Deps) {
+		d.CostSummary = func() configmcp.CostSummaryData {
+			return configmcp.CostSummaryData{GlobalCost: 0.49}
+		}
+		d.TelemetrySummary = func(_ context.Context, _ *time.Time) (*agent.TelemetrySummary, error) {
+			return &agent.TelemetrySummary{
+				ByModel: []agent.ModelCostSummary{
+					{Model: "claude-opus", Provider: "anthropic", TotalCost: 4.00},
+					{Model: "claude-haiku", Provider: "anthropic", TotalCost: 1.28},
+				},
+			}, nil
+		}
+	})
+
+	text, isErr := callTool(t, session, "get_cost_summary", map[string]any{})
+	if isErr {
+		t.Fatalf("get_cost_summary error: %s", text)
+	}
+
+	var result configmcp.CostSummaryData
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	if result.LifetimeCost != 5.28 {
+		t.Errorf("LifetimeCost = %v, want 5.28", result.LifetimeCost)
+	}
+	if result.LifetimeCost == result.GlobalCost {
+		t.Errorf("LifetimeCost (%v) must differ from transient GlobalCost (%v)",
+			result.LifetimeCost, result.GlobalCost)
+	}
+	if result.GlobalCost != 0.49 {
+		t.Errorf("GlobalCost = %v, want 0.49 (live budget number preserved)", result.GlobalCost)
+	}
+}
+
+func TestGetCostSummary_IncludesByModel(t *testing.T) {
+	session, _ := newTestServer(t, func(d *configmcp.Deps) {
+		d.CostSummary = func() configmcp.CostSummaryData {
+			return configmcp.CostSummaryData{GlobalCost: 0.1}
+		}
+		d.TelemetrySummary = func(_ context.Context, _ *time.Time) (*agent.TelemetrySummary, error) {
+			return &agent.TelemetrySummary{
+				ByModel: []agent.ModelCostSummary{
+					{Model: "gpt-4o", Provider: "openai", TotalCost: 2.5, MessageCount: 11, TotalPrompt: 100},
+				},
+			}, nil
+		}
+	})
+
+	text, isErr := callTool(t, session, "get_cost_summary", map[string]any{})
+	if isErr {
+		t.Fatalf("get_cost_summary error: %s", text)
+	}
+
+	var result configmcp.CostSummaryData
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	if len(result.ByModel) != 1 {
+		t.Fatalf("ByModel len = %d, want 1", len(result.ByModel))
+	}
+	got := result.ByModel[0]
+	if got.Model != "gpt-4o" || got.Provider != "openai" || got.TotalCost != 2.5 || got.MessageCount != 11 {
+		t.Errorf("ByModel[0] = %+v, want gpt-4o/openai/2.5/11", got)
+	}
+}
+
 func TestGetCostSummary_DaysFilter(t *testing.T) {
 	var gotSince *time.Time
 	session, _ := newTestServer(t, func(d *configmcp.Deps) {
@@ -1528,6 +1600,12 @@ func TestGetCostSummary_TelemetryErrorIsNonFatal(t *testing.T) {
 	if result.TelemetryError == "" {
 		t.Error("TelemetryError empty, want the lookup error")
 	}
+	if result.LifetimeCost != 0 {
+		t.Errorf("LifetimeCost = %v, want 0 on telemetry failure", result.LifetimeCost)
+	}
+	if result.ByModel != nil {
+		t.Errorf("ByModel = %+v, want nil on telemetry failure", result.ByModel)
+	}
 }
 
 func TestGetCostSummary_NoTelemetryDep(t *testing.T) {
@@ -1543,6 +1621,9 @@ func TestGetCostSummary_NoTelemetryDep(t *testing.T) {
 	}
 	if strings.Contains(text, "by_tool") || strings.Contains(text, "telemetry_error") {
 		t.Errorf("expected no telemetry keys without TelemetrySummary dep, got: %s", text)
+	}
+	if strings.Contains(text, "lifetime_cost") || strings.Contains(text, "by_model") {
+		t.Errorf("expected lifetime_cost/by_model omitted without TelemetrySummary dep, got: %s", text)
 	}
 }
 


### PR DESCRIPTION
## The bug

`handleGetCostSummary` already calls `TelemetrySummary` and gets the persistent per-model breakdown (`summary.ByModel`) back — but it copied only `ByTool`/`BySkill` and **discarded `ByModel`**. The headline `global_cost`/`session_costs` come from the in-memory `CostTracker`, which resets on restart. The reported symptom: the agent saw `global_cost = $0.49` (since-restart) while the persistent store held **$5.28** of real spend over the same window. The lifetime number was already fetched on every call and thrown away.

## The fix

Surface the data the handler already has in hand:

- `CostSummaryData` gains `lifetime_cost` (sum of `summary.ByModel[i].TotalCost`) and `by_model` (the full per-model breakdown), both `omitempty`.
- The telemetry success branch now sets `data.ByModel` and computes `data.LifetimeCost` via a small `sumModelCost` helper.
- Updated the tool description so the agent knows `global_cost`/`session_costs` are since-restart (and drive live budget enforcement) while `lifetime_cost`/`by_model`/`by_tool`/`by_skill` are persistent (lifetime, or last-N-days when `days` is set, global across agents).

## Why not just overload `global_cost`?

`global_cost` is the live budget number that drives cost-limit enforcement against the in-memory tracker. Making it report the persistent total would break that semantics. Instead `lifetime_cost` is an explicit, separate field — both numbers are now available and clearly labelled.

No wiring change in `main.go` — `TelemetrySummary` was already injected. `by_tool`/`by_skill` were already wired and are untouched. No new Config MCP tool added.

## Tests

- `TestGetCostSummary_SurfacesLifetimeCost` — regression test: `ByModel` summing to 5.28 + transient `GlobalCost` 0.49 → `LifetimeCost == 5.28`, distinct from `GlobalCost`.
- `TestGetCostSummary_IncludesByModel` — `by_model` round-trips with fields intact.
- Extended `TestGetCostSummary_NoTelemetryDep` — `lifetime_cost`/`by_model` keys absent (omitempty) when no telemetry dep.
- Extended `TestGetCostSummary_TelemetryErrorIsNonFatal` — `LifetimeCost == 0`, `ByModel` nil, `GlobalCost` survives.

`just hook` green (fmt-check, vet, lint, lint-ui, test, test-ui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)