### PR TITLE
fix(engine): sum cached prompt tokens across tool-call rounds

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -848,15 +848,16 @@ func classifySkillMatch(s skill.Skill, msg adapter.IncomingMessage) string {
 
 // ChatEvent describes an intermediate pipeline event streamed to SSE clients.
 type ChatEvent struct {
-	Type     string  `json:"type"`                  // "tool_start", "tool_end", "thinking", "usage", "tool_approval", "content_delta", "thinking_delta"
-	Tool     string  `json:"tool,omitempty"`        // tool name
-	ToolID   string  `json:"tool_id,omitempty"`     // unique tool call ID (from LLM response)
-	Round    int     `json:"round,omitempty"`       // 1-based tool round
-	Duration int64   `json:"duration_ms,omitempty"` // tool execution time
-	Error    string  `json:"error,omitempty"`       // tool error (if any)
-	Text     string  `json:"text,omitempty"`        // human-readable status message / content delta
-	Tokens   int     `json:"tokens,omitempty"`      // total tokens used (usage event)
-	CostUSD  float64 `json:"cost_usd,omitempty"`    // estimated cost in USD (usage event)
+	Type         string  `json:"type"`                    // "tool_start", "tool_end", "thinking", "usage", "tool_approval", "content_delta", "thinking_delta"
+	Tool         string  `json:"tool,omitempty"`          // tool name
+	ToolID       string  `json:"tool_id,omitempty"`       // unique tool call ID (from LLM response)
+	Round        int     `json:"round,omitempty"`         // 1-based tool round
+	Duration     int64   `json:"duration_ms,omitempty"`   // tool execution time
+	Error        string  `json:"error,omitempty"`         // tool error (if any)
+	Text         string  `json:"text,omitempty"`          // human-readable status message / content delta
+	Tokens       int     `json:"tokens,omitempty"`        // total tokens used (usage event)
+	TokensCached int     `json:"tokens_cached,omitempty"` // cached prompt tokens (usage event)
+	CostUSD      float64 `json:"cost_usd,omitempty"`      // estimated cost in USD (usage event)
 
 	// ApprovalID and ApprovalCallback are set on "tool_approval" events so
 	// the adapter can render inline approve/deny buttons.
@@ -1000,9 +1001,10 @@ func (e *Engine) chatWithApproval(ctx context.Context, msg adapter.IncomingMessa
 
 	if onEvent != nil {
 		onEvent(ChatEvent{
-			Type:    "usage",
-			Tokens:  resp.TokensUsed.Total,
-			CostUSD: resp.CostUSD,
+			Type:         "usage",
+			Tokens:       resp.TokensUsed.Total,
+			TokensCached: resp.TokensUsed.CachedPrompt,
+			CostUSD:      resp.CostUSD,
 		})
 	}
 
@@ -1242,9 +1244,7 @@ func (e *Engine) runLLMWithTools(ctx context.Context, convID string, perms *secu
 func (e *Engine) executeToolRounds(ctx context.Context, convID string, perms *security.PermissionEngine, resp *llm.ChatResponse, llmMessages []llm.Message, onEvent ChatEventFunc) (*llm.ChatResponse, []llm.Message, []ToolCallRecord, error) {
 	var totalUsage llm.TokenUsage
 	var totalCost float64
-	totalUsage.Prompt += resp.TokensUsed.Prompt
-	totalUsage.Completion += resp.TokensUsed.Completion
-	totalUsage.Total += resp.TokensUsed.Total
+	totalUsage.Add(resp.TokensUsed)
 	totalCost += resp.CostUSD
 
 	supervised := perms.Tier() == "supervised" && e.approvals != nil
@@ -1290,9 +1290,7 @@ func (e *Engine) executeToolRounds(ctx context.Context, convID string, perms *se
 		}
 		e.emitLLMAudit(ctx, convID, resp, "", llmAuditOpts{round: round + 1})
 
-		totalUsage.Prompt += resp.TokensUsed.Prompt
-		totalUsage.Completion += resp.TokensUsed.Completion
-		totalUsage.Total += resp.TokensUsed.Total
+		totalUsage.Add(resp.TokensUsed)
 		totalCost += resp.CostUSD
 
 		e.logger.Info("tool round complete",
@@ -1319,9 +1317,7 @@ func (e *Engine) executeToolRounds(ctx context.Context, convID string, perms *se
 		if err != nil {
 			return nil, llmMessages, toolRecords, err
 		}
-		totalUsage.Prompt += resp.TokensUsed.Prompt
-		totalUsage.Completion += resp.TokensUsed.Completion
-		totalUsage.Total += resp.TokensUsed.Total
+		totalUsage.Add(resp.TokensUsed)
 		totalCost += resp.CostUSD
 	}
 

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -4535,3 +4535,311 @@ func TestAttributeSkill_AmbiguousAndEmpty(t *testing.T) {
 		t.Error("zero-match turn should be unattributed (ok=false)")
 	}
 }
+
+// TestExecuteToolRounds_AccumulatesCachedTokens verifies that cached prompt
+// tokens are summed across all tool-call rounds into the stored assistant
+// message, rather than being zeroed by the accumulator overwrite (the bug this
+// change fixes). It also cross-checks that the sum of per-round audit-event
+// tokens_cached equals the stored message's TokensCached — precisely the
+// discrepancy that revealed the bug.
+func TestExecuteToolRounds_AccumulatesCachedTokens(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				Content:      "step 1",
+				ToolCalls:    []llm.ToolCall{{ID: "c1", Type: "function", Function: llm.FunctionCall{Name: "skill_get", Arguments: `{"name":"a"}`}}},
+				TokensUsed:   llm.TokenUsage{Prompt: 10, Completion: 2, CachedPrompt: 100, Total: 112},
+				FinishReason: "tool_calls",
+			},
+			{
+				Content:      "step 2",
+				ToolCalls:    []llm.ToolCall{{ID: "c2", Type: "function", Function: llm.FunctionCall{Name: "skill_get", Arguments: `{"name":"b"}`}}},
+				TokensUsed:   llm.TokenUsage{Prompt: 20, Completion: 3, CachedPrompt: 200, Total: 223},
+				FinishReason: "tool_calls",
+			},
+			{
+				Content:      "All done.",
+				TokensUsed:   llm.TokenUsage{Prompt: 30, Completion: 4, CachedPrompt: 300, Total: 334},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+
+	auditor := &collectingAuditor{}
+	toolMgr := tool.NewManager(testLogger())
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, toolMgr, nil, testLogger())
+	engine.SetAuditor(auditor)
+
+	ctx := context.Background()
+	if _, err := engine.ChatWithEvents(ctx, adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-cached",
+		UserID:     "user-1",
+		Text:       "Process",
+		Timestamp:  time.Now(),
+	}, nil); err != nil {
+		t.Fatalf("ChatWithEvents: %v", err)
+	}
+
+	msgs, err := store.GetMessages(ctx, "default:test:chat-cached", 100)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	assistant := lastAssistant(t, msgs)
+
+	if assistant.TokensCached != 600 {
+		t.Errorf("TokensCached = %d, want 600 (100+200+300)", assistant.TokensCached)
+	}
+	// Regression guards: the pre-existing sums must be unchanged.
+	if assistant.TokensPrompt != 60 {
+		t.Errorf("TokensPrompt = %d, want 60", assistant.TokensPrompt)
+	}
+	if assistant.TokensCompletion != 9 {
+		t.Errorf("TokensCompletion = %d, want 9", assistant.TokensCompletion)
+	}
+	if assistant.TokensUsed != 669 {
+		t.Errorf("TokensUsed = %d, want 669", assistant.TokensUsed)
+	}
+
+	// Cross-check: sum of per-round audit tokens_cached == stored TokensCached.
+	if got := sumAuditCachedTokens(t, auditor.events); got != assistant.TokensCached {
+		t.Errorf("sum of audit tokens_cached = %d, want %d (stored TokensCached)", got, assistant.TokensCached)
+	}
+}
+
+// TestExecuteToolRounds_SingleRoundKeepsCachedTokens covers the 0-tool-round
+// path: even with no tool calls the accumulator overwrite ran, so cached tokens
+// were being zeroed there too.
+func TestExecuteToolRounds_SingleRoundKeepsCachedTokens(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				Content:      "No tools needed.",
+				TokensUsed:   llm.TokenUsage{Prompt: 40, Completion: 10, CachedPrompt: 500, Total: 550},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, nil, nil, testLogger())
+
+	ctx := context.Background()
+	if _, err := engine.ChatWithEvents(ctx, adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-single",
+		UserID:     "user-1",
+		Text:       "Hi",
+		Timestamp:  time.Now(),
+	}, nil); err != nil {
+		t.Fatalf("ChatWithEvents: %v", err)
+	}
+
+	msgs, err := store.GetMessages(ctx, "default:test:chat-single", 100)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	assistant := lastAssistant(t, msgs)
+	if assistant.TokensCached != 500 {
+		t.Errorf("TokensCached = %d, want 500", assistant.TokensCached)
+	}
+}
+
+// TestExecuteToolRounds_NudgeRecoveryAccumulatesCachedTokens forces the empty-
+// content nudge recovery path and asserts the nudge response's cached tokens
+// are included in the accumulated total.
+func TestExecuteToolRounds_NudgeRecoveryAccumulatesCachedTokens(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				// No content alongside the tool call, so there is no accumulated
+				// intermediate content to fall back on.
+				ToolCalls:    []llm.ToolCall{{ID: "c1", Type: "function", Function: llm.FunctionCall{Name: "skill_get", Arguments: `{"name":"a"}`}}},
+				TokensUsed:   llm.TokenUsage{CachedPrompt: 100, Total: 100},
+				FinishReason: "tool_calls",
+			},
+			{
+				// Empty final content forces the nudge path.
+				Content:      "",
+				TokensUsed:   llm.TokenUsage{CachedPrompt: 200, Total: 200},
+				FinishReason: "stop",
+			},
+			{
+				// Nudge recovery response.
+				Content:      "Recovered response.",
+				TokensUsed:   llm.TokenUsage{CachedPrompt: 300, Total: 300},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+
+	toolMgr := tool.NewManager(testLogger())
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, toolMgr, nil, testLogger())
+
+	ctx := context.Background()
+	text, err := engine.ChatWithEvents(ctx, adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-nudge",
+		UserID:     "user-1",
+		Text:       "Process",
+		Timestamp:  time.Now(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("ChatWithEvents: %v", err)
+	}
+	if text != "Recovered response." {
+		t.Fatalf("response = %q, want %q (nudge path not taken)", text, "Recovered response.")
+	}
+
+	msgs, err := store.GetMessages(ctx, "default:test:chat-nudge", 100)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	assistant := lastAssistant(t, msgs)
+	if assistant.TokensCached != 600 {
+		t.Errorf("TokensCached = %d, want 600 (100+200+300 incl. nudge)", assistant.TokensCached)
+	}
+}
+
+// TestChatWithEvents_UsageEventCarriesCachedTokens verifies the user-facing
+// "usage" ChatEvent (consumed by the web chat ticker) surfaces cached prompt
+// tokens accumulated across tool rounds, not just the total.
+func TestChatWithEvents_UsageEventCarriesCachedTokens(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				ToolCalls:    []llm.ToolCall{{ID: "c1", Type: "function", Function: llm.FunctionCall{Name: "skill_get", Arguments: `{"name":"a"}`}}},
+				TokensUsed:   llm.TokenUsage{CachedPrompt: 100, Total: 110},
+				FinishReason: "tool_calls",
+			},
+			{
+				Content:      "Done.",
+				TokensUsed:   llm.TokenUsage{CachedPrompt: 200, Total: 220},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+
+	toolMgr := tool.NewManager(testLogger())
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, toolMgr, nil, testLogger())
+
+	var usage *ChatEvent
+	collect := func(ev ChatEvent) {
+		if ev.Type == "usage" {
+			e := ev
+			usage = &e
+		}
+	}
+
+	if _, err := engine.ChatWithEvents(context.Background(), adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-usage",
+		UserID:     "user-1",
+		Text:       "Process",
+		Timestamp:  time.Now(),
+	}, collect); err != nil {
+		t.Fatalf("ChatWithEvents: %v", err)
+	}
+
+	if usage == nil {
+		t.Fatal("no usage event emitted")
+	}
+	if usage.TokensCached != 300 {
+		t.Errorf("usage event TokensCached = %d, want 300 (100+200)", usage.TokensCached)
+	}
+	if usage.Tokens != 330 {
+		t.Errorf("usage event Tokens = %d, want 330 (110+220)", usage.Tokens)
+	}
+}
+
+// lastAssistant returns the last stored assistant message, failing the test if
+// none is present.
+func lastAssistant(t *testing.T, msgs []StoredMessage) StoredMessage {
+	t.Helper()
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == "assistant" {
+			return msgs[i]
+		}
+	}
+	t.Fatal("no assistant message stored")
+	return StoredMessage{}
+}
+
+// sumAuditCachedTokens parses tokens_cached out of every llm.complete audit
+// event's JSON detail and returns their sum.
+func sumAuditCachedTokens(t *testing.T, events []audit.Event) int {
+	t.Helper()
+	total := 0
+	for _, ev := range events {
+		if ev.Category != audit.CategoryLLM {
+			continue
+		}
+		var detail map[string]any
+		if err := json.Unmarshal([]byte(ev.Detail), &detail); err != nil {
+			t.Fatalf("unmarshal audit detail %q: %v", ev.Detail, err)
+		}
+		if v, ok := detail["tokens_cached"].(float64); ok {
+			total += int(v)
+		}
+	}
+	return total
+}

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -740,6 +740,9 @@ func TestUpdateConversationStats_Incremental(t *testing.T) {
 	if stats.TotalPrompt != 300 || stats.TotalCompletion != 150 {
 		t.Errorf("prompt=%d completion=%d", stats.TotalPrompt, stats.TotalCompletion)
 	}
+	if stats.TotalCached != 10 {
+		t.Errorf("total_tokens_cached = %d, want 10 (10+0)", stats.TotalCached)
+	}
 }
 
 func TestUpdateConversationStats_PersistsAgent(t *testing.T) {
@@ -1235,6 +1238,34 @@ func TestGetTelemetrySummary(t *testing.T) {
 	}
 	if len(summary.BySkill) != 1 || summary.BySkill[0].SkillName != "greeting" {
 		t.Errorf("by_skill: %+v", summary.BySkill)
+	}
+}
+
+func TestGetTelemetrySummary_CachedTokensRollUp(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	_, _ = store.GetOrCreateConversation(ctx, "test", "1")
+	for _, cached := range []int{100, 200, 300} {
+		_, _ = store.AddMessage(ctx, "test:1", StoredMessage{
+			Role: "assistant", Content: "hi", Model: "kimi", Provider: "openrouter",
+			Cost: 0.01, TokensPrompt: 100, TokensCompletion: 50, TokensCached: cached,
+		})
+	}
+
+	summary, err := store.GetTelemetrySummary(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("GetTelemetrySummary: %v", err)
+	}
+	if len(summary.ByModel) != 1 {
+		t.Fatalf("by_model: %+v, want 1 model", summary.ByModel)
+	}
+	if summary.ByModel[0].TotalCached != 600 {
+		t.Errorf("by_model total_tokens_cached = %d, want 600 (100+200+300)", summary.ByModel[0].TotalCached)
 	}
 }
 

