### PR TITLE
feat(scheduler,configmcp,api,ui): scope schedules to their owning agent

### DIFF
--- a/internal/api/schedules_test.go
+++ b/internal/api/schedules_test.go
@@ -320,3 +320,33 @@ func TestScheduleEndpoints_RequiresScope(t *testing.T) {
 		t.Errorf("expected 403 for missing schedules:write scope, got %d", rec.Code)
 	}
 }
+
+func TestListSchedules_AgentFilter(t *testing.T) {
+	deps := testDeps()
+	deps.ConfigPath = "/dev/null"
+	for _, sc := range []scheduler.Config{
+		{Name: "alice-1", Type: "agent", Schedule: "@daily", Agent: "alice", Enabled: true},
+		{Name: "bob-1", Type: "agent", Schedule: "@daily", Agent: "bob", Enabled: true},
+	} {
+		if err := deps.Scheduler.Register(sc, func(scheduler.Entry) {}); err != nil {
+			t.Fatalf("register %s: %v", sc.Name, err)
+		}
+	}
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/schedules?agent=alice", nil)
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "alice-1") {
+		t.Errorf("filtered list missing alice's schedule: %s", body)
+	}
+	if strings.Contains(body, "bob-1") {
+		t.Errorf("filtered list leaked bob's schedule: %s", body)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -857,14 +857,18 @@ func (s *Server) handleSkillsByAgent(w http.ResponseWriter, r *http.Request) {
 
 // handleSchedules godoc
 // @Summary List all schedules
-// @Description Returns all registered schedule entries with their configuration, last run time, and next run time.
+// @Description Returns registered schedule entries with their configuration, last run time, and next run time. Optionally filter by owning agent via the `agent` query parameter.
 // @Tags schedules
 // @Produce json
+// @Param agent query string false "Filter to schedules owned by this agent"
 // @Security BearerAuth
 // @Success 200 {array} object "Array of schedule entries"
 // @Router /schedules [get]
-func (s *Server) handleSchedules(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleSchedules(w http.ResponseWriter, r *http.Request) {
 	entries := s.deps.Scheduler.Entries()
+	if agent := strings.TrimSpace(r.URL.Query().Get("agent")); agent != "" {
+		entries = s.deps.Scheduler.EntriesByAgent(agent)
+	}
 
 	type scheduleInfo struct {
 		Name        string   `json:"name"`

--- a/internal/configmcp/handlers.go
+++ b/internal/configmcp/handlers.go
@@ -150,7 +150,7 @@ func (s *Server) registerTools() {
 
 	s.mcpServer.AddTool(&mcp.Tool{
 		Name:        "schedule_list",
-		Description: "Return all registered agent schedules.",
+		Description: "Return the schedules owned by you (this agent).",
 		InputSchema: json.RawMessage(`{"type": "object", "properties": {}}`),
 	}, s.handleScheduleList)
 
@@ -916,7 +916,7 @@ func (s *Server) handleScheduleList(_ context.Context, _ *mcp.CallToolRequest) (
 		Enabled     bool   `json:"enabled"`
 	}
 
-	entries := s.deps.Sched.AgentEntries()
+	entries := s.deps.Sched.EntriesByAgent(s.deps.AgentName)
 	summaries := make([]entrySummary, len(entries))
 	for i, e := range entries {
 		summaries[i] = entrySummary{
@@ -996,8 +996,11 @@ func MergeScheduleUpdate(existing scheduler.Entry, input ScheduleUpdateInput) (s
 		tags = input.Tags
 	}
 
+	// An explicitly empty agent means "keep the current owner", not "clear the
+	// owner stamp" — a schedule must always carry a concrete owning agent so it
+	// stays visible in that agent's owner-scoped listing.
 	agentName := existing.Agent
-	if input.Agent != nil {
+	if input.Agent != nil && *input.Agent != "" {
 		agentName = *input.Agent
 	}
 
@@ -1013,6 +1016,19 @@ func MergeScheduleUpdate(existing scheduler.Entry, input ScheduleUpdateInput) (s
 		Tags:        tags,
 		Enabled:     enabled,
 	}, ""
+}
+
+// ownsSchedule reports whether the named schedule exists and is owned by this
+// agent. Returns the entry when owned. When the schedule does not exist or
+// belongs to another agent, ok is false so callers can return an identical
+// "not found" response without leaking the existence of other agents'
+// schedules.
+func (s *Server) ownsSchedule(name string) (scheduler.Entry, bool) {
+	e, ok := s.deps.Sched.GetEntry(name)
+	if !ok || e.Agent != s.deps.AgentName {
+		return scheduler.Entry{}, false
+	}
+	return e, true
 }
 
 // resolveScheduleHandler returns the message handler for the given agent name.
@@ -1060,7 +1076,7 @@ func (s *Server) handleScheduleUpdate(ctx context.Context, req *mcp.CallToolRequ
 		return toolError("name is required"), nil
 	}
 
-	existing, ok := s.deps.Sched.GetEntry(input.Name)
+	existing, ok := s.ownsSchedule(input.Name)
 	if !ok {
 		return toolError(fmt.Sprintf("schedule %q not found", input.Name)), nil
 	}
@@ -1178,7 +1194,7 @@ func (s *Server) handleScheduleDelete(ctx context.Context, req *mcp.CallToolRequ
 		return toolError("name is required"), nil
 	}
 
-	if _, ok := s.deps.Sched.GetEntry(input.Name); !ok {
+	if _, ok := s.ownsSchedule(input.Name); !ok {
 		return toolError(fmt.Sprintf("schedule %q not found", input.Name)), nil
 	}
 

--- a/internal/configmcp/server_test.go
+++ b/internal/configmcp/server_test.go
@@ -438,6 +438,89 @@ func TestScheduleList_AfterAdd(t *testing.T) {
 	}
 }
 
+// registerForeignSchedule registers an agent-type schedule owned by another
+// agent directly on the shared scheduler, bypassing the per-agent tools.
+func registerForeignSchedule(t *testing.T, deps *configmcp.Deps, name, owner string) {
+	t.Helper()
+	err := deps.Sched.Register(scheduler.Config{
+		Name:     name,
+		Type:     string(scheduler.ScheduleTypeAgent),
+		Agent:    owner,
+		Schedule: "@daily",
+		Enabled:  true,
+	}, func(scheduler.Entry) {})
+	if err != nil {
+		t.Fatalf("registering foreign schedule: %v", err)
+	}
+}
+
+func TestScheduleList_ExcludesOtherAgents(t *testing.T) {
+	session, deps := newTestServer(t, nil)
+
+	registerForeignSchedule(t, deps, "other-sched", "other-agent")
+
+	_, isErr := callTool(t, session, "schedule_add", map[string]any{
+		"name":     "mine",
+		"schedule": "@daily",
+		"channel":  "telegram:99",
+	})
+	if isErr {
+		t.Fatal("unexpected error adding own schedule")
+	}
+
+	listText, isErr := callTool(t, session, "schedule_list", map[string]any{})
+	if isErr {
+		t.Fatalf("schedule_list error: %s", listText)
+	}
+
+	var listed []map[string]any
+	if err := json.Unmarshal([]byte(listText), &listed); err != nil {
+		t.Fatalf("parsing schedule_list: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected only own schedule, got %d: %s", len(listed), listText)
+	}
+	if listed[0]["name"] != "mine" {
+		t.Errorf("expected own schedule, got %v", listed[0]["name"])
+	}
+}
+
+func TestScheduleDelete_OtherAgentNotFound(t *testing.T) {
+	session, deps := newTestServer(t, nil)
+	registerForeignSchedule(t, deps, "other-sched", "other-agent")
+
+	text, isErr := callTool(t, session, "schedule_delete", map[string]any{
+		"name": "other-sched",
+	})
+	if !isErr {
+		t.Fatalf("expected not-found error deleting another agent's schedule, got: %s", text)
+	}
+	if !strings.Contains(text, "not found") {
+		t.Errorf("expected %q to mention not found", text)
+	}
+
+	// The foreign schedule must remain registered.
+	if _, ok := deps.Sched.GetEntry("other-sched"); !ok {
+		t.Error("foreign schedule was deleted across agent boundary")
+	}
+}
+
+func TestScheduleUpdate_OtherAgentNotFound(t *testing.T) {
+	session, deps := newTestServer(t, nil)
+	registerForeignSchedule(t, deps, "other-sched", "other-agent")
+
+	text, isErr := callTool(t, session, "schedule_update", map[string]any{
+		"name":     "other-sched",
+		"schedule": "@hourly",
+	})
+	if !isErr {
+		t.Fatalf("expected not-found error updating another agent's schedule, got: %s", text)
+	}
+	if !strings.Contains(text, "not found") {
+		t.Errorf("expected %q to mention not found", text)
+	}
+}
+
 // --------------------------------------------------------------------------
 // Tests: tool discovery includes new tools
 // --------------------------------------------------------------------------
@@ -1712,9 +1795,11 @@ func TestScheduleUpdate_CrossAgentReassign(t *testing.T) {
 		t.Fatalf("schedule_update error: %s", text)
 	}
 
+	// After handing the schedule off to another agent it is owned by that agent
+	// and must no longer appear in this agent's owner-scoped listing.
 	listText, _ := callTool(t, session, "schedule_list", map[string]any{})
-	if !strings.Contains(listText, "other-agent") {
-		t.Errorf("expected agent to be updated to other-agent in list, got: %s", listText)
+	if strings.Contains(listText, "reassign-me") {
+		t.Errorf("reassigned schedule should leave this agent's list, got: %s", listText)
 	}
 	_ = otherHandlerCalled
 }

--- a/internal/integration/schedule_api_test.go
+++ b/internal/integration/schedule_api_test.go
@@ -73,6 +73,41 @@ func TestScheduleAPI_CreateAndList(t *testing.T) {
 	}
 }
 
+func TestScheduleAPI_ListAgentFilter(t *testing.T) {
+	h := scheduleHarness(t)
+
+	createRec := h.Do(h.AuthedRequest(http.MethodPost, "/api/v1/schedules", map[string]any{
+		"name":     "owned",
+		"schedule": "@daily",
+		"channel":  "telegram:12345",
+	}))
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d; body: %s", createRec.Code, createRec.Body.String())
+	}
+
+	// Filter to the owning agent ("default") — should include the schedule.
+	ownRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/schedules?agent=default", nil))
+	if ownRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d", ownRec.Code)
+	}
+	var owned []map[string]any
+	DecodeJSON(t, ownRec, &owned)
+	if len(owned) != 1 || owned[0]["name"] != "owned" {
+		t.Fatalf("?agent=default = %v, want [owned]", owned)
+	}
+
+	// Filter to another agent — should be empty.
+	otherRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/schedules?agent=someone-else", nil))
+	if otherRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d", otherRec.Code)
+	}
+	var other []map[string]any
+	DecodeJSON(t, otherRec, &other)
+	if len(other) != 0 {
+		t.Errorf("?agent=someone-else = %v, want []", other)
+	}
+}
+
 func TestScheduleAPI_CreateDuplicate_Returns409(t *testing.T) {
 	h := scheduleHarness(t)
 

--- a/internal/integration/schedule_api_test.go
+++ b/internal/integration/schedule_api_test.go
@@ -85,7 +85,28 @@ func TestScheduleAPI_ListAgentFilter(t *testing.T) {
 		t.Fatalf("create status = %d; body: %s", createRec.Code, createRec.Body.String())
 	}
 
-	// Filter to the owning agent ("default") — should include the schedule.
+	// Register a schedule owned by a different agent directly on the scheduler
+	// so the filter has something to exclude (the API would reject an unknown
+	// agent, so we seed it out-of-band).
+	if err := h.Scheduler.Register(scheduler.Config{
+		Name:     "foreign",
+		Type:     string(scheduler.ScheduleTypeAgent),
+		Agent:    "someone-else",
+		Schedule: "@daily",
+		Enabled:  true,
+	}, func(scheduler.Entry) {}); err != nil {
+		t.Fatalf("seeding foreign schedule: %v", err)
+	}
+
+	// Unfiltered: both agents' schedules are present.
+	allRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/schedules", nil))
+	var all []map[string]any
+	DecodeJSON(t, allRec, &all)
+	if len(all) != 2 {
+		t.Fatalf("unfiltered list = %d entries, want 2: %v", len(all), all)
+	}
+
+	// Filter to the owning agent ("default") — includes "owned", excludes "foreign".
 	ownRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/schedules?agent=default", nil))
 	if ownRec.Code != http.StatusOK {
 		t.Fatalf("list status = %d", ownRec.Code)
@@ -93,18 +114,18 @@ func TestScheduleAPI_ListAgentFilter(t *testing.T) {
 	var owned []map[string]any
 	DecodeJSON(t, ownRec, &owned)
 	if len(owned) != 1 || owned[0]["name"] != "owned" {
-		t.Fatalf("?agent=default = %v, want [owned]", owned)
+		t.Fatalf("?agent=default = %v, want exactly [owned] (foreign excluded)", owned)
 	}
 
-	// Filter to another agent — should be empty.
+	// Filter to the other agent — returns only its schedule.
 	otherRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/schedules?agent=someone-else", nil))
 	if otherRec.Code != http.StatusOK {
 		t.Fatalf("list status = %d", otherRec.Code)
 	}
 	var other []map[string]any
 	DecodeJSON(t, otherRec, &other)
-	if len(other) != 0 {
-		t.Errorf("?agent=someone-else = %v, want []", other)
+	if len(other) != 1 || other[0]["name"] != "foreign" {
+		t.Errorf("?agent=someone-else = %v, want exactly [foreign]", other)
 	}
 }
 

--- a/internal/mcpserver/deps.go
+++ b/internal/mcpserver/deps.go
@@ -26,6 +26,7 @@ import (
 // server. Using an interface allows tests to inject failures.
 type ScheduleManager interface {
 	AgentEntries() []scheduler.Entry
+	EntriesByAgent(agent string) []scheduler.Entry
 	RegisterAndStart(cfg scheduler.Config, job scheduler.JobFunc) error
 	GetEntry(name string) (scheduler.Entry, bool)
 	Unregister(name string) error

--- a/internal/mcpserver/tools_schedules.go
+++ b/internal/mcpserver/tools_schedules.go
@@ -12,7 +12,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-type scheduleListInput struct{}
+type scheduleListInput struct {
+	Agent string `json:"agent,omitempty" jsonschema:"Filter to schedules owned by this agent. Omit to list all agents' schedules."`
+}
 
 type scheduleCreateInput struct {
 	Name        string   `json:"name" jsonschema:"Schedule name"`
@@ -45,8 +47,9 @@ type scheduleDeleteInput struct {
 func (s *Server) registerScheduleTools() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "schedule_list",
-		Description: "List all schedules with name, cron expression, skill, agent, status, " +
-			"and last/next run times. Requires 'schedules:read' scope.",
+		Description: "List schedules with name, cron expression, skill, agent, status, " +
+			"and last/next run times. Optionally filter by owning agent via 'agent'. " +
+			"Requires 'schedules:read' scope.",
 	}, s.handleScheduleList)
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
@@ -68,7 +71,7 @@ func (s *Server) registerScheduleTools() {
 	}, s.handleScheduleDelete)
 }
 
-func (s *Server) handleScheduleList(ctx context.Context, _ *mcp.CallToolRequest, _ scheduleListInput) (*mcp.CallToolResult, any, error) {
+func (s *Server) handleScheduleList(ctx context.Context, _ *mcp.CallToolRequest, input scheduleListInput) (*mcp.CallToolResult, any, error) {
 	if err := requireScope(ctx, "schedules:read"); err != nil {
 		return err, nil, nil
 	}
@@ -89,6 +92,9 @@ func (s *Server) handleScheduleList(ctx context.Context, _ *mcp.CallToolRequest,
 	}
 
 	entries := s.deps.Scheduler.AgentEntries()
+	if agent := strings.TrimSpace(input.Agent); agent != "" {
+		entries = s.deps.Scheduler.EntriesByAgent(agent)
+	}
 	result := make([]schedInfo, len(entries))
 	for i, e := range entries {
 		si := schedInfo{

--- a/internal/mcpserver/tools_schedules_test.go
+++ b/internal/mcpserver/tools_schedules_test.go
@@ -287,3 +287,55 @@ func TestHandleScheduleUpdate_RollbackDoubleFail(t *testing.T) {
 		t.Errorf("expected schedule name in error, got: %s", tc.Text)
 	}
 }
+
+func TestHandleScheduleList_AgentFilter(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sched := scheduler.New(logger, time.UTC)
+
+	for _, sc := range []scheduler.Config{
+		{Name: "alice-1", Type: string(scheduler.ScheduleTypeAgent), Schedule: "0 9 * * *", Agent: "alice", Enabled: true},
+		{Name: "alice-2", Type: string(scheduler.ScheduleTypeAgent), Schedule: "0 10 * * *", Agent: "alice", Enabled: true},
+		{Name: "bob-1", Type: string(scheduler.ScheduleTypeAgent), Schedule: "0 11 * * *", Agent: "bob", Enabled: true},
+	} {
+		if err := sched.RegisterAndStart(sc, func(scheduler.Entry) {}); err != nil {
+			t.Fatalf("seed %s: %v", sc.Name, err)
+		}
+	}
+
+	s := &Server{deps: Deps{Scheduler: sched, Logger: logger}}
+	ctx := withScopes(context.Background(), []string{"admin"})
+
+	textOf := func(r *mcp.CallToolResult) string {
+		t.Helper()
+		tc, ok := r.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("expected TextContent, got %T", r.Content[0])
+		}
+		return tc.Text
+	}
+
+	// No filter: all agents' schedules.
+	all, _, err := s.handleScheduleList(ctx, nil, scheduleListInput{})
+	if err != nil || all.IsError {
+		t.Fatalf("list all: err=%v result=%v", err, all)
+	}
+	allText := textOf(all)
+	for _, want := range []string{"alice-1", "alice-2", "bob-1"} {
+		if !strings.Contains(allText, want) {
+			t.Errorf("unfiltered list missing %q: %s", want, allText)
+		}
+	}
+
+	// Filtered to alice.
+	filtered, _, err := s.handleScheduleList(ctx, nil, scheduleListInput{Agent: "alice"})
+	if err != nil || filtered.IsError {
+		t.Fatalf("list alice: err=%v result=%v", err, filtered)
+	}
+	aliceText := textOf(filtered)
+	if !strings.Contains(aliceText, "alice-1") || !strings.Contains(aliceText, "alice-2") {
+		t.Errorf("alice list missing own schedules: %s", aliceText)
+	}
+	if strings.Contains(aliceText, "bob-1") {
+		t.Errorf("alice list leaked bob's schedule: %s", aliceText)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -403,6 +403,21 @@ func (s *Scheduler) AgentEntries() []Entry {
 	return out
 }
 
+// EntriesByAgent returns a snapshot of agent-type entries owned by the given
+// agent. Used to scope schedule listings so an agent sees only its own
+// schedules.
+func (s *Scheduler) EntriesByAgent(agent string) []Entry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []Entry
+	for _, e := range s.entries {
+		if e.Type == ScheduleTypeAgent && e.Agent == agent {
+			out = append(out, e.Entry)
+		}
+	}
+	return out
+}
+
 // EntriesByTag returns entries that carry the given tag.
 func (s *Scheduler) EntriesByTag(tag string) []Entry {
 	s.mu.RLock()

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -275,6 +275,34 @@ func TestScheduler_EntriesByType(t *testing.T) {
 	}
 }
 
+func TestScheduler_EntriesByAgent(t *testing.T) {
+	s := New(discardLogger(), nil)
+
+	_ = s.Register(Config{Name: "sys1", Type: "system", Schedule: "@hourly", Enabled: true, Agent: "alice"}, func(Entry) {})
+	_ = s.Register(Config{Name: "a1", Type: "agent", Schedule: "@daily", Enabled: true, Agent: "alice"}, func(Entry) {})
+	_ = s.Register(Config{Name: "a2", Type: "agent", Schedule: "@weekly", Enabled: true, Agent: "alice"}, func(Entry) {})
+	_ = s.Register(Config{Name: "b1", Type: "agent", Schedule: "@daily", Enabled: true, Agent: "bob"}, func(Entry) {})
+
+	alice := s.EntriesByAgent("alice")
+	if len(alice) != 2 {
+		t.Errorf("EntriesByAgent(alice) = %d, want 2 (system entries excluded)", len(alice))
+	}
+	for _, e := range alice {
+		if e.Agent != "alice" || e.Type != ScheduleTypeAgent {
+			t.Errorf("EntriesByAgent(alice) returned %q (agent=%q type=%q)", e.Name, e.Agent, e.Type)
+		}
+	}
+
+	bob := s.EntriesByAgent("bob")
+	if len(bob) != 1 || bob[0].Name != "b1" {
+		t.Errorf("EntriesByAgent(bob) = %v, want [{Name:b1}]", bob)
+	}
+
+	if got := s.EntriesByAgent("nobody"); len(got) != 0 {
+		t.Errorf("EntriesByAgent(nobody) = %v, want []", got)
+	}
+}
+
 func TestScheduler_EntriesByTag(t *testing.T) {
 	s := New(discardLogger(), nil)
 

--- a/web/src/__tests__/pages/Schedules.test.js
+++ b/web/src/__tests__/pages/Schedules.test.js
@@ -59,6 +59,88 @@ describe('Schedules page', () => {
     })
   })
 
+  test('agent filter refetches the list scoped to one agent via the API', async () => {
+    const all = [
+      { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+      { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
+    ]
+    let lastAgentParam = '__unset__'
+    server.use(
+      // Mirror the backend: honour the ?agent= query parameter.
+      http.get('/api/v1/schedules', ({ request }) => {
+        const agent = new URL(request.url).searchParams.get('agent')
+        lastAgentParam = agent
+        return HttpResponse.json(agent ? all.filter(s => s.agent === agent) : all)
+      })
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByText('alice-job')).toBeInTheDocument()
+      expect(screen.getByText('bob-job')).toBeInTheDocument()
+    })
+
+    // Filter dropdown appears because there is more than one owning agent.
+    const filter = screen.getByTestId('agent-filter')
+    await fireEvent.change(filter, { target: { value: 'alice' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('alice-job')).toBeInTheDocument()
+      expect(screen.queryByText('bob-job')).not.toBeInTheDocument()
+    })
+    // The narrowing came from a server round-trip carrying ?agent=alice.
+    expect(lastAgentParam).toBe('alice')
+
+    // Switching back to "All agents" refetches without the filter.
+    await fireEvent.change(filter, { target: { value: '' } })
+    await waitFor(() => {
+      expect(screen.getByText('bob-job')).toBeInTheDocument()
+    })
+    expect(lastAgentParam).toBeNull()
+  })
+
+  test('filter control survives an empty filtered result', async () => {
+    const all = [
+      { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+      { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
+    ]
+    server.use(
+      http.get('/api/v1/schedules', ({ request }) => {
+        const agent = new URL(request.url).searchParams.get('agent')
+        // Simulate an agent with no schedules.
+        return HttpResponse.json(agent === 'alice' ? [] : all)
+      })
+    )
+
+    render(Schedules)
+    await waitFor(() => expect(screen.getByText('bob-job')).toBeInTheDocument())
+
+    const filter = screen.getByTestId('agent-filter')
+    await fireEvent.change(filter, { target: { value: 'alice' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/No schedules for alice/)).toBeInTheDocument()
+    })
+    // The filter dropdown must remain so the user can recover.
+    expect(screen.getByTestId('agent-filter')).toBeInTheDocument()
+  })
+
+  test('no agent filter shown for a single-agent list', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'solo', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+        ])
+      )
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByText('solo')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('agent-filter')).not.toBeInTheDocument()
+  })
+
   test('edit button opens pre-filled form', async () => {
     server.use(
       http.get('/api/v1/schedules', () =>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -79,7 +79,7 @@ export const api = {
   deleteSkill: (agent, name) => apiFetch(`/api/v1/skills/${encodeURIComponent(agent)}/${encodeURIComponent(name)}`, { method: 'DELETE' }),
 
   // Schedules
-  schedules: () => apiFetch('/api/v1/schedules'),
+  schedules: (agent) => apiFetch(`/api/v1/schedules${agent ? `?agent=${encodeURIComponent(agent)}` : ''}`),
   addSchedule: data => apiFetch('/api/v1/schedules', {
     method: 'POST',
     body: JSON.stringify(data),

--- a/web/src/pages/Schedules.svelte
+++ b/web/src/pages/Schedules.svelte
@@ -13,6 +13,15 @@
   let agents = []
   let loadWarning = ''
 
+  // List filter (operator view): '' = all agents. The filter drives a
+  // server-side fetch (GET /api/v1/schedules?agent=). knownAgents and
+  // hasSchedules are captured from the last unfiltered load so the filter
+  // control stays stable even when a filtered fetch returns nothing.
+  let filterAgent = ''
+  let knownAgents = []
+  let hasSchedules = false
+  let listLoading = false
+
   // Inline add/edit panel
   let showForm = false
   let editingName = null // null = add mode, string = edit mode
@@ -45,6 +54,10 @@
         api.agents().catch(() => { agErr = true; return [] }),
       ])
       schedules = sched || []
+      // Capture the full picture from this unfiltered load.
+      filterAgent = ''
+      hasSchedules = schedules.length > 0
+      knownAgents = [...new Set(schedules.map(s => s.agent || '').filter(Boolean))].sort()
       timezone = cfg?.timezone || 'UTC'
       channels = (ch || []).filter(c => !c.implicit)
       agents = ag || []
@@ -56,6 +69,19 @@
       error = e.message
     } finally {
       loading = false
+    }
+  }
+
+  // Refetch the list scoped to the selected agent via the API filter.
+  async function applyFilter() {
+    listLoading = true
+    error = ''
+    try {
+      schedules = (await api.schedules(filterAgent || undefined)) || []
+    } catch (e) {
+      error = e.message
+    } finally {
+      listLoading = false
     }
   }
 
@@ -260,13 +286,27 @@
 
   {#if loading}
     <p class="muted">Loading...</p>
-  {:else if schedules.length === 0 && !error}
+  {:else if !hasSchedules && !error}
     <p class="muted">No schedules configured. Add one to automate recurring tasks.</p>
   {:else}
+    {#if knownAgents.length > 1}
+      <div class="filter-bar">
+        <label class="filter-label">
+          Agent
+          <select bind:value={filterAgent} onchange={applyFilter} disabled={listLoading} data-testid="agent-filter">
+            <option value="">All agents</option>
+            {#each knownAgents as a}
+              <option value={a}>{a}</option>
+            {/each}
+          </select>
+        </label>
+        {#if listLoading}<span class="filter-loading">Loading…</span>{/if}
+      </div>
+    {/if}
     <table class="table">
       <thead>
         <tr>
-          <th>Name</th><th>Expression</th><th>Skill</th>
+          <th>Name</th><th>Expression</th><th>Skill</th><th>Agent</th>
           <th>Channel</th><th>Tier</th><th>Enabled</th>
           <th>Last Run</th><th>Next Run</th><th>Actions</th>
         </tr>
@@ -277,6 +317,7 @@
             <td class="name">{s.name}</td>
             <td class="expr">{s.expression}</td>
             <td>{s.skill || '—'}</td>
+            <td>{s.agent || '—'}</td>
             <td class="expr">{s.channel || '—'}</td>
             <td>{s.session_tier || '—'}</td>
             <td>
@@ -291,6 +332,11 @@
             </td>
           </tr>
         {/each}
+        {#if schedules.length === 0 && !listLoading}
+          <tr>
+            <td colspan="10" class="muted">No schedules for {filterAgent}.</td>
+          </tr>
+        {/if}
       </tbody>
     </table>
   {/if}
@@ -325,5 +371,9 @@
   .dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--border); margin-right: 4px; vertical-align: middle; }
   .dot.on { background: var(--success); }
   .actions { white-space: nowrap; }
+  .filter-bar { margin-bottom: 12px; display: flex; align-items: center; gap: 10px; }
+  .filter-label { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-muted); }
+  .filter-label select { font-size: 13px; }
+  .filter-loading { font-size: 12px; color: var(--text-muted); }
   .load-warning { font-size: 12px; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; margin-bottom: 12px; }
 </style>


### PR DESCRIPTION
## Summary

Schedules already carried an `agent` stamp throughout the stack, but nothing enforced ownership — any agent could list, update, or delete another agent's schedules, and every list surface returned all agents' entries. This PR makes each agent own its schedules (a hard boundary at the agent layer) while keeping the REST API and the service-level MCP server as operator planes that can still manage and filter across all agents.

This is the "soft boundary" approach: scoping is enforced at runtime per agent; the TOML `[[schedules]]` schema is unchanged. No agent-to-API-key binding was introduced.

## Changes

- **scheduler** — add `EntriesByAgent(agent)`, an owner-filtered query alongside the existing `AgentEntries`/`SystemEntries`/`EntriesByTag`.
- **configmcp (agent-facing tools)** — the real per-agent boundary:
  - `schedule_list` now returns only the calling agent's schedules (was leaking all agents).
  - `schedule_update` / `schedule_delete` reject other agents' schedules via a new `ownsSchedule()` helper, returning an identical `"not found"` so a foreign schedule's existence isn't leaked.
  - Fix `MergeScheduleUpdate`: an explicit empty `agent` now keeps the current owner instead of clearing the stamp (an empty owner made a schedule invisible to its owner under owner-scoped listing).
- **mcpserver + REST** — operator/service planes, kept able to manage all agents:
  - `schedule_list` gains an optional `agent` input; default returns everything.
  - `GET /api/v1/schedules?agent=` filter; unfiltered by default.
- **web UI** — Agent column plus an agent filter dropdown that drives the API filter server-side (`?agent=`). The filter control stays visible even when a filtered fetch returns nothing, so the user can always recover.

## Tests

Added coverage at scheduler, configmcp (ownership rejection + scoped list), mcpserver (optional filter), REST (`?agent=`), integration (end-to-end filter proving cross-agent exclusion), and Svelte (server-driven filter + empty-result recovery) levels. Two pre-existing configmcp tests were reconciled to the new model (cross-agent reassign now leaves the original owner's list; empty-agent update keeps ownership).

The integration test seeds a second agent's schedule and asserts each filtered REST response returns exactly its owner's entry, so scoping is proven by exclusion, not just inclusion.

## Out of scope (follow-ups)

- Unifying the two schedule dispatch paths (boot uses `Dispatcher.Dispatch`; runtime CRUD binds a captured `engine.HandleMessage`).
- A hard API-key-to-agent boundary for REST/MCP (multi-tenant key isolation).
- `swagger.json` regeneration — the committed spec is already stale and ungated by CI; regenerating would have bundled ~480 lines of unrelated drift. The new query param is documented in the handler's godoc annotation. Tracked in #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

