### PR TITLE
feat(tool,audit): warn when OAuth MCP tool stuck in pending_auth

### DIFF
--- a/internal/tool/health_test.go
+++ b/internal/tool/health_test.go
@@ -40,6 +40,99 @@ func (c *captureEmitter) byAction(action string) []audit.Event {
 	return out
 }
 
+// fakeOAuthHandler is a minimal oauthHandler whose token state can be toggled
+// to simulate authorization completing (or breaking) between health ticks.
+type fakeOAuthHandler struct {
+	hasToken atomic.Bool
+}
+
+func (f *fakeOAuthHandler) ToolName() string                                { return "fake-oauth" }
+func (f *fakeOAuthHandler) HasToken() bool                                  { return f.hasToken.Load() }
+func (f *fakeOAuthHandler) ClearToken() error                               { return nil }
+func (f *fakeOAuthHandler) Close()                                          {}
+func (f *fakeOAuthHandler) InitiateOAuth(_ context.Context, _ string) error { return nil }
+
+func TestCheckServers_OAuthPending_WarnsOnceAcrossTicks(t *testing.T) {
+	m := NewManager(testLogger())
+	auditor := &captureEmitter{}
+	m.Auditor = auditor
+	m.servers["fastmail"] = &serverConn{
+		name:      "fastmail",
+		transport: "sse",
+		cfg:       config.ToolConfig{Auth: "oauth"},
+		// session nil + no oauthHandler => pending_auth (tokenless).
+	}
+
+	// Three ticks: the debounce should hold at exactly one audit event.
+	for i := 0; i < 3; i++ {
+		m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+	}
+
+	events := auditor.byAction("oauth_pending")
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 oauth_pending audit across ticks, got %d", len(events))
+	}
+	if events[0].Category != audit.CategoryMCP || events[0].Source != "health_checker" {
+		t.Errorf("event metadata = {category:%q source:%q}, want {mcp health_checker}",
+			events[0].Category, events[0].Source)
+	}
+	if !strings.Contains(events[0].Detail, `"server":"fastmail"`) {
+		t.Errorf("Detail = %q, want server fastmail", events[0].Detail)
+	}
+}
+
+func TestCheckServers_OAuthPending_ResetsAndRewarnsAfterTokenCycles(t *testing.T) {
+	m := NewManager(testLogger())
+	auditor := &captureEmitter{}
+	m.Auditor = auditor
+	handler := &fakeOAuthHandler{}
+	m.servers["fastmail"] = &serverConn{
+		name:         "fastmail",
+		transport:    "sse",
+		cfg:          config.ToolConfig{Auth: "oauth"},
+		oauthHandler: handler,
+	}
+
+	// Tokenless: first tick warns, second tick is debounced.
+	m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+	m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+	if got := len(auditor.byAction("oauth_pending")); got != 1 {
+		t.Fatalf("after initial pending ticks, oauth_pending count = %d, want 1", got)
+	}
+
+	// Token appears (authorization completed): tick clears the warned flag.
+	handler.hasToken.Store(true)
+	m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+	if got := len(auditor.byAction("oauth_pending")); got != 1 {
+		t.Fatalf("after token appears, oauth_pending count = %d, want 1 (no new warn)", got)
+	}
+
+	// Token disappears again (tool broke): the tool re-warns exactly once.
+	handler.hasToken.Store(false)
+	m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+	m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+	if got := len(auditor.byAction("oauth_pending")); got != 2 {
+		t.Fatalf("after token disappears, oauth_pending count = %d, want 2 (re-warned once)", got)
+	}
+}
+
+func TestCheckServers_NonOAuthSessionNil_NoWarn(t *testing.T) {
+	m := NewManager(testLogger())
+	auditor := &captureEmitter{}
+	m.Auditor = auditor
+	// In-process server: session nil, transport "", not an OAuth tool.
+	m.servers["in-process"] = &serverConn{
+		name: "in-process",
+		cfg:  config.ToolConfig{},
+	}
+
+	m.checkServers(context.Background(), 3, 5*time.Minute, 3)
+
+	if got := len(auditor.byAction("oauth_pending")); got != 0 {
+		t.Errorf("non-OAuth session==nil server emitted %d oauth_pending events, want 0", got)
+	}
+}
+
 func TestServerStatus_Connected(t *testing.T) {
 	m := NewManager(testLogger())
 	m.servers["test"] = &serverConn{

--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -51,6 +51,7 @@ type serverConn struct {
 	connectedAt   time.Time // when the server was last successfully connected
 	restartCount  int       // consecutive restart attempts
 	probeFailures int       // consecutive health-probe failures (reset on healthy probe)
+	oauthWarned   bool      // true once a pending_auth OAuth warning has been emitted (reset when a token/session appears)
 	lastError     string    // most recent failure message
 	disabled      bool      // true when restarts exhausted
 	connecting    bool      // true while background init retries are in progress
@@ -1180,8 +1181,19 @@ func (m *Manager) checkServers(ctx context.Context, maxAttempts int, cooldown ti
 		m.mu.RLock()
 		sc, ok := m.servers[name]
 		m.mu.RUnlock()
-		if !ok || sc.disabled || sc.userDisabled || sc.configError != "" || sc.transport == "" || sc.session == nil {
-			// Skip in-process, disabled, config-error, and OAuth-pending servers.
+		if !ok || sc.disabled || sc.userDisabled || sc.configError != "" {
+			// Skip disabled and config-error servers.
+			continue
+		}
+		// OAuth tools that never completed authorization sit with session==nil
+		// and are invisible to the probe path below (we deliberately do not
+		// ListTools-probe a tokenless server). Surface them in the audit log
+		// once, debounced, so a dead OAuth tool doesn't fail silently for days.
+		if sc.cfg.Auth == "oauth" {
+			m.auditOAuthPending(ctx, sc, name)
+		}
+		if sc.transport == "" || sc.session == nil {
+			// Skip in-process and not-yet-connected (incl. OAuth-pending) servers.
 			continue
 		}
 
@@ -1231,6 +1243,41 @@ func (m *Manager) auditProbeFailure(ctx context.Context, sc *serverConn, name st
 			Action:   "health_fail",
 			Summary:  fmt.Sprintf("MCP server %s health check failed", name),
 			Detail:   fmt.Sprintf(`{"server":"%s","consecutive_failures":%d}`, name, probeFailures),
+			Status:   audit.StatusError,
+			Source:   "health_checker",
+		})
+	}
+}
+
+// auditOAuthPending emits a single audit warning when an OAuth tool is stuck in
+// pending_auth (no session and no token). Emission is debounced via a
+// per-serverConn oauthWarned flag so a tool that never authorizes doesn't warn
+// on every 30s tick. The flag resets once a token/session appears so a tool
+// that later breaks again will re-warn.
+func (m *Manager) auditOAuthPending(ctx context.Context, sc *serverConn, name string) {
+	hasToken := sc.oauthHandler != nil && sc.oauthHandler.HasToken()
+
+	m.mu.Lock()
+	if sc.session != nil || hasToken {
+		// Authorization completed — clear the flag so a future breakage re-warns.
+		sc.oauthWarned = false
+		m.mu.Unlock()
+		return
+	}
+	if sc.oauthWarned {
+		m.mu.Unlock()
+		return
+	}
+	sc.oauthWarned = true
+	m.mu.Unlock()
+
+	m.logger.Warn("OAuth MCP tool stuck in pending_auth", "server", name)
+	if m.Auditor != nil {
+		m.Auditor.Emit(ctx, audit.Event{
+			Category: audit.CategoryMCP,
+			Action:   "oauth_pending",
+			Summary:  fmt.Sprintf("OAuth MCP tool %s is stuck awaiting authorization", name),
+			Detail:   fmt.Sprintf(`{"server":"%s","needs_reauth":true}`, name),
 			Status:   audit.StatusError,
 			Source:   "health_checker",
 		})


### PR DESCRIPTION
## Problem: silent dead OAuth tools

An MCP tool configured with `auth = "oauth"` that never completes authorization sits in `pending_auth` (`session == nil`, `has_token = false`, `needs_reauth = true`). That state was **invisible to every proactive signal**: the health checker deliberately skips servers with `session == nil`, so a dead OAuth tool could stay broken for days with zero notification. This actually happened — a `fastmail` OAuth tool sat dead for days before anyone noticed.

## Fix: debounced audit warning

`checkServers` now emits a single `audit.CategoryMCP` warning (action `oauth_pending`, source `health_checker`, status `error`) the first time it observes an OAuth tool stuck without a session/token, so it surfaces in the Audit Log instead of failing silently.

- Debounced via a per-`serverConn` `oauthWarned` bool — warns once, not every 30s tick — mirroring the existing `health_fail` / `probeFailures` debounce pattern in the same file.
- `oauthWarned` resets when a token/session appears, so a tool that breaks again will re-warn.
- Guarded on `m.Auditor \!= nil`, exactly like the existing `health_fail` emission.
- The (correct) skip-probe decision is preserved: we still do **not** `ListTools`-probe a tokenless server. The skip condition was split so disabled/config-error servers are filtered first, the OAuth-pending check runs, then in-process/not-yet-connected servers `continue` as before.

## Why not an onboarding step

Onboarding is the wrong surface: the onboarding card hides once its checklist completes, so it cannot represent a tool that *regresses* into a broken state later. A recurring health signal belongs in the Audit Log, which is exactly where operators already look for `health_fail`.

## Test coverage

- `TestCheckServers_OAuthPending_WarnsOnceAcrossTicks` — three ticks against a `pending_auth` OAuth server produce exactly one audit event (debounce holds); asserts category/source/detail.
- `TestCheckServers_OAuthPending_ResetsAndRewarnsAfterTokenCycles` — token appears (warned flag clears, no new warn) then disappears (re-warns exactly once), via a toggleable fake `oauthHandler`.
- `TestCheckServers_NonOAuthSessionNil_NoWarn` — an in-process (`session == nil`, non-OAuth) server emits nothing.

`just hook` is fully green (fmt-check, vet, lint, lint-ui, test, test-ui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)