--- a/internal/llm/cost.go
+++ b/internal/llm/cost.go
@@ -24,6 +24,7 @@ type SessionStats struct {
 	Cost           float64        `json:"cost"`
 	InputTokens    int            `json:"input_tokens"`
 	OutputTokens   int            `json:"output_tokens"`
+	CachedTokens   int            `json:"cached_tokens"`
 	Messages       int            `json:"messages"`
 	PricingSources map[string]int `json:"pricing_sources,omitempty"`
 }
@@ -34,6 +35,7 @@ type AgentStats struct {
 	Cost         float64 `json:"cost"`
 	InputTokens  int     `json:"input_tokens"`
 	OutputTokens int     `json:"output_tokens"`
+	CachedTokens int     `json:"cached_tokens"`
 	Messages     int     `json:"messages"`
 	Sessions     int     `json:"sessions"`
 }
@@ -221,6 +223,7 @@ func (ct *CostTracker) AgentCosts() []AgentStats {
 		a.Cost += s.Cost
 		a.InputTokens += s.InputTokens
 		a.OutputTokens += s.OutputTokens
+		a.CachedTokens += s.CachedTokens
 		a.Messages += s.Messages
 		a.Sessions++
 	}
@@ -261,8 +264,12 @@ func (ct *CostTracker) ProviderLimits(provider string) SessionLimits {
 }
 
 // RecordWithProvider adds cost, token usage, and provider attribution for a session.
