### PR TITLE
fix(web): sanitise rendered audit output with DOMPurify + add dashboard CSP (P0-1)

### DIFF
--- a/internal/api/oauth_handlers.go
+++ b/internal/api/oauth_handlers.go
@@ -320,9 +320,22 @@ func (s *Server) handleListPendingOAuth(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, pending)
 }
 
+// callbackAutoCloseScriptHash is the CSP sha256 hash of the inline auto-close
+// script in the OAuth success page below. If that script's bytes change, this
+// hash must be updated — TestServeCallbackHTML_CSPHashMatchesScript guards it.
+const callbackAutoCloseScriptHash = "sha256-Hp5+GtpXGYNgDBbEx0x8wNHWLHjmBDIKDmK4A2m9l34="
+
+// callbackCSP is a page-scoped Content-Security-Policy for the self-contained
+// OAuth callback pages. It overrides the strict dashboard policy: the pages
+// load no external resources ('none' default), carry inline <style> blocks
+// ('unsafe-inline' styles cannot execute script), and the success page uses one
+// static inline auto-close script permitted by its exact hash.
+var callbackCSP = "default-src 'none'; style-src 'unsafe-inline'; script-src '" + callbackAutoCloseScriptHash + "'"
+
 // serveCallbackHTML serves a simple HTML page after OAuth callback.
 func (s *Server) serveCallbackHTML(w http.ResponseWriter, success bool, errMsg string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Security-Policy", callbackCSP)
 
 	if success {
 		w.WriteHeader(http.StatusOK)

--- a/internal/api/security_headers_test.go
+++ b/internal/api/security_headers_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func newHeaderTestServer() *Server {
+	return New(testConfig(), testDeps(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// TestSecurityHeaders_SetCSP asserts the dashboard CSP is emitted and that
+// script-src stays locked to 'self' (the control that defeats the stored-XSS →
+// same-origin RCE chain). 'unsafe-inline' must never leak into script-src.
+func TestSecurityHeaders_SetCSP(t *testing.T) {
+	srv := newHeaderTestServer()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := srv.middlewareSecurityHeaders(mux)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("expected Content-Security-Policy header, got none")
+	}
+	for _, want := range []string{
+		"default-src 'self'", "script-src 'self'", "object-src 'none'",
+		"base-uri 'self'", "frame-ancestors 'none'", "connect-src 'self'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("CSP missing %q; got %q", want, csp)
+		}
+	}
+	// script-src must not permit inline scripts.
+	if regexp.MustCompile(`script-src[^;]*'unsafe-inline'`).MatchString(csp) {
+		t.Errorf("script-src must not allow 'unsafe-inline'; got %q", csp)
+	}
+}
+
+// TestServeCallbackHTML_CSPHashMatchesScript guards against drift between the
+// OAuth success page's inline auto-close script and the CSP hash that permits
+// it: if the script changes, the constant must be regenerated or the browser
+// will silently block the script.
+func TestServeCallbackHTML_CSPHashMatchesScript(t *testing.T) {
+	srv := newHeaderTestServer()
+	rec := httptest.NewRecorder()
+	srv.serveCallbackHTML(rec, true, "")
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, callbackAutoCloseScriptHash) {
+		t.Fatalf("callback CSP missing script hash %q; got %q", callbackAutoCloseScriptHash, csp)
+	}
+
+	m := regexp.MustCompile(`(?s)<script>(.*?)</script>`).FindStringSubmatch(rec.Body.String())
+	if m == nil {
+		t.Fatal("no inline <script> found in success callback page")
+	}
+	sum := sha256.Sum256([]byte(m[1]))
+	got := "sha256-" + base64.StdEncoding.EncodeToString(sum[:])
+	if got != callbackAutoCloseScriptHash {
+		t.Errorf("inline script hash = %q, but callbackAutoCloseScriptHash = %q (update the constant)", got, callbackAutoCloseScriptHash)
+	}
+}

--- a/internal/api/security_headers_test.go
+++ b/internal/api/security_headers_test.go
@@ -70,3 +70,27 @@ func TestServeCallbackHTML_CSPHashMatchesScript(t *testing.T) {
 		t.Errorf("inline script hash = %q, but callbackAutoCloseScriptHash = %q (update the constant)", got, callbackAutoCloseScriptHash)
 	}
 }
+
+// TestServeCallbackHTML_EscapesErrorMessage guards the reflected-XSS sink on the
+// OAuth failure page: errMsg is built from the callback's `error`/
+// `error_description` query params (externally controllable) and is embedded in
+// HTML. It must be HTML-escaped so an attacker-supplied error cannot inject
+// markup into the page.
+func TestServeCallbackHTML_EscapesErrorMessage(t *testing.T) {
+	srv := newHeaderTestServer()
+	rec := httptest.NewRecorder()
+
+	payload := `<script>alert(1)</script>"><img src=x onerror=alert(2)>`
+	srv.serveCallbackHTML(rec, false, payload)
+
+	body := rec.Body.String()
+	for _, raw := range []string{"<script>alert(1)", "<img src=x onerror"} {
+		if strings.Contains(body, raw) {
+			t.Errorf("failure page contains unescaped payload %q; body=%s", raw, body)
+		}
+	}
+	// The escaped form must be present (proves the message was rendered, escaped).
+	if !strings.Contains(body, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Errorf("expected HTML-escaped error message in body; got %s", body)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3118,10 +3118,31 @@ func (s *Server) middlewareCORS(next http.Handler) http.Handler {
 	})
 }
 
+// dashboardCSP is the Content-Security-Policy applied to the dashboard SPA and
+// all other responses by default. `script-src 'self'` is the primary control:
+// it neutralises any script an attacker manages to inject into rendered
+// LLM/audit output, so a stored-XSS payload cannot pivot to same-origin API
+// calls (e.g. POST /api/v1/tools). `style-src` allows 'unsafe-inline' because
+// the SPA uses dynamic inline `style=` attributes (which cannot execute
+// script); `base-uri`/`object-src`/`frame-ancestors` close the <base>, plugin,
+// and clickjacking vectors. The OAuth callback page overrides this with its own
+// page-scoped policy (see serveCallbackHTML).
+const dashboardCSP = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data:; " +
+	"font-src 'self'; " +
+	"connect-src 'self'; " +
+	"object-src 'none'; " +
+	"base-uri 'self'; " +
+	"frame-ancestors 'none'; " +
+	"form-action 'self'"
+
 func (s *Server) middlewareSecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Content-Security-Policy", dashboardCSP)
 		// Set Cache-Control on API routes only (not static assets served by the web handler).
 		if strings.HasPrefix(r.URL.Path, "/api/") {
 			w.Header().Set("Cache-Control", "no-store")

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
     <title>Denkeeper</title>
   </head>
   <body>
-    <script>if(localStorage.getItem('dk_theme')==='dark')document.documentElement.classList.add('dark')</script>
+    <script src="/theme-init.js"></script>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "denkeeper-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "dompurify": "^3.4.11",
         "marked": "^18.0.4"
       },
       "devDependencies": {
@@ -690,9 +691,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,9 +708,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,9 +725,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -750,9 +742,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,9 +759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -790,9 +776,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1101,7 +1084,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1548,6 +1531,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "vitest": "^4.1.3"
   },
   "dependencies": {
+    "dompurify": "^3.4.11",
     "marked": "^18.0.4"
   }
 }

