### PR TITLE
fix(llm): treat abnormally terminated streams as failed rounds

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -1022,11 +1022,15 @@ func (e *Engine) chatWithApproval(ctx context.Context, msg adapter.IncomingMessa
 	responseText := sanitizeStaleDirectives(resp.Content, e.logger)
 	var pendingApproval *approval.Request
 
-	if responseText == "" {
+	// A blank (or whitespace-only) final turn is stored for history consistency
+	// but must not pass silently: surface it in the audit log as an error so a
+	// run that accomplished nothing is visible beyond slog.
+	if strings.TrimSpace(responseText) == "" {
 		e.logger.Warn("llm returned empty response",
 			"finish_reason", resp.FinishReason,
 			"conversation", convID,
 		)
+		e.emitLLMAudit(ctx, convID, resp, "LLM returned an empty final response", llmAuditOpts{round: 0})
 	}
 
 	// Use a background context for storing the assistant response so it
@@ -1122,8 +1126,13 @@ func wrapEventForPartialCapture(onEvent ChatEventFunc, buf *strings.Builder) Cha
 		return nil
 	}
 	return func(evt ChatEvent) {
-		if evt.Type == "content_delta" {
+		switch evt.Type {
+		case "content_delta":
 			buf.WriteString(evt.Text)
+		case "stream_rollback":
+			// A retry is replaying the stream; drop the captured partial text so
+			// interrupted-progress persistence doesn't store duplicated content.
+			buf.Reset()
 		}
 		onEvent(evt)
 	}
@@ -1193,6 +1202,12 @@ func streamCallbackFor(onEvent ChatEventFunc) llm.StreamCallback {
 		return nil
 	}
 	return func(chunk llm.StreamChunk) {
+		if chunk.Reset {
+			// The router is retrying a failed attempt; consumers must discard
+			// the deltas already streamed for this turn before the replay.
+			onEvent(ChatEvent{Type: "stream_rollback", Text: "Stream interrupted — retrying..."})
+			return
+		}
 		if chunk.ContentDelta != "" {
 			onEvent(ChatEvent{Type: "content_delta", Text: chunk.ContentDelta})
 		}
@@ -1217,7 +1232,12 @@ func (e *Engine) runLLMWithTools(ctx context.Context, convID string, perms *secu
 		e.emitLLMAudit(ctx, convID, nil, err.Error(), llmAuditOpts{round: 0})
 		return nil, llmMessages, nil, fmt.Errorf("LLM completion: %w", err)
 	}
-	e.emitLLMAudit(ctx, convID, resp, "", llmAuditOpts{round: 0})
+	// A truncated final skips the ok-status event: executeToolRounds' Layer-3
+	// guard emits the single error-status event for this round-trip instead of
+	// an "ok then error" pair.
+	if !isTruncatedFinal(resp) {
+		e.emitLLMAudit(ctx, convID, resp, "", llmAuditOpts{round: 0})
+	}
 
 	// Validate tool execution preconditions before entering the loop.
 	if resp.FinishReason == "tool_calls" && len(resp.ToolCalls) > 0 {
@@ -1283,23 +1303,13 @@ func (e *Engine) executeToolRounds(ctx context.Context, convID string, perms *se
 		}
 
 		var err error
-		resp, err = e.router.CompleteStream(ctx, convID, llmMessages, streamCallbackFor(onEvent))
+		resp, err = e.completeToolRound(ctx, convID, round+1, llmMessages, onEvent)
 		if err != nil {
-			e.emitLLMAudit(ctx, convID, nil, err.Error(), llmAuditOpts{round: round + 1})
-			return nil, llmMessages, toolRecords, fmt.Errorf("LLM completion (tool round %d): %w", round+1, err)
+			return nil, llmMessages, toolRecords, err
 		}
-		e.emitLLMAudit(ctx, convID, resp, "", llmAuditOpts{round: round + 1})
 
 		totalUsage.Add(resp.TokensUsed)
 		totalCost += resp.CostUSD
-
-		e.logger.Info("tool round complete",
-			"round", round+1,
-			"finish_reason", resp.FinishReason,
-			"content_len", len(resp.Content),
-			"tool_calls_next", len(resp.ToolCalls),
-			"tokens_total", resp.TokensUsed.Total,
-		)
 
 		if e.softCostLimitReached(convID, onEvent) {
 			break
@@ -1310,8 +1320,22 @@ func (e *Engine) executeToolRounds(ctx context.Context, convID string, perms *se
 		parentSpan.SetAttributes(attribute.Int("agent.tool_rounds", toolRounds))
 	}
 
-	// If the model returned empty content after tool rounds, try to recover.
-	if resp.Content == "" && toolRounds > 0 {
+	// Layer 3 (belt-and-braces): reject a final response that never received an
+	// explicit finish reason and carries no tool calls or visible content. For
+	// OAI-path providers Layer 1 (ErrStreamTruncated) already turns this into an
+	// error upstream, so this only fires for providers that bypass
+	// ReadOAIStream. A turn must complete on an explicit finish reason or
+	// non-empty content — never on a silently truncated stream.
+	if isTruncatedFinal(resp) {
+		e.emitLLMAudit(ctx, convID, resp, "truncated final response (no finish_reason)", llmAuditOpts{round: toolRounds})
+		return nil, llmMessages, toolRecords, fmt.Errorf("LLM returned truncated final response (no finish_reason): %w", llm.ErrStreamTruncated)
+	}
+
+	// If the model returned empty (or whitespace-only) content after tool
+	// rounds, try to recover. kimi-k2.6 routinely emits whitespace-only content
+	// (" ", "   ") alongside reasoning even on cleanly-finished streams, so the
+	// trim is required for recovery to fire.
+	if strings.TrimSpace(resp.Content) == "" && toolRounds > 0 {
 		var err error
 		resp, llmMessages, err = e.recoverEmptyToolResponse(ctx, convID, resp, llmMessages, accumulatedContent.String())
 		if err != nil {
@@ -1325,6 +1349,38 @@ func (e *Engine) executeToolRounds(ctx context.Context, convID string, perms *se
 	resp.TokensUsed = totalUsage
 	resp.CostUSD = totalCost
 	return resp, llmMessages, toolRecords, nil
+}
+
+// completeToolRound issues the follow-up completion after one round of tool
+// calls and emits its audit event. A truncated final skips the ok-status
+// event: the Layer-3 guard in executeToolRounds emits the single error-status
+// event for that round-trip instead of an "ok then error" pair.
+func (e *Engine) completeToolRound(ctx context.Context, convID string, round int, llmMessages []llm.Message, onEvent ChatEventFunc) (*llm.ChatResponse, error) {
+	resp, err := e.router.CompleteStream(ctx, convID, llmMessages, streamCallbackFor(onEvent))
+	if err != nil {
+		e.emitLLMAudit(ctx, convID, nil, err.Error(), llmAuditOpts{round: round})
+		return nil, fmt.Errorf("LLM completion (tool round %d): %w", round, err)
+	}
+	if !isTruncatedFinal(resp) {
+		e.emitLLMAudit(ctx, convID, resp, "", llmAuditOpts{round: round})
+	}
+
+	e.logger.Info("tool round complete",
+		"round", round,
+		"finish_reason", resp.FinishReason,
+		"content_len", len(resp.Content),
+		"tool_calls_next", len(resp.ToolCalls),
+		"tokens_total", resp.TokensUsed.Total,
+	)
+	return resp, nil
+}
+
+// isTruncatedFinal reports whether resp looks like a silently truncated final
+// turn: no explicit finish reason, no tool calls, and no visible content. Such
+// a response must be surfaced as an error rather than stored as a completed
+// turn (see Layer 3 in design/truncated-stream-failed-round.md).
+func isTruncatedFinal(resp *llm.ChatResponse) bool {
+	return resp.FinishReason == "" && len(resp.ToolCalls) == 0 && strings.TrimSpace(resp.Content) == ""
 }
 
 // softCostLimitReached checks the soft cost limit between tool rounds.
@@ -1404,7 +1460,7 @@ func recordToolRoundEvent(span trace.Span, round int, toolCalls []llm.ToolCall) 
 // content after tool rounds. It first checks for accumulated intermediate
 // content, then falls back to nudging the model for a response.
 func (e *Engine) recoverEmptyToolResponse(ctx context.Context, convID string, resp *llm.ChatResponse, llmMessages []llm.Message, accumulated string) (*llm.ChatResponse, []llm.Message, error) {
-	if accumulated != "" {
+	if strings.TrimSpace(accumulated) != "" {
 		e.logger.Info("using accumulated content from intermediate tool rounds",
 			"accumulated_len", len(accumulated))
 		resp.Content = accumulated

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -4742,6 +4743,234 @@ func TestExecuteToolRounds_NudgeRecoveryAccumulatesCachedTokens(t *testing.T) {
 	assistant := lastAssistant(t, msgs)
 	if assistant.TokensCached != 600 {
 		t.Errorf("TokensCached = %d, want 600 (100+200+300 incl. nudge)", assistant.TokensCached)
+	}
+}
+
+// TestExecuteToolRounds_WhitespaceFinalContentTriggersNudge verifies that a
+// final round which finishes cleanly ("stop") but with whitespace-only content
+// still triggers the nudge-retry recovery path (kimi-k2.6 emits " " content
+// alongside reasoning). Before the trim fix this passed through as the answer.
+func TestExecuteToolRounds_WhitespaceFinalContentTriggersNudge(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				// Tool call with no accompanying content, so nothing accumulates.
+				ToolCalls:    []llm.ToolCall{{ID: "c1", Type: "function", Function: llm.FunctionCall{Name: "skill_get", Arguments: `{"name":"a"}`}}},
+				TokensUsed:   llm.TokenUsage{Total: 10},
+				FinishReason: "tool_calls",
+			},
+			{
+				// Clean finish, but whitespace-only visible content.
+				Content:      "   ",
+				TokensUsed:   llm.TokenUsage{Total: 5},
+				FinishReason: "stop",
+			},
+			{
+				// Nudge recovery response.
+				Content:      "Here is the actual answer.",
+				TokensUsed:   llm.TokenUsage{Total: 8},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+
+	toolMgr := tool.NewManager(testLogger())
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, toolMgr, nil, testLogger())
+
+	ctx := context.Background()
+	text, err := engine.ChatWithEvents(ctx, adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-ws-nudge",
+		UserID:     "user-1",
+		Text:       "Process",
+		Timestamp:  time.Now(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("ChatWithEvents: %v", err)
+	}
+	if text != "Here is the actual answer." {
+		t.Fatalf("response = %q, want nudge recovery response (whitespace not treated as final)", text)
+	}
+}
+
+// TestExecuteToolRounds_TruncatedFinalErrors covers Layer 3: a final response
+// with no finish_reason, no tool calls, and blank content (a provider that
+// bypasses ReadOAIStream and silently truncates) must surface as an error, not
+// a clean completion. Interrupted progress is persisted and the audit trail
+// carries an error-status LLM event.
+func TestExecuteToolRounds_TruncatedFinalErrors(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				// Truncated: empty finish_reason, no content, no tool calls.
+				Content:      "",
+				TokensUsed:   llm.TokenUsage{Total: 0},
+				FinishReason: "",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+
+	auditor := &collectingAuditor{}
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, nil, nil, testLogger())
+	engine.SetAuditor(auditor)
+
+	ctx := context.Background()
+	_, err = engine.ChatWithEvents(ctx, adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-truncated",
+		UserID:     "user-1",
+		Text:       "Do the thing",
+		Timestamp:  time.Now(),
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for truncated final response, got nil")
+	}
+	if !errors.Is(err, llm.ErrStreamTruncated) {
+		t.Errorf("error = %v, want wrapped ErrStreamTruncated", err)
+	}
+
+	// Exactly one LLM audit event for the truncated round-trip: the error one.
+	// The ok-status event is suppressed when the Layer-3 guard fires, so the
+	// trail doesn't read "ok then error" for a single round.
+	var okCount, errCount int
+	for _, ev := range auditor.events {
+		if ev.Category != audit.CategoryLLM {
+			continue
+		}
+		switch ev.Status {
+		case audit.StatusOK:
+			okCount++
+		case audit.StatusError:
+			errCount++
+		}
+	}
+	if errCount != 1 {
+		t.Errorf("error-status LLM audit events = %d, want exactly 1", errCount)
+	}
+	if okCount != 0 {
+		t.Errorf("ok-status LLM audit events = %d, want 0 for a truncated round", okCount)
+	}
+
+	// Interrupted progress persisted: the user message is stored even though the
+	// turn failed (conversation history stays consistent).
+	msgs, err := store.GetMessages(ctx, "default:test:chat-truncated", 100)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Error("expected interrupted progress to persist at least the user message")
+	}
+}
+
+// TestRecoverEmptyToolResponse_WhitespaceAccumulatedFallsThroughToNudge verifies
+// that whitespace-only accumulated content is not reused as the answer; recovery
+// must fall through to the nudge retry instead.
+func TestRecoverEmptyToolResponse_WhitespaceAccumulatedFallsThroughToNudge(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				Content:      "Nudged answer.",
+				TokensUsed:   llm.TokenUsage{Total: 7},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	costTracker := llm.NewCostTracker(llm.SessionLimits{}, nil)
+	router := llm.NewRouter("mock", "test-model", costTracker)
+	router.RegisterProvider(provider)
+
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+	engine := NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, nil, nil, testLogger())
+
+	resp := &llm.ChatResponse{Content: "", FinishReason: "stop"}
+	llmMessages := []llm.Message{{Role: "user", Content: "hi"}}
+
+	got, _, err := engine.recoverEmptyToolResponse(context.Background(), "conv-1", resp, llmMessages, "   \n  ")
+	if err != nil {
+		t.Fatalf("recoverEmptyToolResponse: %v", err)
+	}
+	if got.Content != "Nudged answer." {
+		t.Errorf("content = %q, want nudge response (whitespace accumulated not reused)", got.Content)
+	}
+}
+
+// TestStreamCallbackFor_ResetEmitsRollback verifies a Reset stream chunk is
+// translated into a stream_rollback ChatEvent (and nothing else).
+func TestStreamCallbackFor_ResetEmitsRollback(t *testing.T) {
+	var events []ChatEvent
+	cb := streamCallbackFor(func(evt ChatEvent) { events = append(events, evt) })
+
+	cb(llm.StreamChunk{ContentDelta: "abc"})
+	cb(llm.StreamChunk{Reset: true})
+
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].Type != "content_delta" {
+		t.Errorf("first event type = %q, want content_delta", events[0].Type)
+	}
+	if events[1].Type != "stream_rollback" {
+		t.Errorf("second event type = %q, want stream_rollback", events[1].Type)
+	}
+}
+
+// TestWrapEventForPartialCapture_RollbackClearsBuffer verifies that a
+// stream_rollback event resets the partial-capture buffer so interrupted-
+// progress persistence doesn't store the failed attempt's deltas twice.
+func TestWrapEventForPartialCapture_RollbackClearsBuffer(t *testing.T) {
+	var buf strings.Builder
+	var forwarded []string
+	wrapped := wrapEventForPartialCapture(func(evt ChatEvent) { forwarded = append(forwarded, evt.Type) }, &buf)
+
+	wrapped(ChatEvent{Type: "content_delta", Text: "stale partial "})
+	wrapped(ChatEvent{Type: "stream_rollback"})
+	wrapped(ChatEvent{Type: "content_delta", Text: "replayed"})
+
+	if got := buf.String(); got != "replayed" {
+		t.Errorf("buffer = %q, want %q (rollback must clear captured partial)", got, "replayed")
+	}
+	if len(forwarded) != 3 {
+		t.Errorf("forwarded events = %d, want 3 (rollback still forwarded)", len(forwarded))
 	}
 }
 

--- a/internal/agent/engine_tool_outcome_test.go
+++ b/internal/agent/engine_tool_outcome_test.go
@@ -61,7 +61,10 @@ func newOutcomeTestEngine(t *testing.T) *Engine {
 
 	costTracker := llm.NewCostTracker(llm.SessionLimits{Hard: 10.0}, nil)
 	router := llm.NewRouter("mock", "test-model", costTracker)
-	router.RegisterProvider(&mockProvider{response: &llm.ChatResponse{}})
+	// Post-tool-round follow-up completions return a valid final response
+	// (explicit finish_reason) so the tool loop terminates cleanly rather than
+	// tripping the truncated-final guard.
+	router.RegisterProvider(&mockProvider{response: &llm.ChatResponse{Content: "done", FinishReason: "stop"}})
 
 	permissions, err := security.NewPermissionEngine("autonomous")
 	if err != nil {

--- a/internal/llm/oaistream.go
+++ b/internal/llm/oaistream.go
@@ -9,6 +9,11 @@ import (
 	"strings"
 )
 
+// ErrStreamTruncated indicates an SSE stream ended (EOF) before delivering a
+// terminal chunk (finish_reason). The response is partial and must not be
+// treated as a completed turn.
+var ErrStreamTruncated = errors.New("stream ended before completion (no finish_reason)")
+
 // OAIStreamResult holds the accumulated data from an OpenAI-compatible
 // streaming response. Providers call ReadOAIStream to parse the SSE body
 // and then convert this into an llm.ChatResponse.
@@ -190,6 +195,14 @@ func ReadOAIStream(body io.Reader, onStream StreamCallback, idle *StreamIdleConf
 			return nil, ErrStreamIdleTimeout
 		}
 		return nil, fmt.Errorf("reading SSE stream: %w", err)
+	}
+
+	// A stream that ends cleanly (EOF, no scanner error) but never delivered a
+	// finish_reason chunk is a truncated/premature close — the accumulated
+	// result is partial and must not be treated as a completed turn.
+	if acc.result.FinishReason == "" {
+		return nil, fmt.Errorf("%w (content=%dB reasoning=%dB tool_calls=%d)",
+			ErrStreamTruncated, acc.contentBuf.Len(), acc.reasoningBuf.Len(), len(acc.toolAccum))
 	}
 
 	return acc.finish(), nil

--- a/internal/llm/oaistream_test.go
+++ b/internal/llm/oaistream_test.go
@@ -224,3 +224,57 @@ func TestReadOAIStream_MalformedChunksSkipped(t *testing.T) {
 		t.Errorf("content = %q, want hi", result.Content)
 	}
 }
+
+func TestReadOAIStream_TruncatedStreamReturnsError(t *testing.T) {
+	// Content and reasoning deltas arrive, then the stream ends (EOF) before any
+	// finish_reason chunk — a premature upstream close. No [DONE] sentinel.
+	body := "data: {\"id\":\"1\",\"model\":\"kimi-k2.6\",\"choices\":[{\"delta\":{\"reasoning\":\"planning...\"},\"finish_reason\":null}]}\n\n" +
+		"data: {\"id\":\"1\",\"model\":\"kimi-k2.6\",\"choices\":[{\"delta\":{\"content\":\"   \"},\"finish_reason\":null}]}\n\n"
+	result, err := ReadOAIStream(strings.NewReader(body), nil, nil)
+	if err == nil {
+		t.Fatalf("expected error, got result: %+v", result)
+	}
+	if !errors.Is(err, ErrStreamTruncated) {
+		t.Errorf("error = %v, want ErrStreamTruncated", err)
+	}
+	if result != nil {
+		t.Errorf("result = %+v, want nil on truncation", result)
+	}
+}
+
+func TestReadOAIStream_CompleteStreamNoUsage(t *testing.T) {
+	// finish_reason present but no usage chunk (stream_options.include_usage off)
+	// — the guard must gate on finish_reason alone, not usage.
+	body := "data: {\"id\":\"1\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"done\"},\"finish_reason\":\"stop\"}]}\n\n"
+	result, err := ReadOAIStream(strings.NewReader(body), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want stop", result.FinishReason)
+	}
+	if result.Usage != nil {
+		t.Errorf("usage = %+v, want nil", result.Usage)
+	}
+	if result.Content != "done" {
+		t.Errorf("content = %q, want done", result.Content)
+	}
+}
+
+func TestReadOAIStream_ToolCallsFinish(t *testing.T) {
+	// Regression: a normal tool_calls finish is unaffected by the truncation guard.
+	body := sseBody(
+		`{"id":"1","model":"gpt-4o","choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc1","type":"function","function":{"name":"search","arguments":"{}"}}]},"finish_reason":null}]}`,
+		`{"id":"1","model":"gpt-4o","choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+	)
+	result, err := ReadOAIStream(strings.NewReader(body), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", result.FinishReason)
+	}
+	if len(result.ToolCalls) != 1 || result.ToolCalls[0].Function.Name != "search" {
+		t.Errorf("tool calls = %+v, want one search call", result.ToolCalls)
+	}
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -18,6 +18,10 @@ type Provider interface {
 type StreamChunk struct {
 	ContentDelta  string // incremental text content
 	ThinkingDelta string // incremental thinking/reasoning content
+	// Reset signals that a failed attempt is being retried and any deltas
+	// already delivered for this completion must be discarded — the retry
+	// replays the turn from the start. No other field is set alongside it.
+	Reset bool
 }
 
 // StreamCallback is invoked for each chunk during a streaming LLM call.
@@ -80,6 +84,13 @@ func (e *LLMError) Retryable() bool {
 // sticky-routing preferences should only be discarded for the former.
 func IsRetryable(err error) bool {
 	if errors.Is(err, ErrStreamIdleTimeout) {
+		return true
+	}
+	// A truncated stream (upstream cut before finish_reason) is worth retrying:
+	// a fallback provider — or a fresh upstream via sticky-routing reset — can
+	// complete the turn. The default "unknown → retryable" branch below already
+	// covers it, but the explicit check pins the behavior in tests.
+	if errors.Is(err, ErrStreamTruncated) {
 		return true
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -503,6 +503,14 @@ func (r *Router) executeFallbackAction(ctx context.Context, rule FallbackRule, a
 		}
 		return req
 	}
+	// resetStream tells the consumer to discard deltas already streamed by the
+	// failed attempt before the retry replays the turn. Emitted even when the
+	// next provider doesn't stream — the stale partial output must go either way.
+	resetStream := func() {
+		if onStream != nil {
+			onStream(StreamChunk{Reset: true})
+		}
+	}
 
 	switch rule.Action {
 	case "wait_and_retry":
@@ -510,6 +518,7 @@ func (r *Router) executeFallbackAction(ctx context.Context, rule FallbackRule, a
 		var callErr error
 		req := buildReq(activeProvider, activeModel)
 		retryErr := doWaitAndRetry(ctx, rule.MaxRetries, rule.Backoff, func() error {
+			resetStream()
 			resp, callErr = activeProvider.ChatCompletion(ctx, req)
 			return callErr
 		})
@@ -525,10 +534,12 @@ func (r *Router) executeFallbackAction(ctx context.Context, rule FallbackRule, a
 		if rule.Model != "" {
 			model = rule.Model
 		}
+		resetStream()
 		resp, err := fp.ChatCompletion(ctx, buildReq(fp, model))
 		return resp, fp.Name(), err
 
 	case "switch_model":
+		resetStream()
 		resp, err := activeProvider.ChatCompletion(ctx, buildReq(activeProvider, rule.Model))
 		return resp, activeProvider.Name(), err
 	}

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -968,6 +968,8 @@ func TestIsRetryable_ContextErrors(t *testing.T) {
 		{"wrapped canceled", fmt.Errorf("sending request: %w", context.Canceled), false},
 		{"wrapped deadline", fmt.Errorf("sending stream request: %w", context.DeadlineExceeded), false},
 		{"wrapped idle timeout", fmt.Errorf("reading stream: %w", ErrStreamIdleTimeout), true},
+		{"bare stream truncated", ErrStreamTruncated, true},
+		{"wrapped stream truncated", fmt.Errorf("LLM completion: %w", ErrStreamTruncated), true},
 		{"llm 503", &LLMError{StatusCode: 503, Message: "down"}, true},
 		{"llm 401", &LLMError{StatusCode: 401, Message: "unauthorized"}, false},
 		{"plain network error", errors.New("connection refused"), true},
@@ -1034,5 +1036,49 @@ func TestRouter_Fallback_IdleTimeoutStillTriggersFallback(t *testing.T) {
 	}
 	if resp.Content != "fallback ok" {
 		t.Errorf("content = %q, want fallback ok", resp.Content)
+	}
+}
+
+func TestRouter_TruncatedStreamUsesFallback(t *testing.T) {
+	ct := NewCostTracker(SessionLimits{Hard: 10.0}, nil)
+	r := NewRouter("primary", "model", ct)
+	r.RegisterProvider(&mockProvider{name: "primary", err: fmt.Errorf("LLM completion: %w", ErrStreamTruncated)})
+	r.RegisterProvider(&mockProvider{name: "fallback", response: &ChatResponse{Content: "fallback ok", TokensUsed: TokenUsage{Total: 5}}})
+	r.SetFallbacks([]FallbackRule{{Trigger: "error", Action: "switch_provider", Provider: "fallback"}})
+
+	resp, err := r.Complete(context.Background(), "s1", []Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "fallback ok" {
+		t.Errorf("content = %q, want fallback ok", resp.Content)
+	}
+}
+
+func TestRouter_FallbackEmitsStreamReset(t *testing.T) {
+	// A fallback retry must signal the stream consumer to discard the deltas
+	// already streamed by the failed attempt (one Reset chunk per attempt),
+	// even when the fallback provider itself does not stream.
+	ct := NewCostTracker(SessionLimits{Hard: 10.0}, nil)
+	r := NewRouter("primary", "model", ct)
+	r.RegisterProvider(&mockProvider{name: "primary", err: fmt.Errorf("LLM completion: %w", ErrStreamTruncated)})
+	r.RegisterProvider(&mockProvider{name: "fallback", response: &ChatResponse{Content: "fallback ok", TokensUsed: TokenUsage{Total: 5}}})
+	r.SetFallbacks([]FallbackRule{{Trigger: "error", Action: "switch_provider", Provider: "fallback"}})
+
+	var resets int
+	onStream := func(chunk StreamChunk) {
+		if chunk.Reset {
+			resets++
+		}
+	}
+	resp, err := r.CompleteStream(context.Background(), "s1", []Message{{Role: "user", Content: "hi"}}, onStream)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "fallback ok" {
+		t.Errorf("content = %q, want fallback ok", resp.Content)
+	}
+	if resets != 1 {
+		t.Errorf("reset chunks = %d, want 1 (one per fallback attempt)", resets)
 	}
 }

--- a/internal/llm/usererror.go
+++ b/internal/llm/usererror.go
@@ -16,6 +16,9 @@ func HTTPStatusForError(err error) int {
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrStreamIdleTimeout) {
 		return 504 // Gateway Timeout
 	}
+	if errors.Is(err, ErrStreamTruncated) {
+		return 502 // Bad Gateway: upstream cut the stream short
+	}
 
 	var llmErr *LLMError
 	if errors.As(err, &llmErr) {
@@ -39,6 +42,9 @@ func UserFacingError(err error) string {
 	}
 	if errors.Is(err, ErrStreamIdleTimeout) {
 		return "The LLM provider stopped responding. Please try again."
+	}
+	if errors.Is(err, ErrStreamTruncated) {
+		return "The LLM provider ended the response prematurely. Please try again."
 	}
 
 	var llmErr *LLMError

--- a/internal/llm/usererror_test.go
+++ b/internal/llm/usererror_test.go
@@ -56,6 +56,14 @@ func TestUserFacingError_StreamIdleTimeout(t *testing.T) {
 	}
 }
 
+func TestUserFacingError_StreamTruncated(t *testing.T) {
+	err := fmt.Errorf("LLM completion: %w", ErrStreamTruncated)
+	got := UserFacingError(err)
+	if !strings.Contains(got, "prematurely") {
+		t.Errorf("UserFacingError(ErrStreamTruncated) = %q, want substring %q", got, "prematurely")
+	}
+}
+
 func TestHTTPStatusForError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -65,6 +73,7 @@ func TestHTTPStatusForError(t *testing.T) {
 		{"canceled", context.Canceled, 499},
 		{"deadline exceeded", context.DeadlineExceeded, 504},
 		{"stream idle timeout", ErrStreamIdleTimeout, 504},
+		{"stream truncated", ErrStreamTruncated, 502},
 		{"429 rate limit", &LLMError{StatusCode: 429, Message: "slow down"}, 429},
 		{"401 auth", &LLMError{StatusCode: 401, Message: "bad key"}, 502},
 		{"402 credits", &LLMError{StatusCode: 402, Message: "no credits"}, 502},

--- a/web/src/__tests__/chatStore.test.js
+++ b/web/src/__tests__/chatStore.test.js
@@ -158,6 +158,21 @@ describe('sendMessage', () => {
 })
 
 describe('handleToolEvent via SSE path', () => {
+  test('stream_rollback discards partial deltas before the retry replays', async () => {
+    mockStreamChat.mockImplementation(async (agent, sid, msg, onChunk, onDone, onToolEvent) => {
+      onToolEvent({ type: 'content_delta', text: 'partial from failed attempt' })
+      onToolEvent({ type: 'thinking_delta', text: 'stale reasoning' })
+      onToolEvent({ type: 'stream_rollback', text: 'Stream interrupted — retrying...' })
+      onToolEvent({ type: 'content_delta', text: 'replayed answer' })
+      onDone('sess-1')
+    })
+
+    await sendMessage('hello')
+    const agentMsg = get(chatState).messages[1]
+    expect(agentMsg.text).toBe('replayed answer')
+    expect(agentMsg.thinking).toBe('')
+  })
+
   test('tool_start adds to toolCalls array', async () => {
     mockStreamChat.mockImplementation(async (agent, sid, msg, onChunk, onDone, onToolEvent) => {
       onToolEvent({ type: 'tool_start', tool: 'web_search', round: 1 })

--- a/web/src/chatStore.js
+++ b/web/src/chatStore.js
@@ -142,6 +142,15 @@ function handleToolEvent(agentMsg, evt) {
     touchMessagesThrottled()
     return
   }
+  if (evt.type === 'stream_rollback') {
+    // A provider retry is replaying the stream — discard the partial deltas
+    // from the failed attempt so the replay doesn't render duplicated text.
+    agentMsg.text = ''
+    agentMsg.thinking = ''
+    agentMsg.status = evt.text || 'Retrying...'
+    touchMessages()
+    return
+  }
   if (evt.type === 'thinking') {
     agentMsg.status = evt.text || 'Thinking...'
     touchMessages()


### PR DESCRIPTION
## Summary

A scheduled skill run silently accomplished nothing: the upstream provider cut the SSE stream mid-generation, `ReadOAIStream` treated the EOF as success, and the engine stored a whitespace-only final turn as a clean completion — every audit event read `ok`. This PR makes truncated streams loud, per `design/truncated-stream-failed-round.md`:

- **Layer 1 (provider):** `ReadOAIStream` now returns `ErrStreamTruncated` when a stream ends without a `finish_reason` chunk. The error is retryable (enters the router fallback chain, resets OpenRouter sticky routing), maps to HTTP 502, and has a user-facing message.
- **Layer 2 (engine recovery):** empty-response recovery trims whitespace, catching models (e.g. kimi-k2.6) that emit whitespace-only content alongside reasoning; whitespace-only accumulated content falls through to the nudge retry; blank final turns emit an error-status audit event instead of only a slog warning.
- **Layer 3 (engine invariant):** a final response with no `finish_reason`, no tool calls, and blank content is rejected as an error — belt-and-braces for providers that bypass `ReadOAIStream` (e.g. Anthropic native).

Review follow-ups included:

- A truncated round now emits exactly **one** error-status LLM audit event, not an "ok then error" pair (ok emit suppressed when the Layer-3 guard fires; per-round completion extracted into `completeToolRound` for gocyclo).
- Router fallback retries emit a `StreamChunk.Reset` signal → `stream_rollback` ChatEvent, so the engine's partial-capture buffer and the web chat discard the failed attempt's streamed deltas instead of rendering/persisting them twice.

## Behavior change

An interactively-observed truncated stream now surfaces as an error message ("The LLM provider ended the response prematurely. Please try again.") instead of a silent blank reply, unless a fallback rule completes the turn.

## Test plan

- [x] `just hook` green (fmt-check, vet, lint, lint-ui, test with `-race`, test-ui)
- [x] New tests: truncated-stream error + complete-stream-without-usage + tool-calls-finish regression (`oaistream_test.go`), retryability + fallback + one-reset-per-attempt (`router_test.go`), 502 mapping (`usererror_test.go`), whitespace nudge recovery + truncated-final error/audit + rollback buffer clear (`engine_test.go`), rollback delta discard (`chatStore.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bqDeZqgo9mh85RFZXfVQn