-// Returns true if within hard budget.
-func (ct *CostTracker) RecordWithProvider(sessionID, provider string, cost float64, inputTokens, outputTokens int, pricingSource string) bool {
+// Returns true if within hard budget. usage carries the full token breakdown;
+// its CachedPrompt is the cache-read portion of the prompt, reported separately
+// by providers (never included in Prompt). Taking TokenUsage whole (rather than
+// positional counts) means new token fields are threaded through without a
+// signature change on every call site.
+func (ct *CostTracker) RecordWithProvider(sessionID, provider string, cost float64, usage TokenUsage, pricingSource string) bool {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
 
@@ -275,8 +282,9 @@ func (ct *CostTracker) RecordWithProvider(sessionID, provider string, cost float
 
 	s := ct.getOrCreateStats(sessionID)
 	s.Cost += cost
-	s.InputTokens += inputTokens
-	s.OutputTokens += outputTokens
+	s.InputTokens += usage.Prompt
+	s.OutputTokens += usage.Completion
+	s.CachedTokens += usage.CachedPrompt
 	s.Messages++
 
 	if pricingSource != "" {

--- a/internal/llm/cost_test.go
+++ b/internal/llm/cost_test.go
@@ -350,8 +350,8 @@ func TestCostTracker_MaxBudgetPerSession_Deprecated(t *testing.T) {
 func TestCostTracker_RecordWithProvider_TracksProvider(t *testing.T) {
 	ct := NewCostTracker(SessionLimits{Hard: 10.0}, nil)
 
-	ct.RecordWithProvider("agent1:tg:1", "anthropic", 0.5, 100, 50, "registry")
-	ct.RecordWithProvider("agent1:tg:1", "anthropic", 0.3, 80, 40, "provider")
+	ct.RecordWithProvider("agent1:tg:1", "anthropic", 0.5, TokenUsage{Prompt: 100, Completion: 50, CachedPrompt: 20}, "registry")
+	ct.RecordWithProvider("agent1:tg:1", "anthropic", 0.3, TokenUsage{Prompt: 80, Completion: 40, CachedPrompt: 10}, "provider")
 
 	stats := ct.AllSessionStats()
 	s := stats["agent1:tg:1"]
@@ -360,6 +360,9 @@ func TestCostTracker_RecordWithProvider_TracksProvider(t *testing.T) {
 	}
 	if s.OutputTokens != 90 {
 		t.Errorf("output tokens = %d, want 90", s.OutputTokens)
+	}
+	if s.CachedTokens != 30 {
+		t.Errorf("cached tokens = %d, want 30", s.CachedTokens)
 	}
 	if s.Messages != 2 {
 		t.Errorf("messages = %d, want 2", s.Messages)
@@ -377,7 +380,7 @@ func TestCostTracker_ProviderLimits(t *testing.T) {
 	ct.SetProviderLimits("expensive-provider", SessionLimits{Soft: 5.0, Hard: 10.0})
 
 	// Session using the expensive provider should get higher limits.
-	ct.RecordWithProvider("agent:tg:1", "expensive-provider", 2.0, 100, 50, "registry")
+	ct.RecordWithProvider("agent:tg:1", "expensive-provider", 2.0, TokenUsage{Prompt: 100, Completion: 50}, "registry")
 	if ct.ExceedsSoftLimit("agent:tg:1") {
 		t.Error("expected NOT to exceed soft limit (provider limit=5.0, cost=2.0)")
 	}
@@ -385,7 +388,7 @@ func TestCostTracker_ProviderLimits(t *testing.T) {
 		t.Error("expected NOT to exceed hard limit (provider limit=10.0, cost=2.0)")
 	}
 
-	ct.RecordWithProvider("agent:tg:1", "expensive-provider", 4.0, 100, 50, "registry")
+	ct.RecordWithProvider("agent:tg:1", "expensive-provider", 4.0, TokenUsage{Prompt: 100, Completion: 50}, "registry")
 	if !ct.ExceedsSoftLimit("agent:tg:1") {
 		t.Error("expected to exceed soft limit (provider limit=5.0, cost=6.0)")
 	}
@@ -401,7 +404,7 @@ func TestCostTracker_AgentOverrideTakesPriorityOverProvider(t *testing.T) {
 	ct.SetProviderLimits("cheap-provider", SessionLimits{Hard: 5.0})
 
 	// Agent override (50.0) should win over provider limit (5.0).
-	ct.RecordWithProvider("premium:tg:1", "cheap-provider", 20.0, 100, 50, "registry")
+	ct.RecordWithProvider("premium:tg:1", "cheap-provider", 20.0, TokenUsage{Prompt: 100, Completion: 50}, "registry")
 	if ct.ExceedsHardLimit("premium:tg:1") {
 		t.Error("agent override (50.0) should take priority over provider limit (5.0)")
 	}
@@ -412,7 +415,7 @@ func TestCostTracker_ProviderLimits_FallsBackToDefault(t *testing.T) {
 	ct.SetProviderLimits("special", SessionLimits{Hard: 10.0})
 
 	// Session using a different provider should use default limits.
-	ct.RecordWithProvider("agent:tg:1", "other-provider", 2.0, 100, 50, "registry")
+	ct.RecordWithProvider("agent:tg:1", "other-provider", 2.0, TokenUsage{Prompt: 100, Completion: 50}, "registry")
 	if !ct.ExceedsHardLimit("agent:tg:1") {
 		t.Error("expected to exceed default hard limit (1.0) at cost 2.0")
 	}
@@ -422,7 +425,7 @@ func TestCostTracker_RecordWithProvider_EmptyProvider(t *testing.T) {
 	ct := NewCostTracker(SessionLimits{Hard: 1.0}, nil)
 
 	// Empty provider should not affect limit resolution.
-	ct.RecordWithProvider("agent:tg:1", "", 0.5, 100, 50, "registry")
+	ct.RecordWithProvider("agent:tg:1", "", 0.5, TokenUsage{Prompt: 100, Completion: 50}, "registry")
 	if ct.ExceedsHardLimit("agent:tg:1") {
 		t.Error("expected within default hard limit at cost 0.5")
 	}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -159,6 +159,17 @@ type TokenUsage struct {
 	Total        int
 }
 
+// Add accumulates u into t field-by-field. Keeping accumulation in one place
+// means new TokenUsage fields get summed by updating this method rather than
+// every hand-rolled call site (the omission of CachedPrompt from the tool-round
+// accumulator is exactly the bug this guards against).
+func (t *TokenUsage) Add(u TokenUsage) {
+	t.Prompt += u.Prompt
+	t.Completion += u.Completion
+	t.CachedPrompt += u.CachedPrompt
+	t.Total += u.Total
+}
+
 type ProviderMetadata struct {
 	Name    string
 	BaseURL string

--- a/internal/llm/provider_test.go
+++ b/internal/llm/provider_test.go
@@ -1,0 +1,22 @@
+package llm
+
+import "testing"
+
+func TestTokenUsageAdd_AllFields(t *testing.T) {
+	var total TokenUsage
+	total.Add(TokenUsage{Prompt: 10, Completion: 5, CachedPrompt: 100, Total: 15})
+	total.Add(TokenUsage{Prompt: 20, Completion: 8, CachedPrompt: 200, Total: 28})
+
+	if total.Prompt != 30 {
+		t.Errorf("Prompt = %d, want 30", total.Prompt)
+	}
+	if total.Completion != 13 {
+		t.Errorf("Completion = %d, want 13", total.Completion)
+	}
+	if total.CachedPrompt != 300 {
+		t.Errorf("CachedPrompt = %d, want 300", total.CachedPrompt)
+	}
+	if total.Total != 43 {
+		t.Errorf("Total = %d, want 43", total.Total)
+	}
+}

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -331,7 +331,7 @@ func (r *Router) completeInternal(ctx context.Context, sessionID string, message
 		cost, source := TokenCost(resp, r.pricing, activeProvider.Name())
 		r.recordOTelSuccess(start, resp, cost, source, attrs)
 		r.setSpanResponseAttrs(span, resp, cost)
-		r.costTracker.RecordWithProvider(sessionID, activeProvider.Name(), cost, resp.TokensUsed.Prompt, resp.TokensUsed.Completion, source)
+		r.costTracker.RecordWithProvider(sessionID, activeProvider.Name(), cost, resp.TokensUsed, source)
 		if source == "unknown" {
 			slog.Warn("no pricing data for model", "model", resp.Model)
 		}
@@ -359,7 +359,7 @@ func (r *Router) completeInternal(ctx context.Context, sessionID string, message
 	cost, source := TokenCost(resp, r.pricing, resolvedProvider)
 	r.recordOTelSuccess(start, resp, cost, source, attrs)
 	r.setSpanResponseAttrs(span, resp, cost)
-	r.costTracker.RecordWithProvider(sessionID, resolvedProvider, cost, resp.TokensUsed.Prompt, resp.TokensUsed.Completion, source)
+	r.costTracker.RecordWithProvider(sessionID, resolvedProvider, cost, resp.TokensUsed, source)
 	if source == "unknown" {
 		slog.Warn("no pricing data for model", "model", resp.Model)
 	}


### PR DESCRIPTION
## Problem

`Engine.executeToolRounds` accumulated per-round usage into a fresh `TokenUsage` and overwrote the final response's usage with it, but **never summed `CachedPrompt`**. Any turn that ran the accumulator — including 0-round (no-tool) turns — stored `TokensCached: 0` regardless of what the provider reported.

Everything downstream of the stored message inherited the zero: `messages.tokens_cached`, `conversation_stats.total_tokens_cached`, `GetTelemetrySummary`/session stats, the `GET /api/v1/telemetry/summary` and `/sessions/{id}/stats` REST surfaces, the `get_cost_summary`/`cost_summary` MCP tools, and the web Costs/Sessions pages. The audit path was unaffected (it reads `CachedPrompt` per round *before* accumulation) — which is exactly why per-round audit events showed ~23–29k cached tokens while the telemetry summary reported `0`.

## Fix

- **Add `TokenUsage.Add()`** (`internal/llm/provider.go`) that accumulates every field, and replace the three hand-rolled accumulation trios in `executeToolRounds` with it. New `TokenUsage` fields now get summed by updating one method — closing the "struct grew a field, hand-rolled accumulation didn't" class of bug.
- **Thread cached tokens through the cost tracker**: `RecordWithProvider` now takes `TokenUsage` whole (not positional counts), and `SessionStats`/`AgentStats` gain a `cached_tokens` field surfaced via the `cost_summary` MCP tool and session stats.
- **Add `TokensCached` to the `usage` `ChatEvent`** for the web chat ticker.

## Tests

- `TestTokenUsageAdd_AllFields` — every field accumulates.
- Engine accumulation across multi-round, single-round (the 0-round overwrite), and nudge-recovery paths, with Prompt/Completion/Total regression guards.
- **Cross-check invariant**: summed per-round audit `tokens_cached` equals the stored message's `TokensCached` — precisely the discrepancy that revealed the bug.
- Usage-event cached tokens; telemetry `by_model` and conversation-stats cached roll-up.

## Historical data

Rows written before this cutover permanently undercount `tokens_cached`. No backfill: the error is conservative (dashboards show *less* caching than reality) and self-heals within the 90-day telemetry retention window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)