--- a/web/public/theme-init.js
+++ b/web/public/theme-init.js
@@ -1,0 +1,6 @@
+// Applies the persisted dark-theme class before first paint to avoid a flash of
+// the wrong theme. Loaded as an external classic script (not inline) so the
+// dashboard can enforce a strict `script-src 'self'` Content-Security-Policy.
+if (localStorage.getItem('dk_theme') === 'dark') {
+  document.documentElement.classList.add('dark')
+}

--- a/web/src/components/AuditDetail.svelte
+++ b/web/src/components/AuditDetail.svelte
@@ -1,5 +1,15 @@
 <script>
   import { marked } from 'marked'
+  import DOMPurify from 'dompurify'
+
+  // Force external links opened from rendered LLM/audit output to be
+  // isolated from the dashboard (no window.opener back-reference).
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A' && node.hasAttribute('href')) {
+      node.setAttribute('rel', 'noopener noreferrer')
+      node.setAttribute('target', '_blank')
+    }
+  })
 
   let { event } = $props()
 
@@ -15,12 +25,17 @@
     try { return JSON.parse(detail) } catch { return null }
   }
 
-  // Strip dangerous HTML from rendered markdown (scripts, event handlers)
+  // Sanitize rendered markdown with DOMPurify — a real HTML parser that strips
+  // scripts, event handlers, javascript:/data: URIs, and mutation-XSS vectors
+  // (<svg>, <base>, unclosed tags) that a regex-based filter cannot catch.
+  // LLM/audit output is attacker-influenceable (indirect prompt injection), so
+  // it is treated as untrusted before {@html} injection.
   function sanitizeHTML(html) {
-    return html
-      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-      .replace(/<iframe\b[^>]*>/gi, '')
-      .replace(/\bon\w+\s*=/gi, 'data-removed=')
+    return DOMPurify.sanitize(html, {
+      ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i, // block javascript:, data:, vbscript:
+      FORBID_TAGS: ['style', 'base', 'form'],
+      FORBID_ATTR: ['style'],
+    })
   }
 
   let detail = $derived(parseDetail(event.detail))

