### PR TITLE
fix(configmcp): split windowed cost into window_cost, never reuse lifetime_cost

### DIFF
--- a/internal/configmcp/handlers.go
+++ b/internal/configmcp/handlers.go
@@ -1281,7 +1281,7 @@ func (s *Server) handleSetFallback(ctx context.Context, req *mcp.CallToolRequest
 func (s *Server) registerCostTools() {
 	s.mcpServer.AddTool(&mcp.Tool{
 		Name:        "get_cost_summary",
-		Description: "Return cost tracking data. global_cost/session_costs come from the in-memory tracker — spend since the last restart, and they drive live budget enforcement. lifetime_cost/by_model/by_tool/by_skill/by_tool_skill come from persistent storage (lifetime, or the last N days when 'days' is set, and are global across all agents). by_model carries per-model cost/token totals; by_tool/by_skill carry call counts, error counts, and average duration. Each by_tool/by_tool_skill entry splits outcomes into failure_count (transport/exec failure — the real broken-tool signal), rejection_count (bad args), and denial_count (approval denied — not a fault); error_count is the legacy combined total. by_tool_skill keys those per owning (skill_name, skill_version) so a skill's tool reliability can be compared across versions.",
+		Description: "Return cost tracking data. global_cost/session_costs come from the in-memory tracker — spend since the last restart, and they drive live budget enforcement. lifetime_cost/window_cost/by_model/by_tool/by_skill/by_tool_skill come from persistent storage and are global across all agents. Without 'days' the persistent total lands in lifetime_cost (all-time); with 'days' it lands in window_cost alongside window_days (restart-proof spend over the last N days) and lifetime_cost is omitted — use window_cost, not global_cost, for week-over-week trends. by_model carries per-model cost/token totals; by_tool/by_skill carry call counts, error counts, and average duration. Each by_tool/by_tool_skill entry splits outcomes into failure_count (transport/exec failure — the real broken-tool signal), rejection_count (bad args), and denial_count (approval denied — not a fault); error_count is the legacy combined total. by_tool_skill keys those per owning (skill_name, skill_version) so a skill's tool reliability can be compared across versions.",
 		InputSchema: json.RawMessage(`{"type": "object", "properties": {"days": {"type": "integer", "description": "Restrict per-tool/per-skill stats to the last N days (0 or absent = all time)"}}}`),
 	}, s.handleGetCostSummary)
 }
@@ -1309,10 +1309,20 @@ func (s *Server) handleGetCostSummary(ctx context.Context, req *mcp.CallToolRequ
 			data.TelemetryError = err.Error()
 		} else {
 			data.ByModel = summary.ByModel
-			data.LifetimeCost = sumModelCost(summary.ByModel)
 			data.ByTool = summary.ByTool
 			data.BySkill = summary.BySkill
 			data.ByToolSkill = summary.ByToolSkill
+			// Persistent spend is restart-proof. Route it to the field that
+			// matches the query so lifetime_cost never carries a windowed number:
+			// a bounded 'days' query populates window_cost, an all-time query
+			// populates lifetime_cost.
+			total := sumModelCost(summary.ByModel)
+			if input.Days > 0 {
+				data.WindowCost = total
+				data.WindowDays = input.Days
+			} else {
+				data.LifetimeCost = total
+			}
 		}
 	}
 

--- a/internal/configmcp/server.go
+++ b/internal/configmcp/server.go
@@ -167,10 +167,19 @@ type CostSummaryData struct {
 	MaxPerSession float64            `json:"max_per_session"`
 	SessionCosts  map[string]float64 `json:"session_costs"`
 
-	// LifetimeCost is the persistent total spend (sum of ByModel costs),
-	// lifetime or last-N-days when the 'days' filter is set. Unlike
-	// GlobalCost it survives restarts.
+	// LifetimeCost is the persistent all-time spend (sum of ByModel costs).
+	// Unlike GlobalCost it survives restarts. It is populated only for an
+	// all-time query; when the 'days' filter is set the bounded figure goes to
+	// WindowCost instead, so lifetime_cost never carries a windowed number.
 	LifetimeCost float64 `json:"lifetime_cost,omitempty"`
+	// WindowCost is the persistent spend over the last WindowDays days, set only
+	// when the 'days' filter is provided. Like LifetimeCost it survives restarts,
+	// but it is a bounded window — use it (not GlobalCost) for restart-proof
+	// week-over-week trend comparisons. LifetimeCost and WindowCost are mutually
+	// exclusive: one carries the all-time total, the other the windowed total.
+	WindowCost float64 `json:"window_cost,omitempty"`
+	// WindowDays echoes the 'days' filter that produced WindowCost.
+	WindowDays int `json:"window_days,omitempty"`
 	// ByModel, ByTool and BySkill are populated from TelemetrySummary when
 	// available and reflect persistent storage (global across agents).
 	ByModel []agent.ModelCostSummary  `json:"by_model,omitempty"`

--- a/internal/configmcp/server_test.go
+++ b/internal/configmcp/server_test.go
@@ -1658,6 +1658,51 @@ func TestGetCostSummary_DaysFilter(t *testing.T) {
 	}
 }
 
