### PR TITLE
feat(telemetry,tool,agent): split tool-call rejections from execution failures

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -1393,6 +1394,7 @@ func (e *Engine) executeToolCallDeduped(ctx context.Context, tc llm.ToolCall, ro
 			ToolName: tc.Function.Name,
 			Round:    round,
 			Success:  false,
+			Outcome:  "denied",
 			ErrorMsg: "denied (repeat)",
 		}
 		if e.tools != nil {
@@ -1416,6 +1418,7 @@ func (e *Engine) executeToolCall(ctx context.Context, tc llm.ToolCall, round int
 		ToolName: tc.Function.Name,
 		Round:    round,
 		Success:  true,
+		Outcome:  "ok",
 	}
 	if e.tools != nil {
 		record.ServerName = e.tools.ToolServer(tc.Function.Name)
@@ -1426,6 +1429,7 @@ func (e *Engine) executeToolCall(ctx context.Context, tc llm.ToolCall, round int
 	if supervised {
 		if outcome := e.resolveSupervisedApproval(ctx, tc, round, convID, onEvent); outcome.denied {
 			record.Success = false
+			record.Outcome = "denied"
 			record.ErrorMsg = "denied"
 			return outcome.denyText, record
 		}
@@ -1454,6 +1458,14 @@ func (e *Engine) executeToolCall(ctx context.Context, tc llm.ToolCall, round int
 		result = fmt.Sprintf("Tool error: %v", execErr)
 		record.Success = false
 		record.ErrorMsg = execErr.Error()
+		// Classify: a healthy tool that returned an error result (bad args) is a
+		// "rejected" outcome; a transport/exec failure is "failed".
+		var re *tool.RejectionError
+		if errors.As(execErr, &re) {
+			record.Outcome = "rejected"
+		} else {
+			record.Outcome = "failed"
+		}
 	} else {
 		e.logger.Info("tool execution complete", "tool", tc.Function.Name, "round", round,
 			"duration_ms", toolDur.Milliseconds(), "result_len", len(result))

--- a/internal/agent/engine_tool_outcome_test.go
+++ b/internal/agent/engine_tool_outcome_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/llm"
+	"github.com/Temikus/denkeeper/internal/security"
+	"github.com/Temikus/denkeeper/internal/tool"
+)
+
+type outcomeToolArgs struct {
+	Value string `json:"value"`
+}
+
+func okOutcomeTool(_ context.Context, _ *mcp.CallToolRequest, _ outcomeToolArgs) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: "did the thing"}},
+	}, nil, nil
+}
+
+func rejectOutcomeTool(_ context.Context, _ *mcp.CallToolRequest, _ outcomeToolArgs) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{Text: "invalid arguments"}},
+	}, nil, nil
+}
+
+// newOutcomeTestEngine builds an autonomous engine whose tool manager exposes
+// an "ok_tool" (succeeds) and a "reject_tool" (returns IsError) backed by a
+// real in-process MCP server over loopback HTTP.
+func newOutcomeTestEngine(t *testing.T) *Engine {
+	t.Helper()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "outcome-server", Version: "v1"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "ok_tool", Description: "ok"}, okOutcomeTool)
+	mcp.AddTool(server, &mcp.Tool{Name: "reject_tool", Description: "rejects"}, rejectOutcomeTool)
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	toolMgr := tool.NewManager(testLogger(), config.MCPConfig{RequestTimeoutSecs: 10})
+	if err := toolMgr.RegisterServer(context.Background(), "outcome-tool", config.ToolConfig{
+		Transport: "sse", URL: ts.URL, AllowLoopback: true,
+	}); err != nil {
+		t.Fatalf("RegisterServer: %v", err)
+	}
+	t.Cleanup(func() { _ = toolMgr.Close() })
+
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{Hard: 10.0}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(&mockProvider{response: &llm.ChatResponse{}})
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+	return NewEngine("default", router, store, nil, permissions, nil, "test", nil, toolMgr, nil, testLogger())
+}
+
+func TestExecuteToolCall_OutcomeOk(t *testing.T) {
+	e := newOutcomeTestEngine(t)
+	_, record := e.executeToolCall(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "ok_tool", Arguments: `{"value":"x"}`},
+	}, 1, "conv:1", false, nil)
+
+	if !record.Success {
+		t.Errorf("Success = false, want true")
+	}
+	if record.Outcome != "ok" {
+		t.Errorf("Outcome = %q, want ok", record.Outcome)
+	}
+}
+
+func TestExecuteToolCall_OutcomeRejected(t *testing.T) {
+	e := newOutcomeTestEngine(t)
+	_, record := e.executeToolCall(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "reject_tool", Arguments: `{"value":"x"}`},
+	}, 1, "conv:1", false, nil)
+
+	if record.Success {
+		t.Errorf("Success = true, want false")
+	}
+	if record.Outcome != "rejected" {
+		t.Errorf("Outcome = %q, want rejected (healthy tool, bad args)", record.Outcome)
+	}
+}
+
+func TestExecuteToolCall_OutcomeFailed(t *testing.T) {
+	e := newOutcomeTestEngine(t)
+	// Unknown tool => manager returns a plain error (not a RejectionError).
+	_, record := e.executeToolCall(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "no_such_tool", Arguments: `{}`},
+	}, 1, "conv:1", false, nil)
+
+	if record.Success {
+		t.Errorf("Success = true, want false")
+	}
+	if record.Outcome != "failed" {
+		t.Errorf("Outcome = %q, want failed (transport/exec failure)", record.Outcome)
+	}
+}
+
+func TestExecuteToolCallDeduped_OutcomeDenied(t *testing.T) {
+	e := newOutcomeTestEngine(t)
+	tc := llm.ToolCall{Function: llm.FunctionCall{Name: "ok_tool", Arguments: `{"value":"x"}`}}
+	denialKey := tc.Function.Name + "\x00" + tc.Function.Arguments
+	deniedCalls := map[string]string{denialKey: "Tool call was denied by the operator."}
+
+	_, record := e.executeToolCallDeduped(context.Background(), tc, 2, "conv:1", false, nil, deniedCalls)
+	if record.Success {
+		t.Errorf("Success = true, want false")
+	}
+	if record.Outcome != "denied" {
+		t.Errorf("Outcome = %q, want denied", record.Outcome)
+	}
+}

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -42,16 +42,19 @@ type ConversationInfo struct {
 
 // ToolCallRecord represents a persisted tool call linked to an assistant message.
 type ToolCallRecord struct {
-	ID             int64     `db:"id"              json:"id"`
-	MessageID      int64     `db:"message_id"      json:"message_id"`
-	ConversationID string    `db:"conversation_id" json:"conversation_id"`
-	ToolName       string    `db:"tool_name"       json:"tool_name"`
-	ServerName     string    `db:"server_name"     json:"server_name"`
-	Round          int       `db:"round"           json:"round"`
-	DurationMs     int64     `db:"duration_ms"     json:"duration_ms"`
-	Success        bool      `db:"success"         json:"success"`
-	ErrorMsg       string    `db:"error_msg"       json:"error_msg,omitempty"`
-	CreatedAt      time.Time `db:"created_at"      json:"created_at"`
+	ID             int64  `db:"id"              json:"id"`
+	MessageID      int64  `db:"message_id"      json:"message_id"`
+	ConversationID string `db:"conversation_id" json:"conversation_id"`
+	ToolName       string `db:"tool_name"       json:"tool_name"`
+	ServerName     string `db:"server_name"     json:"server_name"`
+	Round          int    `db:"round"           json:"round"`
+	DurationMs     int64  `db:"duration_ms"     json:"duration_ms"`
+	Success        bool   `db:"success"         json:"success"`
+	// Outcome refines Success: "ok", "rejected" (healthy tool, bad args),
+	// "failed" (transport/exec failure), or "denied" (approval denied).
+	Outcome   string    `db:"outcome"    json:"outcome"`
+	ErrorMsg  string    `db:"error_msg"  json:"error_msg,omitempty"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
 }
 
 // SkillUsageRecord represents a skill matched for a user message.
@@ -224,6 +227,16 @@ var statsMigrations = []string{
 	`ALTER TABLE conversation_stats ADD COLUMN agent TEXT NOT NULL DEFAULT ''`,
 }
 
+// toolCallMigrations adds columns to tool_calls. These run after
+// telemetryTablesSchema creates the table. The ALTER is guarded by
+// isDuplicateColumn; the UPDATE's `AND outcome='ok'` predicate makes the
+// legacy backfill idempotent so a second run never clobbers a row that has
+// already been classified (e.g. 'rejected').
+var toolCallMigrations = []string{
+	`ALTER TABLE tool_calls ADD COLUMN outcome TEXT NOT NULL DEFAULT 'ok'`,
+	`UPDATE tool_calls SET outcome='failed' WHERE success=0 AND outcome='ok'`,
+}
+
 const telemetryTablesSchema = `
 CREATE TABLE IF NOT EXISTS tool_calls (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -340,6 +353,11 @@ func initDB(db *sqlx.DB) error {
 		return fmt.Errorf("initializing telemetry schema: %w", err)
 	}
 	for _, m := range statsMigrations {
+		if _, err := db.Exec(m); err != nil && !isDuplicateColumn(err) {
+			return fmt.Errorf("migrating schema: %w", err)
+		}
+	}
+	for _, m := range toolCallMigrations {
 		if _, err := db.Exec(m); err != nil && !isDuplicateColumn(err) {
 			return fmt.Errorf("migrating schema: %w", err)
 		}
@@ -635,8 +653,8 @@ func (s *SQLiteMemoryStore) AddToolCalls(ctx context.Context, convID string, mes
 	defer func() { _ = tx.Rollback() }()
 
 	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO tool_calls (message_id, conversation_id, tool_name, server_name, round, duration_ms, success, error_msg)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+		`INSERT INTO tool_calls (message_id, conversation_id, tool_name, server_name, round, duration_ms, success, outcome, error_msg)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("preparing tool call insert: %w", err)
 	}
@@ -647,7 +665,11 @@ func (s *SQLiteMemoryStore) AddToolCalls(ctx context.Context, convID string, mes
 		if !tc.Success {
 			successInt = 0
 		}
-		if _, err := stmt.ExecContext(ctx, messageID, convID, tc.ToolName, tc.ServerName, tc.Round, tc.DurationMs, successInt, tc.ErrorMsg); err != nil {
+		outcome := tc.Outcome
+		if outcome == "" {
+			outcome = "ok"
+		}
+		if _, err := stmt.ExecContext(ctx, messageID, convID, tc.ToolName, tc.ServerName, tc.Round, tc.DurationMs, successInt, outcome, tc.ErrorMsg); err != nil {
 			return fmt.Errorf("inserting tool call %q: %w", tc.ToolName, err)
 		}
 	}
@@ -777,6 +799,7 @@ type toolCallRow struct {
 	Round          int       `db:"round"`
 	DurationMs     int64     `db:"duration_ms"`
 	Success        int       `db:"success"`
+	Outcome        string    `db:"outcome"`
 	ErrorMsg       string    `db:"error_msg"`
 	CreatedAt      time.Time `db:"created_at"`
 }
@@ -785,7 +808,7 @@ type toolCallRow struct {
 func (s *SQLiteMemoryStore) GetToolCalls(ctx context.Context, convID string) ([]ToolCallRecord, error) {
 	var rows []toolCallRow
 	err := s.db.SelectContext(ctx, &rows,
-		`SELECT id, message_id, conversation_id, tool_name, server_name, round, duration_ms, success, error_msg, created_at
+		`SELECT id, message_id, conversation_id, tool_name, server_name, round, duration_ms, success, outcome, error_msg, created_at
 		 FROM tool_calls WHERE conversation_id = ?
 		 ORDER BY created_at ASC`, convID)
 	if err != nil {
@@ -796,8 +819,8 @@ func (s *SQLiteMemoryStore) GetToolCalls(ctx context.Context, convID string) ([]
 		records[i] = ToolCallRecord{
 			ID: r.ID, MessageID: r.MessageID, ConversationID: r.ConversationID,
 			ToolName: r.ToolName, ServerName: r.ServerName, Round: r.Round,
-			DurationMs: r.DurationMs, Success: r.Success != 0, ErrorMsg: r.ErrorMsg,
-			CreatedAt: r.CreatedAt,
+			DurationMs: r.DurationMs, Success: r.Success != 0, Outcome: r.Outcome,
+			ErrorMsg: r.ErrorMsg, CreatedAt: r.CreatedAt,
 		}
 	}
 	return records, nil
@@ -883,11 +906,17 @@ type ModelCostSummary struct {
 
 // ToolUsageSummary aggregates tool call data per tool.
 type ToolUsageSummary struct {
-	ToolName    string  `db:"tool_name"     json:"tool_name"`
-	ServerName  string  `db:"server_name"   json:"server_name"`
-	CallCount   int     `db:"call_count"    json:"call_count"`
-	ErrorCount  int     `db:"error_count"   json:"error_count"`
-	AvgDuration float64 `db:"avg_duration"  json:"avg_duration_ms"`
+	ToolName   string `db:"tool_name"     json:"tool_name"`
+	ServerName string `db:"server_name"   json:"server_name"`
+	CallCount  int    `db:"call_count"    json:"call_count"`
+	// ErrorCount is the total of non-ok outcomes (rejected + failed + denied),
+	// kept for backward compatibility. RejectionCount and FailureCount split it
+	// into app-level rejections (healthy tool, bad args) vs transport/exec
+	// failures so a "healthy but argued-with" tool isn't reported as broken.
+	ErrorCount     int     `db:"error_count"     json:"error_count"`
+	RejectionCount int     `db:"rejection_count" json:"rejection_count"`
+	FailureCount   int     `db:"failure_count"   json:"failure_count"`
+	AvgDuration    float64 `db:"avg_duration"    json:"avg_duration_ms"`
 }
 
 // SkillUsageSummary aggregates skill usage data per skill.
@@ -936,6 +965,8 @@ func (s *SQLiteMemoryStore) GetTelemetrySummary(ctx context.Context, since, unti
 	// Tool call frequency.
 	toolQuery := `SELECT tool_name, server_name, COUNT(*) AS call_count,
 	              SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count,
+	              SUM(CASE WHEN outcome = 'rejected' THEN 1 ELSE 0 END) AS rejection_count,
+	              SUM(CASE WHEN outcome = 'failed' THEN 1 ELSE 0 END) AS failure_count,
 	              AVG(duration_ms) AS avg_duration
 	              FROM tool_calls WHERE 1=1` + timeFilter + `
 	              GROUP BY tool_name, server_name ORDER BY call_count DESC`

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -910,12 +910,14 @@ type ToolUsageSummary struct {
 	ServerName string `db:"server_name"   json:"server_name"`
 	CallCount  int    `db:"call_count"    json:"call_count"`
 	// ErrorCount is the total of non-ok outcomes (rejected + failed + denied),
-	// kept for backward compatibility. RejectionCount and FailureCount split it
-	// into app-level rejections (healthy tool, bad args) vs transport/exec
-	// failures so a "healthy but argued-with" tool isn't reported as broken.
+	// kept for backward compatibility. RejectionCount, FailureCount, and
+	// DenialCount split it into app-level rejections (healthy tool, bad args),
+	// transport/exec failures, and approval denials, so a "healthy but
+	// argued-with" tool isn't reported as broken.
 	ErrorCount     int     `db:"error_count"     json:"error_count"`
 	RejectionCount int     `db:"rejection_count" json:"rejection_count"`
 	FailureCount   int     `db:"failure_count"   json:"failure_count"`
+	DenialCount    int     `db:"denial_count"    json:"denial_count"`
 	AvgDuration    float64 `db:"avg_duration"    json:"avg_duration_ms"`
 }
 
@@ -967,6 +969,7 @@ func (s *SQLiteMemoryStore) GetTelemetrySummary(ctx context.Context, since, unti
 	              SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) AS error_count,
 	              SUM(CASE WHEN outcome = 'rejected' THEN 1 ELSE 0 END) AS rejection_count,
 	              SUM(CASE WHEN outcome = 'failed' THEN 1 ELSE 0 END) AS failure_count,
+	              SUM(CASE WHEN outcome = 'denied' THEN 1 ELSE 0 END) AS denial_count,
 	              AVG(duration_ms) AS avg_duration
 	              FROM tool_calls WHERE 1=1` + timeFilter + `
 	              GROUP BY tool_name, server_name ORDER BY call_count DESC`

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -589,6 +589,72 @@ func TestAddToolCalls_Empty(t *testing.T) {
 	}
 }
 
+func TestAddToolCalls_OutcomeRoundTrip(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+	_, _ = store.GetOrCreateConversation(ctx, "test", "1")
+	msgID, _ := store.AddMessage(ctx, "test:1", StoredMessage{Role: "assistant", Content: "used tools"})
+
+	calls := []ToolCallRecord{
+		{ToolName: "ok_tool", Round: 1, Success: true, Outcome: "ok"},
+		{ToolName: "rejected_tool", Round: 1, Success: false, Outcome: "rejected", ErrorMsg: "bad args"},
+		{ToolName: "failed_tool", Round: 1, Success: false, Outcome: "failed", ErrorMsg: "server down"},
+		{ToolName: "denied_tool", Round: 1, Success: false, Outcome: "denied", ErrorMsg: "denied"},
+	}
+	if err := store.AddToolCalls(ctx, "test:1", msgID, calls); err != nil {
+		t.Fatalf("AddToolCalls: %v", err)
+	}
+
+	got, err := store.GetToolCalls(ctx, "test:1")
+	if err != nil {
+		t.Fatalf("GetToolCalls: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("expected 4 tool calls, got %d", len(got))
+	}
+	want := map[string]string{
+		"ok_tool":       "ok",
+		"rejected_tool": "rejected",
+		"failed_tool":   "failed",
+		"denied_tool":   "denied",
+	}
+	for _, r := range got {
+		if want[r.ToolName] != r.Outcome {
+			t.Errorf("tool %q outcome = %q, want %q", r.ToolName, r.Outcome, want[r.ToolName])
+		}
+	}
+}
+
+func TestAddToolCalls_EmptyOutcomeDefaultsToOk(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+	_, _ = store.GetOrCreateConversation(ctx, "test", "1")
+	msgID, _ := store.AddMessage(ctx, "test:1", StoredMessage{Role: "assistant", Content: "x"})
+
+	// Outcome left empty (e.g. legacy caller).
+	if err := store.AddToolCalls(ctx, "test:1", msgID, []ToolCallRecord{
+		{ToolName: "legacy_tool", Round: 1, Success: true},
+	}); err != nil {
+		t.Fatalf("AddToolCalls: %v", err)
+	}
+
+	got, err := store.GetToolCalls(ctx, "test:1")
+	if err != nil {
+		t.Fatalf("GetToolCalls: %v", err)
+	}
+	if len(got) != 1 || got[0].Outcome != "ok" {
+		t.Fatalf("empty Outcome should default to 'ok', got %+v", got)
+	}
+}
+
 func TestAddSkillUsages_RoundTrip(t *testing.T) {
 	store, err := NewInMemoryStore()
 	if err != nil {
@@ -1169,6 +1235,100 @@ func TestGetTelemetrySummary(t *testing.T) {
 	}
 	if len(summary.BySkill) != 1 || summary.BySkill[0].SkillName != "greeting" {
 		t.Errorf("by_skill: %+v", summary.BySkill)
+	}
+}
+
+func TestGetTelemetrySummary_SplitsRejectionAndFailure(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	_, _ = store.GetOrCreateConversation(ctx, "test", "1")
+	msgID, _ := store.AddMessage(ctx, "test:1", StoredMessage{Role: "assistant", Content: "hi"})
+
+	// Same tool: 1 ok, 3 rejected (bad args), 1 failed (transport).
+	_ = store.AddToolCalls(ctx, "test:1", msgID, []ToolCallRecord{
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: true, Outcome: "ok"},
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "rejected"},
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "rejected"},
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "rejected"},
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "failed"},
+	})
+
+	summary, err := store.GetTelemetrySummary(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("GetTelemetrySummary: %v", err)
+	}
+	if len(summary.ByTool) != 1 {
+		t.Fatalf("expected 1 tool summary, got %d", len(summary.ByTool))
+	}
+	ts := summary.ByTool[0]
+	if ts.CallCount != 5 {
+		t.Errorf("CallCount = %d, want 5", ts.CallCount)
+	}
+	if ts.RejectionCount != 3 {
+		t.Errorf("RejectionCount = %d, want 3", ts.RejectionCount)
+	}
+	if ts.FailureCount != 1 {
+		t.Errorf("FailureCount = %d, want 1", ts.FailureCount)
+	}
+	// ErrorCount stays the total of non-ok rows (backward compat): rejected+failed = 4.
+	if ts.ErrorCount != 4 {
+		t.Errorf("ErrorCount = %d, want 4 (rejected+failed)", ts.ErrorCount)
+	}
+	if ts.ErrorCount != ts.RejectionCount+ts.FailureCount {
+		t.Errorf("ErrorCount (%d) should equal RejectionCount (%d) + FailureCount (%d)",
+			ts.ErrorCount, ts.RejectionCount, ts.FailureCount)
+	}
+}
+
+func TestToolCallMigration_BackfillsLegacyAndIsIdempotent(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	_, _ = store.GetOrCreateConversation(ctx, "test", "1")
+	msgID, _ := store.AddMessage(ctx, "test:1", StoredMessage{Role: "assistant", Content: "x"})
+
+	// Simulate a legacy failed row (success=0) whose outcome was defaulted to 'ok'
+	// by the ALTER, plus an already-classified 'rejected' row that must be preserved.
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO tool_calls (message_id, conversation_id, tool_name, server_name, round, duration_ms, success, outcome, error_msg)
+		 VALUES (?, ?, 'legacy', '', 1, 0, 0, 'ok', 'old error')`, msgID, "test:1"); err != nil {
+		t.Fatalf("inserting legacy row: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO tool_calls (message_id, conversation_id, tool_name, server_name, round, duration_ms, success, outcome, error_msg)
+		 VALUES (?, ?, 'already', '', 1, 0, 0, 'rejected', 'bad args')`, msgID, "test:1"); err != nil {
+		t.Fatalf("inserting rejected row: %v", err)
+	}
+
+	// Run migrations again (idempotency).
+	for _, m := range toolCallMigrations {
+		if _, err := store.db.Exec(m); err != nil && !isDuplicateColumn(err) {
+			t.Fatalf("re-running migration %q: %v", m, err)
+		}
+	}
+
+	outcomes := map[string]string{}
+	rows, err := store.GetToolCalls(ctx, "test:1")
+	if err != nil {
+		t.Fatalf("GetToolCalls: %v", err)
+	}
+	for _, r := range rows {
+		outcomes[r.ToolName] = r.Outcome
+	}
+	if outcomes["legacy"] != "failed" {
+		t.Errorf("legacy success=0 row should backfill to 'failed', got %q", outcomes["legacy"])
+	}
+	if outcomes["already"] != "rejected" {
+		t.Errorf("already-classified 'rejected' row must be preserved, got %q", outcomes["already"])
 	}
 }
 

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -1249,13 +1249,15 @@ func TestGetTelemetrySummary_SplitsRejectionAndFailure(t *testing.T) {
 	_, _ = store.GetOrCreateConversation(ctx, "test", "1")
 	msgID, _ := store.AddMessage(ctx, "test:1", StoredMessage{Role: "assistant", Content: "hi"})
 
-	// Same tool: 1 ok, 3 rejected (bad args), 1 failed (transport).
+	// Same tool: 1 ok, 3 rejected (bad args), 1 failed (transport), 2 denied (approval).
 	_ = store.AddToolCalls(ctx, "test:1", msgID, []ToolCallRecord{
 		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: true, Outcome: "ok"},
 		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "rejected"},
 		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "rejected"},
 		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "rejected"},
 		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "failed"},
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "denied"},
+		{ToolName: "schedule_update", ServerName: "cfg", Round: 1, Success: false, Outcome: "denied"},
 	})
 
 	summary, err := store.GetTelemetrySummary(ctx, nil, nil)
@@ -1266,8 +1268,8 @@ func TestGetTelemetrySummary_SplitsRejectionAndFailure(t *testing.T) {
 		t.Fatalf("expected 1 tool summary, got %d", len(summary.ByTool))
 	}
 	ts := summary.ByTool[0]
-	if ts.CallCount != 5 {
-		t.Errorf("CallCount = %d, want 5", ts.CallCount)
+	if ts.CallCount != 7 {
+		t.Errorf("CallCount = %d, want 7", ts.CallCount)
 	}
 	if ts.RejectionCount != 3 {
 		t.Errorf("RejectionCount = %d, want 3", ts.RejectionCount)
@@ -1275,13 +1277,16 @@ func TestGetTelemetrySummary_SplitsRejectionAndFailure(t *testing.T) {
 	if ts.FailureCount != 1 {
 		t.Errorf("FailureCount = %d, want 1", ts.FailureCount)
 	}
-	// ErrorCount stays the total of non-ok rows (backward compat): rejected+failed = 4.
-	if ts.ErrorCount != 4 {
-		t.Errorf("ErrorCount = %d, want 4 (rejected+failed)", ts.ErrorCount)
+	if ts.DenialCount != 2 {
+		t.Errorf("DenialCount = %d, want 2", ts.DenialCount)
 	}
-	if ts.ErrorCount != ts.RejectionCount+ts.FailureCount {
-		t.Errorf("ErrorCount (%d) should equal RejectionCount (%d) + FailureCount (%d)",
-			ts.ErrorCount, ts.RejectionCount, ts.FailureCount)
+	// ErrorCount stays the total of non-ok rows (backward compat): rejected+failed+denied = 6.
+	if ts.ErrorCount != 6 {
+		t.Errorf("ErrorCount = %d, want 6 (rejected+failed+denied)", ts.ErrorCount)
+	}
+	if ts.ErrorCount != ts.RejectionCount+ts.FailureCount+ts.DenialCount {
+		t.Errorf("ErrorCount (%d) should equal RejectionCount (%d) + FailureCount (%d) + DenialCount (%d)",
+			ts.ErrorCount, ts.RejectionCount, ts.FailureCount, ts.DenialCount)
 	}
 }
 

--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -31,6 +31,21 @@ var (
 	toolDuration metric.Float64Histogram
 )
 
+// RejectionError indicates a tool ran successfully at the transport level but
+// returned an application-level error result (IsError=true) — typically because
+// the model passed invalid or unusable arguments. It is distinct from genuine
+// execution/transport failures (server unreachable, crashed, timed out), which
+// surface as plain errors. Callers can use errors.As to classify a tool-call
+// telemetry outcome as "rejected" (healthy tool, bad args) vs "failed".
+type RejectionError struct {
+	Tool string // tool/function name that returned the error result
+	Text string // the error text the tool returned
+}
+
+func (e *RejectionError) Error() string {
+	return fmt.Sprintf("tool %q returned error: %s", e.Tool, e.Text)
+}
+
 func init() {
 	toolDuration, _ = toolMeter.Float64Histogram("denkeeper.tool.duration",
 		metric.WithDescription("Tool execution latency in seconds"),
@@ -778,6 +793,8 @@ func (m *Manager) Execute(ctx context.Context, call llm.ToolCall) (string, error
 
 	var arguments map[string]any
 	if call.Function.Arguments != "" {
+		// Arg-parse failure is arguably a model-driven rejection, but we keep it
+		// as a plain "failed" error for now to keep this change tightly scoped.
 		if err := json.Unmarshal([]byte(call.Function.Arguments), &arguments); err != nil {
 			err = fmt.Errorf("parsing tool arguments: %w", err)
 			span.RecordError(err)
@@ -811,7 +828,10 @@ func (m *Manager) Execute(ctx context.Context, call llm.ToolCall) (string, error
 	span.SetAttributes(attribute.Int("tool.result.size_bytes", len(text)))
 
 	if result.IsError {
-		err = fmt.Errorf("tool %q returned error: %s", call.Function.Name, text)
+		// App-level rejection: the tool is healthy but returned an error result
+		// (typically bad/unusable args). Surface as a typed RejectionError so
+		// telemetry can distinguish this from transport/exec failures above.
+		err = &RejectionError{Tool: call.Function.Name, Text: text}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return text, err

--- a/internal/tool/manager_rejection_test.go
+++ b/internal/tool/manager_rejection_test.go
@@ -1,0 +1,102 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/llm"
+)
+
+// rejectingTool is an MCP tool handler that returns an application-level error
+// result (IsError=true) without a transport error — simulating a healthy tool
+// rejecting bad arguments.
+func rejectingTool(_ context.Context, _ *mcp.CallToolRequest, _ sayHiParams) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "invalid arguments: missing required field 'cron'"},
+		},
+	}, nil, nil
+}
+
+// startRejectingServer starts an httptest MCP server whose single "schedule_update"
+// tool always returns IsError=true.
+func startRejectingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "reject-server", Version: "v1.0.0"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "schedule_update", Description: "update a schedule"}, rejectingTool)
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestExecute_IsErrorResultReturnsRejectionError(t *testing.T) {
+	ts := startRejectingServer(t)
+
+	m := NewManager(testLogger(), config.MCPConfig{RequestTimeoutSecs: 10})
+	cfg := config.ToolConfig{Transport: "sse", URL: ts.URL, AllowLoopback: true}
+	if err := m.RegisterServer(context.Background(), "reject-tool", cfg); err != nil {
+		t.Fatalf("RegisterServer failed: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+
+	text, err := m.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "schedule_update", Arguments: `{"name":"x"}`},
+	})
+	if err == nil {
+		t.Fatal("Execute() should return an error for an IsError result")
+	}
+
+	var re *RejectionError
+	if !errors.As(err, &re) {
+		t.Fatalf("error should be a *RejectionError, got %T: %v", err, err)
+	}
+	if re.Tool != "schedule_update" {
+		t.Errorf("RejectionError.Tool = %q, want schedule_update", re.Tool)
+	}
+	if re.Text == "" {
+		t.Error("RejectionError.Text should carry the tool error text")
+	}
+	// The result text is still returned so it can be fed back to the LLM.
+	if text == "" {
+		t.Error("Execute() should still return the tool result text alongside the rejection error")
+	}
+}
+
+func TestExecute_SessionNilIsNotRejectionError(t *testing.T) {
+	m := NewManager(testLogger())
+	sc := &serverConn{
+		name:    "test-server",
+		session: nil, // not connected — a transport/exec failure, not a rejection
+		cfg:     config.ToolConfig{Command: "test"},
+	}
+	m.servers["test-server"] = sc
+	m.toolMap = map[string]*serverConn{"some_tool": sc}
+
+	_, err := m.Execute(context.Background(), llm.ToolCall{
+		Function: llm.FunctionCall{Name: "some_tool"},
+	})
+	if err == nil {
+		t.Fatal("Execute() should error when session is nil")
+	}
+	var re *RejectionError
+	if errors.As(err, &re) {
+		t.Fatalf("session-nil failure must NOT be a *RejectionError, got %v", err)
+	}
+}
+
+func TestRejectionError_ErrorString(t *testing.T) {
+	re := &RejectionError{Tool: "do_thing", Text: "bad arg"}
+	got := re.Error()
+	want := `tool "do_thing" returned error: bad arg`
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

Tool-call telemetry collapsed two very different things into one `error_count`:

1. **Validation/usage rejections** — a healthy tool returned `IsError` because the model passed bad/unusable arguments.
2. **Execution/transport failures** — the MCP server was unreachable, crashed, or timed out.

Because both counted as errors, the agent's self-audit raised a false alarm that `schedule_update` was "93% broken" when in reality the tool was fine and just being argued with.

## Approach

- **`internal/tool/manager.go`**: added an exported `RejectionError` type (`Tool`, `Text`, `Error()`). The `result.IsError` branch in `Manager.Execute` now returns `&RejectionError{...}` instead of an opaque `fmt.Errorf`, still returning the result text and keeping span recording. Session-nil, CallTool, and JSON arg-parse branches stay as plain errors ("failed") — arg-parse is arguably a rejection but kept as failed to keep the change tightly scoped (noted in a code comment).
- **`internal/agent/engine.go`**: `executeToolCall` initializes `record.Outcome = "ok"`; the denied path sets `"denied"`; the error path classifies via `errors.As(execErr, &re)` into `"rejected"` vs `"failed"`. The per-turn dedup auto-deny record sets `"denied"`. The legacy `\!r.Success` toolErrors loop in `persistTelemetry` is unchanged for backward compat.
- **`internal/agent/memory.go`**: added `ToolCallRecord.Outcome`, a `toolCallMigrations` slice, `outcome` plumbing through `AddToolCalls` / `GetToolCalls`, and `RejectionCount` + `FailureCount` on `ToolUsageSummary` (computed in the `by_tool` query) alongside the retained `ErrorCount`.

The MCP `telemetry_summary` tool and REST `/telemetry/summary` endpoint pick up the new fields automatically (the structs serialize through; swagger has no `ToolUsageSummary` ref to regenerate).

## Idempotent migration note

The migration is:

```sql
ALTER TABLE tool_calls ADD COLUMN outcome TEXT NOT NULL DEFAULT 'ok';
UPDATE tool_calls SET outcome='failed' WHERE success=0 AND outcome='ok';
```

The `AND outcome='ok'` predicate is the critical correctness detail: it makes the backfill idempotent. A second migration run will not re-touch — and therefore not clobber — any row that has already been classified as `rejected` (or `denied`). The `ALTER` is guarded by the existing `isDuplicateColumn` check.

## Test coverage

- **tool**: `IsError` result returns a `*RejectionError`; session-nil failure is NOT a `RejectionError`; `Error()` string.
- **engine**: outcome `ok` / `rejected` / `failed` set correctly through `executeToolCall` (real in-process MCP server over loopback); `denied` through the dedup path.
- **memory**: `Outcome` round-trips; empty `Outcome` defaults to `ok`; `GetTelemetrySummary` splits `rejection_count` vs `failure_count` and `error_count` still equals their sum (compat); migration backfills legacy `success=0` rows to `failed` and a second run preserves an existing `rejected` row.

`just hook` is fully green (fmt-check, vet, lint, lint-ui, test, test-ui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)