### PR TITLE
feat(web): group schedules by agent with inline toggles and filter chips

### DIFF
--- a/web/src/__tests__/agentColor.test.js
+++ b/web/src/__tests__/agentColor.test.js
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest'
+import { agentColor } from '../agentColor.js'
+
+describe('agentColor', () => {
+  test('is deterministic for the same name', () => {
+    expect(agentColor('default')).toBe(agentColor('default'))
+    expect(agentColor('argus')).toBe(agentColor('argus'))
+  })
+
+  test('returns an hsl color string', () => {
+    expect(agentColor('default')).toMatch(/^hsl\(\d+ 55% 45%\)$/)
+  })
+
+  test('distinct names produce distinct hues', () => {
+    const colors = new Set(['default', 'argus', 'helper', 'reviewer'].map(agentColor))
+    expect(colors.size).toBe(4)
+  })
+
+  test('handles empty and missing input without throwing', () => {
+    expect(agentColor('')).toMatch(/^hsl\(/)
+    expect(agentColor(undefined)).toMatch(/^hsl\(/)
+  })
+})

--- a/web/src/__tests__/api.test.js
+++ b/web/src/__tests__/api.test.js
@@ -541,7 +541,7 @@ describe('API method smoke tests', () => {
   test('schedules() returns schedule list', async () => {
     token.set('key')
     const result = await api.schedules()
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
     expect(result[0].name).toBe('daily-check')
   })
 

--- a/web/src/__tests__/pages/Schedules.mobile.test.js
+++ b/web/src/__tests__/pages/Schedules.mobile.test.js
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/svelte'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/server.js'
+import { token, authMode } from '../../store.js'
+import Schedules from '../../pages/Schedules.svelte'
+
+// Force the mobile layout: isMobile is a matchMedia-backed singleton created at
+// module load, so the branch can only be exercised via a module mock.
+vi.mock('../../store.js', async (importOriginal) => {
+  const mod = await importOriginal()
+  const { readable } = await import('svelte/store')
+  return { ...mod, isMobile: readable(true) }
+})
+
+beforeEach(() => {
+  token.set('test-key')
+  authMode.set('token')
+})
+
+const rows = [
+  {
+    name: 'daily-check', expression: '0 9 * * *', skill: 'report', agent: 'default',
+    channel: 'telegram:123', enabled: true,
+    last_run: '2026-01-01T09:00:00Z', next_run: '2099-01-02T09:00:00Z',
+  },
+  { name: 'paused-job', expression: '@hourly', agent: 'default', channel: 'telegram:123', enabled: false },
+]
+
+function useSchedules(list = rows) {
+  server.use(http.get('/api/v1/schedules', () => HttpResponse.json(list)))
+}
+
+describe('Schedules page (mobile)', () => {
+  test('renders card cells instead of a table', async () => {
+    useSchedules()
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-daily-check')).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    const cell = screen.getByTestId('schedule-row-daily-check')
+    expect(within(cell).getByText('0 9 * * *')).toBeInTheDocument()
+    expect(within(cell).getByText('skill: report')).toBeInTheDocument()
+    expect(within(cell).getByLabelText('Toggle daily-check')).toBeChecked()
+    // Channel and last-run are desktop-only columns; edit panel still has them.
+    expect(within(cell).queryByText('telegram:123')).not.toBeInTheDocument()
+  })
+
+  test('section header shows a numeric count', async () => {
+    useSchedules()
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-section-default')).toBeInTheDocument()
+    })
+    const header = screen.getByTestId('agent-section-default').querySelector('.section-header')
+    expect(header.textContent).not.toContain('schedules')
+    expect(header.textContent).toContain('2')
+  })
+
+  test('paused cell shows Paused and the paused class', async () => {
+    useSchedules()
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-paused-job')).toBeInTheDocument()
+    })
+    const cell = screen.getByTestId('schedule-row-paused-job')
+    expect(cell).toHaveClass('paused')
+    expect(within(cell).getByText('Paused')).toBeInTheDocument()
+    expect(within(cell).getByLabelText('Toggle paused-job')).not.toBeChecked()
+  })
+
+  test('kebab Edit opens the form prefilled', async () => {
+    useSchedules()
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-daily-check')).toBeInTheDocument()
+    })
+    const cell = screen.getByTestId('schedule-row-daily-check')
+    await fireEvent.click(within(cell).getByTitle('More actions'))
+    await fireEvent.click(within(cell).getByText('Edit'))
+    await waitFor(() => {
+      expect(screen.getByText('Edit Schedule')).toBeInTheDocument()
+    })
+    expect(screen.getByPlaceholderText('e.g. daily-report')).toHaveValue('daily-check')
+  })
+
+  test('kebab Delete opens the confirm modal', async () => {
+    useSchedules()
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-daily-check')).toBeInTheDocument()
+    })
+    const cell = screen.getByTestId('schedule-row-daily-check')
+    await fireEvent.click(within(cell).getByTitle('More actions'))
+    await fireEvent.click(within(cell).getByText('Delete'))
+    await waitFor(() => {
+      expect(screen.getByTestId('delete-confirm')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('delete-confirm').textContent).toContain('daily-check')
+  })
+
+  test('toggle sends a partial enabled PATCH from a card cell', async () => {
+    let patchBody = null
+    useSchedules()
+    server.use(
+      http.patch('/api/v1/schedules/daily-check', async ({ request }) => {
+        patchBody = await request.json()
+        return HttpResponse.json({ status: 'ok' })
+      })
+    )
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-daily-check')).toBeInTheDocument()
+    })
+    await fireEvent.click(screen.getByLabelText('Toggle daily-check'))
+    await waitFor(() => {
+      expect(patchBody).toEqual({ enabled: false })
+    })
+  })
+
+  test('opening edit scrolls the inline panel into view', async () => {
+    // jsdom has no scrollIntoView; the component guards with ?. so a stub is enough.
+    const scrollSpy = vi.fn()
+    Element.prototype.scrollIntoView = scrollSpy
+    useSchedules()
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-daily-check')).toBeInTheDocument()
+    })
+    const cell = screen.getByTestId('schedule-row-daily-check')
+    await fireEvent.click(within(cell).getByTitle('More actions'))
+    await fireEvent.click(within(cell).getByText('Edit'))
+    await waitFor(() => {
+      expect(scrollSpy).toHaveBeenCalled()
+    })
+    delete Element.prototype.scrollIntoView
+  })
+
+  test('add button renders as a compact FAB', async () => {
+    render(Schedules)
+    const btn = screen.getByTestId('add-schedule-btn')
+    expect(btn).toHaveTextContent('+')
+    expect(btn).not.toHaveTextContent('Add Schedule')
+    expect(btn).toHaveClass('mobile-fab')
+    expect(btn).toHaveAccessibleName('Add schedule')
+  })
+})