+func TestGetCostSummary_WindowCostWhenDaysSet(t *testing.T) {
+	// A bounded 'days' query must route the persistent total to window_cost
+	// (+ window_days), leaving lifetime_cost omitted so it never carries a
+	// windowed number. This is the restart-proof figure self-audit diffs
+	// week-over-week — the trap was that a windowed total used to surface under
+	// the "lifetime_cost" name, nudging callers toward the transient global_cost.
+	session, _ := newTestServer(t, func(d *configmcp.Deps) {
+		d.CostSummary = func() configmcp.CostSummaryData {
+			return configmcp.CostSummaryData{GlobalCost: 0.61}
+		}
+		d.TelemetrySummary = func(_ context.Context, _ *time.Time) (*agent.TelemetrySummary, error) {
+			return &agent.TelemetrySummary{
+				ByModel: []agent.ModelCostSummary{
+					{Model: "kimi-k2", Provider: "moonshotai", TotalCost: 2.03},
+				},
+			}, nil
+		}
+	})
+
+	text, isErr := callTool(t, session, "get_cost_summary", map[string]any{"days": 7})
+	if isErr {
+		t.Fatalf("get_cost_summary error: %s", text)
+	}
+
+	var result configmcp.CostSummaryData
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		t.Fatalf("parsing result: %v", err)
+	}
+	if result.WindowCost != 2.03 {
+		t.Errorf("WindowCost = %v, want 2.03", result.WindowCost)
+	}
+	if result.WindowDays != 7 {
+		t.Errorf("WindowDays = %v, want 7", result.WindowDays)
+	}
+	if result.LifetimeCost != 0 {
+		t.Errorf("LifetimeCost = %v, want 0 (windowed total must not reuse the lifetime field)", result.LifetimeCost)
+	}
+	if strings.Contains(text, "lifetime_cost") {
+		t.Errorf("windowed query must omit lifetime_cost, got: %s", text)
+	}
+	if result.GlobalCost != 0.61 {
+		t.Errorf("GlobalCost = %v, want 0.61 (transient number preserved)", result.GlobalCost)
+	}
+}
+
 func TestGetCostSummary_TelemetryErrorIsNonFatal(t *testing.T) {
 	session, _ := newTestServer(t, func(d *configmcp.Deps) {
 		d.CostSummary = func() configmcp.CostSummaryData {


### PR DESCRIPTION
## Problem

`get_cost_summary` surfaced the last-N-days persistent spend under the **`lifetime_cost`** field name whenever `days` was set — so a windowed number masqueraded as an all-time total. That naming trap nudged callers (notably the `self-audit` skill) toward diffing the transient in-memory `global_cost` instead, which resets to ~0 on every restart and silently breaks week-over-week trend analysis. This is the root cause behind self-audit finding **A3** ("cost tracker resets on restart — no week-over-week baseline").

## Change

Route persistent spend to the field that matches the query — the two are now mutually exclusive:

- **all-time query** (no `days`) → `lifetime_cost`
- **windowed query** (`days: N`) → `window_cost` + `window_days`, and `lifetime_cost` is omitted

`window_cost` is the restart-proof figure to diff week-over-week. `lifetime_cost` can never carry a windowed number again.

## Files

- `internal/configmcp/server.go` — add `WindowCost`/`WindowDays` to `CostSummaryData`; clarify `LifetimeCost` doc
- `internal/configmcp/handlers.go` — split routing in `handleGetCostSummary`; update tool description
- `internal/configmcp/server_test.go` — new `TestGetCostSummary_WindowCostWhenDaysSet` asserting `window_cost`/`window_days` are set and `lifetime_cost` is **absent** on a windowed query

## Testing

`just hook` green (fmt-check, vet, lint, lint-ui, test, test-ui).

## Companion change (not in this PR)

The live `default` agent's `self-audit` skill was bumped to v1.4.0 to read `window_cost` (via `get_cost_summary({days: 7})`) and offload trend/failure-rate math to `run_javascript`. The skill falls back to `lifetime_cost` when `window_cost` is absent, so there's no hard deploy-ordering dependency — but they're best shipped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)