--- a/web/src/components/__tests__/AuditDetail.test.js
+++ b/web/src/components/__tests__/AuditDetail.test.js
@@ -345,6 +345,12 @@ describe('AuditDetail', () => {
     expect(el.querySelector('base')).toBeNull()
   })
 
+  test('strips <iframe> (regression: old sanitiser had a dedicated iframe regex)', () => {
+    const el = renderOutput('<iframe src="javascript:alert(1)"></iframe>text')
+    expect(el.querySelector('iframe')).toBeNull()
+    expect(el.innerHTML).not.toMatch(/javascript:/i)
+  })
+
   test('strips <script> content including malformed/unclosed tags', () => {
     const el = renderOutput('before <script>alert(1)</script> after <script src="//evil.example/x.js">')
     expect(el.querySelector('script')).toBeNull()

--- a/web/src/components/__tests__/AuditDetail.test.js
+++ b/web/src/components/__tests__/AuditDetail.test.js
@@ -302,4 +302,62 @@ describe('AuditDetail', () => {
     }})
     expect(screen.getByText('truncated')).toBeInTheDocument()
   })
+
+  // ─── XSS sanitisation of rendered LLM output (P0-1) ──────────────────────
+  // LLM/audit output is attacker-influenceable (indirect prompt injection), so
+  // the {@html}-injected OUTPUT must be sanitised. These assert the dangerous
+  // vectors the old 3-regex sanitiser missed are stripped by DOMPurify.
+  function renderOutput(responseText) {
+    render(AuditDetail, { props: {
+      event: makeEvent({
+        category: 'llm',
+        detail: JSON.stringify({ model: 'claude-3', tokens: 10, cost: 0.01, response_text: responseText }),
+      }),
+    }})
+    return document.querySelector('.output-rendered')
+  }
+
+  test('strips javascript: URIs from markdown links', () => {
+    const el = renderOutput('[click me](javascript:alert(document.cookie))')
+    expect(el.innerHTML).not.toMatch(/javascript:/i)
+    const link = el.querySelector('a')
+    if (link) expect(link.getAttribute('href') || '').not.toMatch(/javascript:/i)
+  })
+
+  test('strips data: URIs from markdown links', () => {
+    const el = renderOutput('[x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)')
+    expect(el.innerHTML).not.toMatch(/data:text\/html/i)
+  })
+
+  test('strips inline event handlers from raw HTML', () => {
+    const el = renderOutput('<img src=x onerror="alert(1)"> text')
+    expect(el.innerHTML).not.toMatch(/onerror/i)
+    expect(el.querySelector('img[onerror]')).toBeNull()
+  })
+
+  test('strips svg-based onload vector', () => {
+    const el = renderOutput('<svg><g onload="alert(1)"></g></svg>')
+    expect(el.innerHTML).not.toMatch(/onload/i)
+  })
+
+  test('strips <base> tag (base-uri hijack vector)', () => {
+    const el = renderOutput('<base href="//evil.example.com/">text')
+    expect(el.querySelector('base')).toBeNull()
+  })
+
+  test('strips <script> content including malformed/unclosed tags', () => {
+    const el = renderOutput('before <script>alert(1)</script> after <script src="//evil.example/x.js">')
+    expect(el.querySelector('script')).toBeNull()
+    expect(el.innerHTML).not.toMatch(/alert\(1\)/)
+  })
+
+  test('preserves safe markdown and hardens surviving links', () => {
+    const el = renderOutput('**bold** and a [safe link](https://example.com) with `code`')
+    expect(el.querySelector('strong')).not.toBeNull()
+    expect(el.querySelector('code')).not.toBeNull()
+    const link = el.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link.getAttribute('href')).toBe('https://example.com')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes **P0-1 — Stored XSS → same-origin RCE chain in the dashboard** (OWASP A03/A04). LLM/audit output is attacker-influenceable (indirect prompt injection from a fetched page, an inbound Telegram/Discord message, or a tool result). It was rendered through a homemade 3-regex `sanitizeHTML` before `{@html}` injection in `AuditDetail.svelte`, which missed `javascript:`/`data:` URIs, `<svg>`/`<base>` vectors, and malformed/unclosed tags. Because the dashboard session carries all `:write` scopes, an injected same-origin script could pivot to `POST /api/v1/tools` (RCE).

## Changes

- **Real sanitiser**: replace the regex filter in `AuditDetail.svelte` with **DOMPurify** (a real HTML parser). Blocks scripts, event handlers, `javascript:`/`data:` URIs, and mutation-XSS vectors (`<svg>`, `<base>`, unclosed tags). Surviving links are hardened with `rel="noopener noreferrer" target="_blank"`.
- **Content-Security-Policy** (defense in depth) added in `middlewareSecurityHeaders`:
  `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'`.
  `script-src 'self'` neutralises any injected script even on a sanitiser bypass, cutting the RCE pivot. `base-uri`/`object-src`/`frame-ancestors` close the `<base>`, plugin, and clickjacking vectors. `style-src 'unsafe-inline'` is required only for the SPA's dynamic inline `style=` attributes (which cannot execute script).
- **Externalised the theme-bootstrap script** to `/theme-init.js` so the dashboard needs no `script 'unsafe-inline'`.
- **OAuth callback page** gets a page-scoped CSP that permits its single static inline auto-close script by **sha256 hash** (drift-guarded by a Go test).

## Tests

- 7 new XSS-vector tests in `AuditDetail.test.js` (javascript:/data: links, `onerror`/`onload`, `<base>`, unclosed `<script>`, plus a safe-markdown + link-hardening assertion).
- Go tests: CSP header is set, `script-src` excludes `'unsafe-inline'`, and the OAuth CSP hash matches the served inline script.
- `just hook` green (fmt-check, vet, lint, lint-ui, test, test-ui).

## Not in scope

**P1-6** (MCP stdio subprocesses inheriting the full secret-bearing parent env) is intentionally deferred to a follow-up PR, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)