--- a/web/src/__tests__/pages/Schedules.test.js
+++ b/web/src/__tests__/pages/Schedules.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/svelte'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/svelte'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../test/server.js'
 import { token, authMode } from '../../store.js'
@@ -17,11 +17,11 @@ describe('Schedules page', () => {
     expect(screen.getByText('+ Add Schedule')).toBeInTheDocument()
   })
 
-  test('renders schedule table with data', async () => {
+  test('renders grouped schedule table with data', async () => {
     server.use(
       http.get('/api/v1/schedules', () =>
         HttpResponse.json([
-          { name: 'daily-check', expression: '0 9 * * *', skill: 'report', channel: 'telegram:123', enabled: true },
+          { name: 'daily-check', expression: '0 9 * * *', skill: 'report', agent: 'default', channel: 'telegram:123', enabled: true },
         ])
       )
     )
@@ -30,8 +30,90 @@ describe('Schedules page', () => {
     await waitFor(() => {
       expect(screen.getByText('daily-check')).toBeInTheDocument()
       expect(screen.getByText('0 9 * * *')).toBeInTheDocument()
-      expect(screen.getByText('yes')).toBeInTheDocument()
+      expect(screen.getByText('skill: report')).toBeInTheDocument()
     })
+    expect(screen.getByTestId('agent-section-default')).toBeInTheDocument()
+    expect(screen.getByLabelText('Toggle daily-check')).toBeChecked()
+  })
+
+  test('groups schedules into one section per agent, no Agent column', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+          { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
+        ])
+      )
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-section-alice')).toBeInTheDocument()
+      expect(screen.getByTestId('agent-section-bob')).toBeInTheDocument()
+    })
+    expect(within(screen.getByTestId('agent-section-alice')).getByText('alice-job')).toBeInTheDocument()
+    expect(within(screen.getByTestId('agent-section-bob')).getByText('bob-job')).toBeInTheDocument()
+    expect(within(screen.getByTestId('agent-section-alice')).getByText('1 schedule')).toBeInTheDocument()
+    // Agent ownership lives in section headers now — no Agent table column.
+    expect(screen.queryByRole('columnheader', { name: 'Agent' })).not.toBeInTheDocument()
+  })
+
+  test('section header shows the agent tier badge from the agents list', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+        ])
+      ),
+      http.get('/api/v1/agents', () =>
+        HttpResponse.json([{ name: 'alice', permission_tier: 'supervised' }])
+      )
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-section-alice')).toBeInTheDocument()
+    })
+    const header = screen.getByTestId('agent-section-alice').querySelector('.section-header')
+    expect(header.textContent).toContain('supervised')
+  })
+
+  test('sections render without tier badges when agents fail to load', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+        ])
+      ),
+      http.get('/api/v1/agents', () =>
+        HttpResponse.json({ error: 'forbidden' }, { status: 403 })
+      )
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-section-alice')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('agent-section-alice').querySelector('.tier-badge')).toBeNull()
+  })
+
+  test('row shows a tier badge only for a session_tier override', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'plain', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+          { name: 'override', expression: '@daily', agent: 'alice', channel: 'telegram:1', session_tier: 'restricted', enabled: true },
+        ])
+      ),
+      http.get('/api/v1/agents', () => HttpResponse.json([]))
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-override')).toBeInTheDocument()
+    })
+    expect(within(screen.getByTestId('schedule-row-override')).getByText('restricted')).toBeInTheDocument()
+    expect(screen.getByTestId('schedule-row-plain').querySelector('.tier-badge')).toBeNull()
   })
 
   test('shows empty state when no schedules', async () => {
@@ -59,18 +141,15 @@ describe('Schedules page', () => {
     })
   })
 
-  test('agent filter refetches the list scoped to one agent via the API', async () => {
-    const all = [
-      { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
-      { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
-    ]
-    let lastAgentParam = '__unset__'
+  test('agent chips filter sections client-side without a refetch', async () => {
+    let getCount = 0
     server.use(
-      // Mirror the backend: honour the ?agent= query parameter.
-      http.get('/api/v1/schedules', ({ request }) => {
-        const agent = new URL(request.url).searchParams.get('agent')
-        lastAgentParam = agent
-        return HttpResponse.json(agent ? all.filter(s => s.agent === agent) : all)
+      http.get('/api/v1/schedules', () => {
+        getCount++
+        return HttpResponse.json([
+          { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+          { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
+        ])
       })
     )
 
@@ -79,50 +158,40 @@ describe('Schedules page', () => {
       expect(screen.getByText('alice-job')).toBeInTheDocument()
       expect(screen.getByText('bob-job')).toBeInTheDocument()
     })
+    expect(getCount).toBe(1)
 
-    // Filter dropdown appears because there is more than one owning agent.
-    const filter = screen.getByTestId('agent-filter')
-    await fireEvent.change(filter, { target: { value: 'alice' } })
-
+    await fireEvent.click(screen.getByTestId('agent-chip-alice'))
     await waitFor(() => {
       expect(screen.getByText('alice-job')).toBeInTheDocument()
       expect(screen.queryByText('bob-job')).not.toBeInTheDocument()
     })
-    // The narrowing came from a server round-trip carrying ?agent=alice.
-    expect(lastAgentParam).toBe('alice')
 
-    // Switching back to "All agents" refetches without the filter.
-    await fireEvent.change(filter, { target: { value: '' } })
+    await fireEvent.click(screen.getByText(/All agents/))
     await waitFor(() => {
       expect(screen.getByText('bob-job')).toBeInTheDocument()
     })
-    expect(lastAgentParam).toBeNull()
+    // Narrowing never went back to the server.
+    expect(getCount).toBe(1)
   })
 
-  test('filter control survives an empty filtered result', async () => {
-    const all = [
-      { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
-      { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
-    ]
+  test('chips show per-agent schedule counts', async () => {
     server.use(
-      http.get('/api/v1/schedules', ({ request }) => {
-        const agent = new URL(request.url).searchParams.get('agent')
-        // Simulate an agent with no schedules.
-        return HttpResponse.json(agent === 'alice' ? [] : all)
-      })
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+          { name: 'alice-job-2', expression: '@hourly', agent: 'alice', channel: 'telegram:1', enabled: true },
+          { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
+        ])
+      )
     )
 
     render(Schedules)
-    await waitFor(() => expect(screen.getByText('bob-job')).toBeInTheDocument())
-
-    const filter = screen.getByTestId('agent-filter')
-    await fireEvent.change(filter, { target: { value: 'alice' } })
-
     await waitFor(() => {
-      expect(screen.getByText(/No schedules for alice/)).toBeInTheDocument()
+      expect(screen.getByTestId('agent-filter')).toBeInTheDocument()
     })
-    // The filter dropdown must remain so the user can recover.
-    expect(screen.getByTestId('agent-filter')).toBeInTheDocument()
+    expect(screen.getByText('All agents (3)')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-chip-alice').textContent).toContain('alice (2)')
+    expect(screen.getByTestId('agent-chip-bob').textContent).toContain('bob (1)')
   })
 
   test('no agent filter shown for a single-agent list', async () => {
@@ -141,6 +210,54 @@ describe('Schedules page', () => {
     expect(screen.queryByTestId('agent-filter')).not.toBeInTheDocument()
   })
 
+  test('toggle PATCHes enabled and reflects the refetched state', async () => {
+    let patchBody = null
+    let toggled = false
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'daily-check', expression: '0 9 * * *', agent: 'default', channel: 'telegram:123', enabled: !toggled },
+        ])
+      ),
+      http.patch('/api/v1/schedules/:name', async ({ request }) => {
+        patchBody = await request.json()
+        toggled = true
+        return HttpResponse.json({ ok: true })
+      })
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByLabelText('Toggle daily-check')).toBeChecked()
+    })
+
+    await fireEvent.click(screen.getByLabelText('Toggle daily-check'))
+    await waitFor(() => {
+      expect(patchBody).toEqual({ enabled: false })
+      expect(screen.getByLabelText('Toggle daily-check')).not.toBeChecked()
+    })
+  })
+
+  test('disabled schedule renders paused and dimmed, missing last run as Never', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'sleepy', expression: '@daily', agent: 'default', channel: 'telegram:1', enabled: false },
+        ])
+      )
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('schedule-row-sleepy')).toBeInTheDocument()
+    })
+    const row = screen.getByTestId('schedule-row-sleepy')
+    expect(row.classList.contains('paused')).toBe(true)
+    expect(within(row).getByText('Paused')).toBeInTheDocument()
+    expect(within(row).getByText('Never')).toBeInTheDocument()
+    expect(screen.getByLabelText('Toggle sleepy')).not.toBeChecked()
+  })
+
   test('edit button opens pre-filled form', async () => {
     server.use(
       http.get('/api/v1/schedules', () =>
@@ -152,10 +269,10 @@ describe('Schedules page', () => {
 
     render(Schedules)
     await waitFor(() => {
-      expect(screen.getByText('Edit')).toBeInTheDocument()
+      expect(screen.getByLabelText('Edit daily-check')).toBeInTheDocument()
     })
 
-    await fireEvent.click(screen.getByText('Edit'))
+    await fireEvent.click(screen.getByLabelText('Edit daily-check'))
     await waitFor(() => {
       expect(screen.getByText('Edit Schedule')).toBeInTheDocument()
     })
@@ -172,13 +289,10 @@ describe('Schedules page', () => {
 
     render(Schedules)
     await waitFor(() => {
-      // Find the delete button in the actions column
-      const deleteBtn = document.querySelector('.btn-sm.danger')
-      expect(deleteBtn).toBeInTheDocument()
+      expect(screen.getByLabelText('Delete daily-check')).toBeInTheDocument()
     })
 
-    const deleteBtn = document.querySelector('.btn-sm.danger')
-    await fireEvent.click(deleteBtn)
+    await fireEvent.click(screen.getByLabelText('Delete daily-check'))
     await waitFor(() => {
       expect(screen.getByText('Delete Schedule')).toBeInTheDocument()
     })
@@ -303,10 +417,10 @@ describe('Schedules page', () => {
 
     render(Schedules)
     await waitFor(() => {
-      expect(screen.getByText('Edit')).toBeInTheDocument()
+      expect(screen.getByLabelText('Edit sched-known')).toBeInTheDocument()
     })
 
-    await fireEvent.click(screen.getByText('Edit'))
+    await fireEvent.click(screen.getByLabelText('Edit sched-known'))
     await waitFor(() => {
       expect(screen.getByText('Edit Schedule')).toBeInTheDocument()
     })

--- a/web/src/__tests__/relativeTime.test.js
+++ b/web/src/__tests__/relativeTime.test.js
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest'
+import { relativeTime, shortAbsolute } from '../relativeTime.js'
+
+// Fixed reference point, built in local time so day boundaries are stable
+// regardless of the runner's timezone.
+const NOW = new Date(2026, 0, 15, 12, 0, 0).getTime()
+const at = (...args) => new Date(...args).toISOString()
+
+describe('relativeTime', () => {
+  test('returns empty string for falsy or invalid input', () => {
+    expect(relativeTime(null, NOW)).toBe('')
+    expect(relativeTime('', NOW)).toBe('')
+    expect(relativeTime('not-a-date', NOW)).toBe('')
+  })
+
+  test('past tiers: seconds, minutes, hours, days', () => {
+    expect(relativeTime(NOW - 30 * 1000, NOW)).toBe('30s ago')
+    expect(relativeTime(NOW - 45 * 60 * 1000, NOW)).toBe('45m ago')
+    expect(relativeTime(NOW - 2 * 3600 * 1000, NOW)).toBe('2h ago')
+    expect(relativeTime(NOW - 3 * 86400 * 1000, NOW)).toBe('3d ago')
+  })
+
+  test('future tiers include a second unit for hours and days', () => {
+    expect(relativeTime(NOW + 45 * 60 * 1000, NOW)).toBe('in 45m')
+    expect(relativeTime(NOW + (2 * 3600 + 15 * 60) * 1000, NOW)).toBe('in 2h 15m')
+    expect(relativeTime(NOW + 2 * 3600 * 1000, NOW)).toBe('in 2h')
+    expect(relativeTime(NOW + (3 * 86400 + 4 * 3600) * 1000, NOW)).toBe('in 3d 4h')
+    expect(relativeTime(NOW + 3 * 86400 * 1000, NOW)).toBe('in 3d')
+  })
+})
+
+describe('shortAbsolute', () => {
+  test('returns empty string for falsy or invalid input', () => {
+    expect(shortAbsolute(null, NOW)).toBe('')
+    expect(shortAbsolute('not-a-date', NOW)).toBe('')
+  })
+
+  test('same day renders as today', () => {
+    expect(shortAbsolute(at(2026, 0, 15, 14, 30), NOW)).toBe('today 14:30')
+  })
+
+  test('next day renders as tomorrow', () => {
+    expect(shortAbsolute(at(2026, 0, 16, 8, 0), NOW)).toBe('tomorrow 08:00')
+  })
+
+  test('previous day renders as yesterday', () => {
+    expect(shortAbsolute(at(2026, 0, 14, 18, 5), NOW)).toBe('yesterday 18:05')
+  })
+
+  test('other days render as short date plus time', () => {
+    expect(shortAbsolute(at(2026, 2, 5, 9, 0), NOW)).toBe('Mar 5 09:00')
+  })
+})

--- a/web/src/agentColor.js
+++ b/web/src/agentColor.js
@@ -1,0 +1,9 @@
+// Stable per-agent identity color. Hashes the agent name to a hue so the
+// same agent always renders the same color across pages and sessions.
+// Fixed mid-range saturation/lightness reads on both light and dark themes.
+export function agentColor(name) {
+  let h = 0
+  const s = name || ''
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0
+  return `hsl(${h % 360} 55% 45%)`
+}

--- a/web/src/pages/Schedules.svelte
+++ b/web/src/pages/Schedules.svelte
@@ -1,7 +1,9 @@
 <script>
-  import { onMount } from 'svelte'
+  import { onMount, tick } from 'svelte'
   import { api } from '../api.js'
+  import { isMobile } from '../store.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
+  import KebabMenu from '../components/KebabMenu.svelte'
   import { agentColor } from '../agentColor.js'
   import { relativeTime, shortAbsolute } from '../relativeTime.js'
 
@@ -43,6 +45,15 @@
 
   // In-flight enable/disable toggle (schedule name)
   let togglingName = $state(null)
+
+  let panelEl = $state(null)
+
+  // The inline panel sits above the sections; on mobile, opening it from a
+  // card deep in the list would otherwise expand off-screen with no feedback.
+  function revealForm() {
+    showForm = true
+    if ($isMobile) tick().then(() => panelEl?.scrollIntoView?.({ behavior: 'smooth', block: 'start' }))
+  }
 
   const tierByAgent = $derived(new Map(agents.map(a => [a.name, a.permission_tier])))
 
@@ -127,7 +138,7 @@
     formAgentCustom = ''
     formTags = ''
     formEnabled = true
-    showForm = true
+    revealForm()
   }
 
   function openEdit(s) {
@@ -145,7 +156,7 @@
     formAgentCustom = formAgent === '__custom__' ? (s.agent || '') : ''
     formTags = (s.tags || []).join(', ')
     formEnabled = s.enabled
-    showForm = true
+    revealForm()
   }
 
   function closeForm() {
@@ -213,7 +224,8 @@
 <div class="page">
   <div class="page-header">
     <h1 class="page-title">Schedules</h1>
-    <button class="btn-primary" onclick={openAdd} data-testid="add-schedule-btn">+ Add Schedule</button>
+    <button class="btn-primary" class:mobile-fab={$isMobile} onclick={openAdd}
+      data-testid="add-schedule-btn" aria-label="Add schedule">{$isMobile ? '+' : '+ Add Schedule'}</button>
   </div>
 
   <p class="tz-note">Cron schedules run in <strong>{timezone}</strong> time. <a href="#/server">Change</a></p>
@@ -225,7 +237,7 @@
   {/if}
 
   <!-- Inline Add/Edit Panel -->
-  <div class="inline-panel" class:open={showForm}>
+  <div class="inline-panel" class:open={showForm} bind:this={panelEl}>
     <div class="inline-panel-inner">
       <div class="inline-form" data-testid="schedule-form">
         <h2 class="form-title">{editingName ? 'Edit Schedule' : 'Add Schedule'}</h2>
@@ -329,8 +341,43 @@
           {#if g.tier}
             <span class="tier-badge tier-{g.tier}">{g.tier}</span>
           {/if}
-          <span class="count">{g.schedules.length} schedule{g.schedules.length === 1 ? '' : 's'}</span>
+          <span class="count">{$isMobile ? g.schedules.length : `${g.schedules.length} schedule${g.schedules.length === 1 ? '' : 's'}`}</span>
         </header>
+        {#if $isMobile}
+          <ul class="cell-list">
+            {#each g.schedules as s (s.name)}
+              <li class="cell" class:paused={!s.enabled} data-testid="schedule-row-{s.name}">
+                <div class="cell-top">
+                  <span class="name">{s.name}</span>
+                  {#if s.session_tier}
+                    <span class="tier-badge tier-{s.session_tier}">{s.session_tier}</span>
+                  {/if}
+                  <label class="switch">
+                    <input type="checkbox" checked={s.enabled} disabled={togglingName === s.name}
+                      onchange={() => toggleEnabled(s)} aria-label="Toggle {s.name}" />
+                    <span class="switch-slider"></span>
+                  </label>
+                  <KebabMenu items={[
+                    { label: 'Edit', onclick: () => openEdit(s) },
+                    { label: 'Delete', danger: true, onclick: () => { confirmDelete = s.name } },
+                  ]} />
+                </div>
+                {#if s.skill}
+                  <div class="subline">skill: {s.skill}</div>
+                {/if}
+                <div class="cell-bottom">
+                  <span class="cron">{s.expression}</span>
+                  {#if !s.enabled}
+                    <span class="paused-label">Paused</span>
+                  {:else if s.next_run}
+                    <span class="rel">{relativeTime(s.next_run)}</span>
+                    <span class="abs">{shortAbsolute(s.next_run)}</span>
+                  {/if}
+                </div>
+              </li>
+            {/each}
+          </ul>
+        {:else}
         <div class="table-wrap">
           <table class="table">
             <thead>
@@ -384,6 +431,7 @@
             </tbody>
           </table>
         </div>
+        {/if}
       </section>
     {/each}
   {/if}
@@ -461,7 +509,34 @@
   .rel { color: var(--text); font-weight: 500; }
   .abs { display: block; color: var(--text-muted); font-size: 11px; }
   .paused-label { color: var(--text-muted); }
-  tr.paused .name, tr.paused .cron { opacity: 0.55; }
+  tr.paused .name, tr.paused .cron,
+  .cell.paused .name, .cell.paused .cron { opacity: 0.55; }
+
+  /* Round add-FAB when the header button renders in mobile mode */
+  .mobile-fab {
+    width: 36px; height: 36px; border-radius: 50%;
+    padding: 0; display: flex; align-items: center; justify-content: center;
+    font-size: 20px; line-height: 1;
+  }
+
+  /* Mobile card list — replaces the per-section table under isMobile */
+  .cell-list { list-style: none; margin: 0; padding: 0; }
+  .cell { display: flex; flex-direction: column; gap: 4px; padding: 12px 16px; }
+  .cell + .cell { border-top: 1px solid var(--border); }
+  .cell-top { display: flex; align-items: center; gap: 8px; }
+  .cell-top .name {
+    flex: 1; min-width: 0; font-weight: 600; font-size: 13px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .cell .subline { color: var(--text-muted); font-size: 11px; }
+  .cell-bottom { display: flex; align-items: baseline; gap: 8px; font-size: 12px; }
+  .cell-bottom .cron {
+    flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+    font-family: monospace;
+  }
+  .cell-bottom .rel { font-size: 11px; }
+  .cell-bottom .abs { display: inline; white-space: nowrap; }
+  .cell-bottom .paused-label { font-size: 11px; }
 
   /* Pill toggle switch — Tools-style, compact for table rows; green = enabled status */
   .switch { position: relative; display: inline-block; width: 36px; height: 20px; flex-shrink: 0; }

--- a/web/src/pages/Schedules.svelte
+++ b/web/src/pages/Schedules.svelte
@@ -2,45 +2,66 @@
   import { onMount } from 'svelte'
   import { api } from '../api.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
+  import { agentColor } from '../agentColor.js'
+  import { relativeTime, shortAbsolute } from '../relativeTime.js'
 
-  let schedules = []
-  let loading = true
-  let error = ''
-  let timezone = 'UTC'
+  let schedules = $state([])
+  let loading = $state(true)
+  let error = $state('')
+  let timezone = $state('UTC')
 
   // Available channels and agents for dropdowns
-  let channels = []
-  let agents = []
-  let loadWarning = ''
+  let channels = $state([])
+  let agents = $state([])
+  let loadWarning = $state('')
 
-  // List filter (operator view): '' = all agents. The filter drives a
-  // server-side fetch (GET /api/v1/schedules?agent=). knownAgents and
-  // hasSchedules are captured from the last unfiltered load so the filter
-  // control stays stable even when a filtered fetch returns nothing.
-  let filterAgent = ''
-  let knownAgents = []
-  let hasSchedules = false
-  let listLoading = false
+  // Client-side agent filter: '' = all agents. The full list is always
+  // loaded (chip counts and grouping need it); chips narrow which sections
+  // render without another round-trip.
+  let filterAgent = $state('')
+  let hasSchedules = $state(false)
 
   // Inline add/edit panel
-  let showForm = false
-  let editingName = null // null = add mode, string = edit mode
-  let formName = ''
-  let formSchedule = ''
-  let formSkill = ''
-  let formChannel = ''
-  let formChannelCustom = ''
-  let formSessionMode = 'isolated'
-  let formSessionTier = ''
-  let formAgent = ''
-  let formAgentCustom = ''
-  let formTags = ''
-  let formEnabled = true
-  let saving = false
+  let showForm = $state(false)
+  let editingName = $state(null) // null = add mode, string = edit mode
+  let formName = $state('')
+  let formSchedule = $state('')
+  let formSkill = $state('')
+  let formChannel = $state('')
+  let formChannelCustom = $state('')
+  let formSessionMode = $state('isolated')
+  let formSessionTier = $state('')
+  let formAgent = $state('')
+  let formAgentCustom = $state('')
+  let formTags = $state('')
+  let formEnabled = $state(true)
+  let saving = $state(false)
 
   // Delete confirmation
-  let confirmDelete = null
-  let deleting = false
+  let confirmDelete = $state(null)
+  let deleting = $state(false)
+
+  // In-flight enable/disable toggle (schedule name)
+  let togglingName = $state(null)
+
+  const tierByAgent = $derived(new Map(agents.map(a => [a.name, a.permission_tier])))
+
+  // Schedules grouped by owning agent, sorted by agent name. The section
+  // tier badge is the agent-level tier; a per-schedule session_tier renders
+  // as a row-level override badge instead.
+  const groups = $derived.by(() => {
+    const m = new Map()
+    for (const s of schedules) {
+      const a = s.agent || 'default'
+      if (!m.has(a)) m.set(a, [])
+      m.get(a).push(s)
+    }
+    return [...m.entries()]
+      .map(([agent, list]) => ({ agent, schedules: list, tier: tierByAgent.get(agent) }))
+      .sort((a, b) => a.agent.localeCompare(b.agent))
+  })
+
+  const visibleGroups = $derived(filterAgent ? groups.filter(g => g.agent === filterAgent) : groups)
 
   async function loadData() {
     loading = true
@@ -54,10 +75,8 @@
         api.agents().catch(() => { agErr = true; return [] }),
       ])
       schedules = sched || []
-      // Capture the full picture from this unfiltered load.
       filterAgent = ''
       hasSchedules = schedules.length > 0
-      knownAgents = [...new Set(schedules.map(s => s.agent || '').filter(Boolean))].sort()
       timezone = cfg?.timezone || 'UTC'
       channels = (ch || []).filter(c => !c.implicit)
       agents = ag || []
@@ -72,16 +91,18 @@
     }
   }
 
-  // Refetch the list scoped to the selected agent via the API filter.
-  async function applyFilter() {
-    listLoading = true
+  async function toggleEnabled(s) {
+    togglingName = s.name
     error = ''
     try {
-      schedules = (await api.schedules(filterAgent || undefined)) || []
+      await api.updateSchedule(s.name, { enabled: !s.enabled })
+      // Light refetch for the server-computed next_run; keeps the client
+      // filter and avoids flashing the page-level loading state.
+      schedules = (await api.schedules()) || []
     } catch (e) {
       error = e.message
     } finally {
-      listLoading = false
+      togglingName = null
     }
   }
 
@@ -186,8 +207,6 @@
     }
   }
 
-  function fmtDate(s) { return s ? new Date(s).toLocaleString() : '—' }
-
   onMount(loadData)
 </script>
 
@@ -289,56 +308,84 @@
   {:else if !hasSchedules && !error}
     <p class="muted">No schedules configured. Add one to automate recurring tasks.</p>
   {:else}
-    {#if knownAgents.length > 1}
-      <div class="filter-bar">
-        <label class="filter-label">
-          Agent
-          <select bind:value={filterAgent} onchange={applyFilter} disabled={listLoading} data-testid="agent-filter">
-            <option value="">All agents</option>
-            {#each knownAgents as a}
-              <option value={a}>{a}</option>
-            {/each}
-          </select>
-        </label>
-        {#if listLoading}<span class="filter-loading">Loading…</span>{/if}
+    {#if groups.length > 1}
+      <div class="filter-chips" role="radiogroup" aria-label="Filter by agent" data-testid="agent-filter">
+        <button class="chip" class:active={filterAgent === ''} role="radio" aria-checked={filterAgent === ''}
+          onclick={() => filterAgent = ''}>All agents ({schedules.length})</button>
+        {#each groups as g (g.agent)}
+          <button class="chip" class:active={filterAgent === g.agent} role="radio" aria-checked={filterAgent === g.agent}
+            data-testid="agent-chip-{g.agent}" onclick={() => filterAgent = g.agent}>
+            <span class="chip-dot" style="background: {agentColor(g.agent)}"></span>{g.agent} ({g.schedules.length})
+          </button>
+        {/each}
       </div>
     {/if}
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Name</th><th>Expression</th><th>Skill</th><th>Agent</th>
-          <th>Channel</th><th>Tier</th><th>Enabled</th>
-          <th>Last Run</th><th>Next Run</th><th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each schedules as s}
-          <tr data-testid="schedule-row-{s.name}">
-            <td class="name">{s.name}</td>
-            <td class="expr">{s.expression}</td>
-            <td>{s.skill || '—'}</td>
-            <td>{s.agent || '—'}</td>
-            <td class="expr">{s.channel || '—'}</td>
-            <td>{s.session_tier || '—'}</td>
-            <td>
-              <span class="dot" class:on={s.enabled}></span>
-              {s.enabled ? 'yes' : 'no'}
-            </td>
-            <td class="date">{fmtDate(s.last_run)}</td>
-            <td class="date">{fmtDate(s.next_run)}</td>
-            <td class="actions">
-              <button class="btn-sm" onclick={() => openEdit(s)}>Edit</button>
-              <button class="btn-sm danger" onclick={() => { confirmDelete = s.name }}>Delete</button>
-            </td>
-          </tr>
-        {/each}
-        {#if schedules.length === 0 && !listLoading}
-          <tr>
-            <td colspan="10" class="muted">No schedules for {filterAgent}.</td>
-          </tr>
-        {/if}
-      </tbody>
-    </table>
+
+    {#each visibleGroups as g (g.agent)}
+      <section class="agent-section" data-testid="agent-section-{g.agent}">
+        <header class="section-header">
+          <span class="agent-dot" style="background: {agentColor(g.agent)}"></span>
+          <h2 class="agent-name">{g.agent}</h2>
+          {#if g.tier}
+            <span class="tier-badge tier-{g.tier}">{g.tier}</span>
+          {/if}
+          <span class="count">{g.schedules.length} schedule{g.schedules.length === 1 ? '' : 's'}</span>
+        </header>
+        <div class="table-wrap">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Name</th><th>Schedule</th><th>Channel</th>
+                <th>Last run</th><th>Next run</th><th>On</th><th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each g.schedules as s (s.name)}
+                <tr data-testid="schedule-row-{s.name}" class:paused={!s.enabled}>
+                  <td class="name-cell">
+                    <span class="name">{s.name}</span>
+                    {#if s.session_tier}
+                      <span class="tier-badge tier-{s.session_tier}">{s.session_tier}</span>
+                    {/if}
+                    {#if s.skill}
+                      <span class="subline">skill: {s.skill}</span>
+                    {/if}
+                  </td>
+                  <td class="expr cron">{s.expression}</td>
+                  <td class="expr channel">{s.channel || '—'}</td>
+                  <td class="date">{s.last_run ? relativeTime(s.last_run) : 'Never'}</td>
+                  <td class="date">
+                    {#if !s.enabled}
+                      <span class="paused-label">Paused</span>
+                    {:else if s.next_run}
+                      <span class="rel">{relativeTime(s.next_run)}</span>
+                      <span class="abs">{shortAbsolute(s.next_run)}</span>
+                    {:else}
+                      —
+                    {/if}
+                  </td>
+                  <td>
+                    <label class="switch">
+                      <input type="checkbox" checked={s.enabled} disabled={togglingName === s.name}
+                        onchange={() => toggleEnabled(s)} aria-label="Toggle {s.name}" />
+                      <span class="switch-slider"></span>
+                    </label>
+                  </td>
+                  <td class="actions">
+                    <button class="icon-btn" onclick={() => openEdit(s)} aria-label="Edit {s.name}" title="Edit">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+                    </button>
+                    <button class="icon-btn danger" onclick={() => { confirmDelete = s.name }} aria-label="Delete {s.name}" title="Delete">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                    </button>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    {/each}
   {/if}
 </div>
 
@@ -365,15 +412,81 @@
   .tz-note a { color: var(--accent); text-decoration: none; }
   .tz-note a:hover { text-decoration: underline; }
   .form-title { font-size: 16px; font-weight: 600; margin-bottom: 16px; }
-  .name { font-weight: 600; }
-  .expr { font-family: monospace; font-size: 12px; white-space: nowrap; }
-  .date { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
-  .dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--border); margin-right: 4px; vertical-align: middle; }
-  .dot.on { background: var(--success); }
-  .actions { white-space: nowrap; }
-  .filter-bar { margin-bottom: 12px; display: flex; align-items: center; gap: 10px; }
-  .filter-label { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-muted); }
-  .filter-label select { font-size: 13px; }
-  .filter-loading { font-size: 12px; color: var(--text-muted); }
   .load-warning { font-size: 12px; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; margin-bottom: 12px; }
+
+  /* Agent filter chips */
+  .filter-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 11px; background: transparent;
+    border: 1px solid var(--border); border-radius: 999px;
+    font-size: 12px; color: var(--text); cursor: pointer; transition: all 0.1s;
+  }
+  .chip:hover { border-color: var(--accent); }
+  .chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .chip.active { background: var(--accent); color: white; border-color: var(--accent); }
+  .chip-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+
+  /* Agent sections */
+  .agent-section {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: var(--radius); margin-bottom: 20px; overflow: hidden;
+  }
+  .section-header {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+  }
+  .agent-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+  .agent-name { font-size: 14px; font-weight: 600; margin: 0; }
+  .count { color: var(--text-muted); font-size: 12px; margin-left: auto; }
+  .table-wrap { overflow-x: auto; }
+  .table-wrap .table { margin-bottom: 0; }
+
+  /* Tier badge (matches Agents page) */
+  .tier-badge {
+    display: inline-block; padding: 2px 8px; border-radius: 4px;
+    font-size: 11px; font-weight: 500; text-transform: capitalize;
+  }
+  .tier-autonomous { background: rgba(76,175,125,0.15); color: var(--success); }
+  .tier-supervised { background: rgba(240,169,88,0.15); color: var(--warn); }
+  .tier-restricted { background: rgba(224,92,110,0.15); color: var(--danger); }
+
+  /* Rows */
+  .name-cell .name { font-weight: 600; }
+  .name-cell .tier-badge { margin-left: 6px; }
+  .name-cell .subline { display: block; color: var(--text-muted); font-size: 11px; margin-top: 2px; }
+  .expr { font-family: monospace; font-size: 12px; white-space: nowrap; }
+  .channel { color: var(--text-muted); }
+  .date { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
+  .rel { color: var(--text); font-weight: 500; }
+  .abs { display: block; color: var(--text-muted); font-size: 11px; }
+  .paused-label { color: var(--text-muted); }
+  tr.paused .name, tr.paused .cron { opacity: 0.55; }
+
+  /* Pill toggle switch — Tools-style, compact for table rows; green = enabled status */
+  .switch { position: relative; display: inline-block; width: 36px; height: 20px; flex-shrink: 0; }
+  .switch input { opacity: 0; width: 0; height: 0; }
+  .switch-slider {
+    position: absolute; cursor: pointer; inset: 0;
+    background: var(--border); border-radius: 20px; transition: background 0.2s;
+  }
+  .switch-slider::before {
+    content: ""; position: absolute; height: 14px; width: 14px;
+    left: 3px; bottom: 3px; background: white; border-radius: 50%;
+    transition: transform 0.2s;
+  }
+  .switch input:checked + .switch-slider { background: var(--success); }
+  .switch input:checked + .switch-slider::before { transform: translateX(16px); }
+  .switch input:disabled + .switch-slider { opacity: 0.6; cursor: wait; }
+  .switch input:focus-visible + .switch-slider { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* Icon action buttons */
+  .actions { white-space: nowrap; }
+  .icon-btn {
+    background: none; border: none; cursor: pointer; padding: 4px;
+    color: var(--text-muted); border-radius: 4px; line-height: 0;
+  }
+  .icon-btn:hover { color: var(--text); background: var(--hover-overlay); }
+  .icon-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+  .icon-btn.danger:hover { color: var(--danger); }
 </style>

--- a/web/src/relativeTime.js
+++ b/web/src/relativeTime.js
@@ -1,0 +1,41 @@
+// Compact relative + short absolute time formatting shared by dashboard pages.
+// Both helpers take an optional `now` (ms epoch) so tests stay deterministic.
+
+// "45m ago" / "in 2h 15m". Future values in the hours/days tiers carry a
+// second unit because upcoming times (schedule runs) benefit from precision;
+// past values stay single-unit like the audit views.
+export function relativeTime(ts, now = Date.now()) {
+  if (!ts) return ''
+  const t = new Date(ts).getTime()
+  if (Number.isNaN(t)) return ''
+  const future = t > now
+  const diff = Math.abs(t - now)
+  const s = Math.floor(diff / 1000)
+  const m = Math.floor(s / 60)
+  const h = Math.floor(m / 60)
+  const d = Math.floor(h / 24)
+  let out
+  if (s < 60) out = `${s}s`
+  else if (m < 60) out = `${m}m`
+  else if (h < 24) out = future && m % 60 ? `${h}h ${m % 60}m` : `${h}h`
+  else out = future && h % 24 ? `${d}d ${h % 24}h` : `${d}d`
+  return future ? `in ${out}` : `${out} ago`
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+// "today 14:30" / "tomorrow 09:00" / "yesterday 18:00" / "Mar 5 09:00".
+// Fixed month names and 24h time keep output identical across runner locales.
+export function shortAbsolute(ts, now = Date.now()) {
+  if (!ts) return ''
+  const dt = new Date(ts)
+  if (Number.isNaN(dt.getTime())) return ''
+  const pad = (n) => String(n).padStart(2, '0')
+  const time = `${pad(dt.getHours())}:${pad(dt.getMinutes())}`
+  const startOfDay = (x) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime()
+  const dayDiff = Math.round((startOfDay(dt) - startOfDay(new Date(now))) / 86400000)
+  if (dayDiff === 0) return `today ${time}`
+  if (dayDiff === 1) return `tomorrow ${time}`
+  if (dayDiff === -1) return `yesterday ${time}`
+  return `${MONTHS[dt.getMonth()]} ${dt.getDate()} ${time}`
+}

--- a/web/src/test/fixtures/index.js
+++ b/web/src/test/fixtures/index.js
@@ -55,7 +55,15 @@ export const skills = [
 ]
 
 export const schedules = [
-  { name: 'daily-check', agent: 'default', cron: '0 9 * * *', message: 'Good morning', enabled: true },
+  {
+    name: 'daily-check', agent: 'default', expression: '0 9 * * *', skill: 'report',
+    channel: 'telegram:123', session_mode: 'isolated', enabled: true,
+    last_run: '2026-01-01T09:00:00Z', next_run: '2026-01-02T09:00:00Z',
+  },
+  {
+    name: 'helper-sync', agent: 'helper', expression: '@hourly', channel: 'discord:99',
+    session_tier: 'restricted', enabled: false,
+  },
 ]
 
 export const tools = [

--- a/web/test/e2e/helpers/schedules.js
+++ b/web/test/e2e/helpers/schedules.js
@@ -84,15 +84,15 @@ export class SchedulesPage {
     return this.page.locator(`[data-testid="schedule-row-${name}"]`)
   }
 
-  /** Click the Edit button on a schedule row. */
+  /** Click the Edit icon button on a schedule row. */
   async editRow(name) {
-    await this.row(name).locator('button:has-text("Edit")').click()
+    await this.row(name).getByRole('button', { name: `Edit ${name}` }).click()
     await this.page.locator('.inline-panel.open').waitFor({ state: 'visible' })
   }
 
-  /** Click the Delete button on a schedule row. */
+  /** Click the Delete icon button on a schedule row. */
   async deleteRow(name) {
-    await this.row(name).locator('button:has-text("Delete")').click()
+    await this.row(name).getByRole('button', { name: `Delete ${name}` }).click()
     await this.page.locator('[data-testid="delete-confirm"]').waitFor({ state: 'visible' })
   }
 


### PR DESCRIPTION
## Summary

Reworks the Schedules dashboard page so agent ownership is the organizing principle (implements the Paper design draft "Schedules — Rework"):

- **Per-agent section cards** replace the flat 10-column table: colored identity dot, agent name, tier badge (from `permission_tier`), schedule count
- **Agent filter chips** with counts replace the `<select>` filter; filtering is now client-side (full list is needed for counts/grouping anyway)
- **Skill** folds into a muted subline under the name; per-row tier badges appear only for `session_tier` overrides
- **Relative times** ("45m ago" / "in 2h 15m" + "today 14:30"); disabled schedules render "Paused" and dim
- **Inline enable/disable switches** wired to `PATCH /api/v1/schedules/{name}` with `{enabled}` (partial-merge supported server-side), followed by a light list refetch for the server-computed `next_run`
- **Icon action buttons** (pencil/trash) with aria-labels and `:focus-visible` states; delete keeps the confirm modal
- New shared utils `agentColor.js` (stable name→HSL identity color, intended for reuse on Sessions/Audit/Chat) and `relativeTime.js` (locale-stable past/future formatting), both fully unit-tested
- Component converted wholesale to Svelte 5 runes; stale `schedules` fixture refreshed to the real wire shape

The Add/Edit inline panel and delete confirmation are intentionally unchanged.

## Mobile layout (second commit)

Follows the approved Paper mock "Schedules — Mobile". On phones (`isMobile` store, ≤768px) each agent section renders a card list instead of the table — no horizontal scrolling:

- Card cell: name + enable toggle + kebab menu (Edit/Delete) on top, `skill:` subline, mono cron + relative/absolute next-run below; paused cells dim and show "Paused"
- Channel and last-run stay desktop/edit-panel-only; section counts drop to the bare number
- Add button becomes a compact round FAB (Agents-page idiom)
- Opening add/edit on mobile scrolls the inline panel into view (ui-reviewer finding)
- New `Schedules.mobile.test.js` (8 tests) mocks `isMobile` and covers card rendering, kebab flows, toggle PATCH, paused state, FAB, and the scroll behavior

## Test plan

- [x] `just test-ui` — 718/718 pass
- [x] Coverage gates hold: lines 77.91 ≥ 76, branches 60.42 ≥ 58
- [x] `just hook` green (fmt, vet, lint, lint-ui, Go tests, UI tests)
- [x] ui-reviewer agent pass: compliant; page-scoped suggestions applied (focus-visible states, capitalized tier badges)
- New/updated tests: grouping into sections, tier badge + graceful 403 fallback, chip filtering without refetch (request counter), toggle PATCH body assertion, Paused/Never rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiHd9GJZy6PuB5qbHsL2U3
