### PR TITLE
fix(tool): scope MCP stdio subprocess environment to an allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ cached_input = 0.5 # per million cached input tokens (0 = same as input)
 
 **Security**: SSRF protection, header injection prevention, env var denylist, URL/arg redaction in API responses.
 
+**Stdio subprocess env scoping** (`internal/tool/env.go`, `buildStdioEnv`): stdio MCP servers do NOT inherit the full parent environment — that would leak every `DENKEEPER_*` secret (API keys, tokens, session/OIDC secrets) into any tool subprocess. Instead the child gets a minimal explicit env: a built-in non-secret allowlist (`PATH`, `HOME`, `TMPDIR`, `USER`, `LOGNAME`, `SHELL`, `LANG`, `LC_*` prefix, `TZ`, `TERM`; runtime vars `NODE_PATH`/`NODE_OPTIONS`/`PYTHONPATH`/`VIRTUAL_ENV`/`GOPATH`; Windows equivalents `SYSTEMROOT`/`COMSPEC`/`PATHEXT`/`TEMP`/`TMP`/`USERPROFILE`/`APPDATA`/`LOCALAPPDATA`/`PROGRAMFILES`) plus the tool's own `env` (appended last, wins). Escape hatch: `env_passthrough = ["VAR", ...]` on `[mcp]` (global) and/or `[tools.*]` (per-tool) forwards extra parent vars. A hard exclusion filter (`isExcludedEnvVar`: any `DENKEEPER_*` name or the `forbiddenEnvPatterns` denylist) is applied to every forwarded name — allowlist hits AND passthrough — so a secret can never reach the child even if allowlisted or passed through by accident (a passthrough attempt on a protected var is logged and dropped). Only spawn site affected: `registerStdio`.
+
 ## External REST API
 
 `internal/api/` — HTTP API server (enabled by default). Auth via Bearer token (API keys) or session cookies (password/OIDC).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -669,6 +669,11 @@ type MCPConfig struct {
 	// URLAllowlist restricts which hosts SSE tool servers may connect to.
 	// Supports wildcards (e.g. "*.internal.corp"). Empty = all non-blocked hosts allowed.
 	URLAllowlist []string `toml:"url_allowlist"`
+	// EnvPassthrough names additional parent-process environment variables to
+	// forward into every stdio MCP subprocess, on top of the built-in non-secret
+	// allowlist. Secret-bearing names (DENKEEPER_* and the forbidden-pattern
+	// denylist) are always filtered out even if listed here.
+	EnvPassthrough []string `toml:"env_passthrough"`
 }
 
 // ToolConfig defines an MCP tool server to spawn.
@@ -691,6 +696,13 @@ type ToolConfig struct {
 
 	// Tool filtering — MCP tool names to exclude from the LLM tool payload.
 	DisabledTools []string `toml:"disabled_tools"`
+
+	// EnvPassthrough names additional parent-process environment variables to
+	// forward into this stdio server's subprocess, on top of the built-in
+	// non-secret allowlist and the global [mcp] env_passthrough. Secret-bearing
+	// names (DENKEEPER_* and the forbidden-pattern denylist) are always filtered
+	// out even if listed here.
+	EnvPassthrough []string `toml:"env_passthrough"`
 
 	// Unsafe options.
 	AllowLoopback bool `toml:"allow_loopback"` // bypass SSRF loopback block (localhost/127.x/::1)

--- a/internal/tool/env.go
+++ b/internal/tool/env.go
@@ -1,0 +1,117 @@
+package tool
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// stdioEnvAllowlist is the set of non-secret parent-process environment variable
+// names that are forwarded into stdio MCP subprocesses by default. It covers
+// generic system vars, runtime vars MCP servers commonly need (Node, Python,
+// Go), and their Windows equivalents. Secret-bearing names are never included
+// here; they are additionally excluded by isExcludedEnvVar as a hard backstop.
+var stdioEnvAllowlist = map[string]struct{}{
+	// Generic POSIX/system.
+	"PATH":    {},
+	"HOME":    {},
+	"TMPDIR":  {},
+	"USER":    {},
+	"LOGNAME": {},
+	"SHELL":   {},
+	"LANG":    {},
+	"TZ":      {},
+	"TERM":    {},
+	// Common language-runtime vars MCP servers rely on.
+	"NODE_PATH":    {},
+	"NODE_OPTIONS": {},
+	"PYTHONPATH":   {},
+	"VIRTUAL_ENV":  {},
+	"GOPATH":       {},
+	// Windows equivalents.
+	"SYSTEMROOT":   {},
+	"COMSPEC":      {},
+	"PATHEXT":      {},
+	"TEMP":         {},
+	"TMP":          {},
+	"USERPROFILE":  {},
+	"APPDATA":      {},
+	"LOCALAPPDATA": {},
+	"PROGRAMFILES": {},
+}
+
+// isAllowlistedEnvVar reports whether an env var name is in the built-in
+// non-secret allowlist. LC_* locale vars are matched by prefix.
+func isAllowlistedEnvVar(name string) bool {
+	if _, ok := stdioEnvAllowlist[name]; ok {
+		return true
+	}
+	return strings.HasPrefix(name, "LC_")
+}
+
+// isExcludedEnvVar reports whether an env var name must never reach a
+// subprocess, regardless of any allowlist or passthrough entry. This is the
+// hard secret backstop: everything under the DENKEEPER_* namespace plus the
+// forbidden-pattern denylist used for placeholder resolution.
+func isExcludedEnvVar(name string) bool {
+	if strings.HasPrefix(strings.ToUpper(name), "DENKEEPER_") {
+		return true
+	}
+	return isForbiddenEnvVar(name)
+}
+
+// buildStdioEnv constructs the explicit environment for a stdio MCP subprocess.
+//
+// Instead of inheriting the full secret-bearing parent environment
+// (os.Environ()), it forwards only:
+//   - names in the built-in non-secret allowlist (stdioEnvAllowlist + LC_*),
+//   - names explicitly listed in passthrough ([mcp] env_passthrough merged with
+//     the tool's own env_passthrough).
+//
+// A hard exclusion filter (isExcludedEnvVar) is applied to every forwarded name
+// so a secret can never reach the child even if it was allowlisted or passed
+// through by accident; a passthrough name that trips the filter is logged.
+//
+// The tool's own cfg.Env (explicit, already placeholder-resolved) is appended
+// last so it wins over any inherited value.
+func buildStdioEnv(cfgEnv map[string]string, passthrough []string, logger *slog.Logger) []string {
+	passSet := make(map[string]struct{}, len(passthrough))
+	for _, name := range passthrough {
+		if name == "" {
+			continue
+		}
+		if isExcludedEnvVar(name) {
+			if logger != nil {
+				logger.Warn("env_passthrough entry names a protected variable; refusing to forward it to MCP subprocess", "var", name)
+			}
+			continue
+		}
+		passSet[name] = struct{}{}
+	}
+
+	env := make([]string, 0, len(passSet)+len(cfgEnv)+16)
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		name := kv[:eq]
+
+		_, passed := passSet[name]
+		if !passed && !isAllowlistedEnvVar(name) {
+			continue
+		}
+		// Hard backstop: never forward a secret even if allowlisted or passed.
+		if isExcludedEnvVar(name) {
+			continue
+		}
+		env = append(env, kv)
+	}
+
+	// Tool-specific env is explicit config and wins; appended last so the child
+	// process (last-value-wins semantics) uses it over any inherited value.
+	for k, v := range cfgEnv {
+		env = append(env, k+"="+v)
+	}
+	return env
+}

--- a/internal/tool/env.go
+++ b/internal/tool/env.go
@@ -41,12 +41,16 @@ var stdioEnvAllowlist = map[string]struct{}{
 }
 
 // isAllowlistedEnvVar reports whether an env var name is in the built-in
-// non-secret allowlist. LC_* locale vars are matched by prefix.
+// non-secret allowlist. LC_* locale vars are matched by prefix. Matching is
+// case-insensitive (uppercase-normalized, mirroring isExcludedEnvVar) because
+// Windows env var names are case-insensitive and conventionally mixed-case
+// (Path, SystemRoot, ComSpec) — an exact match would silently drop them.
 func isAllowlistedEnvVar(name string) bool {
-	if _, ok := stdioEnvAllowlist[name]; ok {
+	upper := strings.ToUpper(name)
+	if _, ok := stdioEnvAllowlist[upper]; ok {
 		return true
 	}
-	return strings.HasPrefix(name, "LC_")
+	return strings.HasPrefix(upper, "LC_")
 }
 
 // isExcludedEnvVar reports whether an env var name must never reach a
@@ -75,6 +79,8 @@ func isExcludedEnvVar(name string) bool {
 // The tool's own cfg.Env (explicit, already placeholder-resolved) is appended
 // last so it wins over any inherited value.
 func buildStdioEnv(cfgEnv map[string]string, passthrough []string, logger *slog.Logger) []string {
+	// Keyed by uppercase name so passthrough matching is case-insensitive,
+	// consistent with the allowlist and exclusion filter (Windows names).
 	passSet := make(map[string]struct{}, len(passthrough))
 	for _, name := range passthrough {
 		if name == "" {
@@ -86,7 +92,7 @@ func buildStdioEnv(cfgEnv map[string]string, passthrough []string, logger *slog.
 			}
 			continue
 		}
-		passSet[name] = struct{}{}
+		passSet[strings.ToUpper(name)] = struct{}{}
 	}
 
 	env := make([]string, 0, len(passSet)+len(cfgEnv)+16)
@@ -97,7 +103,7 @@ func buildStdioEnv(cfgEnv map[string]string, passthrough []string, logger *slog.
 		}
 		name := kv[:eq]
 
-		_, passed := passSet[name]
+		_, passed := passSet[strings.ToUpper(name)]
 		if !passed && !isAllowlistedEnvVar(name) {
 			continue
 		}

--- a/internal/tool/env_test.go
+++ b/internal/tool/env_test.go
@@ -1,0 +1,118 @@
+package tool
+
+import (
+	"strings"
+	"testing"
+)
+
+// envToMap parses a []string of "K=V" entries into a map for easy assertions.
+func envToMap(t *testing.T, env []string) map[string]string {
+	t.Helper()
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			t.Fatalf("malformed env entry %q", kv)
+		}
+		m[kv[:eq]] = kv[eq+1:]
+	}
+	return m
+}
+
+func TestBuildStdioEnv_IncludesAllowlistedAndCfgEnv(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/home/tester")
+
+	cfgEnv := map[string]string{"MY_TOOL_FLAG": "on"}
+	env := buildStdioEnv(cfgEnv, nil, testLogger())
+	got := envToMap(t, env)
+
+	if got["PATH"] != "/usr/bin:/bin" {
+		t.Errorf("PATH not forwarded: got %q", got["PATH"])
+	}
+	if got["HOME"] != "/home/tester" {
+		t.Errorf("HOME not forwarded: got %q", got["HOME"])
+	}
+	if got["MY_TOOL_FLAG"] != "on" {
+		t.Errorf("cfg.Env value not present: got %q", got["MY_TOOL_FLAG"])
+	}
+}
+
+func TestBuildStdioEnv_ExcludesDenkeeperSecrets(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	t.Setenv("DENKEEPER_LLM_ANTHROPIC_API_KEY", "sk-secret")
+	t.Setenv("DENKEEPER_API_AUTH_SESSION_SECRET", "hunter2")
+
+	env := buildStdioEnv(nil, nil, testLogger())
+	got := envToMap(t, env)
+
+	if _, ok := got["DENKEEPER_LLM_ANTHROPIC_API_KEY"]; ok {
+		t.Error("DENKEEPER_LLM_ANTHROPIC_API_KEY leaked into subprocess env")
+	}
+	if _, ok := got["DENKEEPER_API_AUTH_SESSION_SECRET"]; ok {
+		t.Error("DENKEEPER_API_AUTH_SESSION_SECRET leaked into subprocess env")
+	}
+	if got["PATH"] != "/usr/bin" {
+		t.Errorf("PATH should still be forwarded: got %q", got["PATH"])
+	}
+}
+
+func TestBuildStdioEnv_PassthroughCannotForwardDenkeeperSecret(t *testing.T) {
+	t.Setenv("DENKEEPER_TELEGRAM_TOKEN", "bot-token")
+
+	// Operator tries to explicitly pass a secret through — the hard exclusion
+	// filter must still drop it.
+	env := buildStdioEnv(nil, []string{"DENKEEPER_TELEGRAM_TOKEN"}, testLogger())
+	got := envToMap(t, env)
+
+	if _, ok := got["DENKEEPER_TELEGRAM_TOKEN"]; ok {
+		t.Error("DENKEEPER_TELEGRAM_TOKEN was forwarded despite the exclusion filter")
+	}
+}
+
+func TestBuildStdioEnv_PassthroughForwardsNonSecret(t *testing.T) {
+	t.Setenv("MY_CUSTOM_VAR", "value1")
+
+	// Not in the allowlist, so only forwarded because of passthrough.
+	envWithout := buildStdioEnv(nil, nil, testLogger())
+	if _, ok := envToMap(t, envWithout)["MY_CUSTOM_VAR"]; ok {
+		t.Fatal("MY_CUSTOM_VAR should not be forwarded without passthrough")
+	}
+
+	env := buildStdioEnv(nil, []string{"MY_CUSTOM_VAR"}, testLogger())
+	if got := envToMap(t, env)["MY_CUSTOM_VAR"]; got != "value1" {
+		t.Errorf("MY_CUSTOM_VAR not forwarded via passthrough: got %q", got)
+	}
+}
+
+func TestBuildStdioEnv_LCPrefixMatching(t *testing.T) {
+	t.Setenv("LC_ALL", "en_US.UTF-8")
+	t.Setenv("LC_TIME", "de_DE.UTF-8")
+
+	got := envToMap(t, buildStdioEnv(nil, nil, testLogger()))
+
+	if got["LC_ALL"] != "en_US.UTF-8" {
+		t.Errorf("LC_ALL not forwarded via prefix match: got %q", got["LC_ALL"])
+	}
+	if got["LC_TIME"] != "de_DE.UTF-8" {
+		t.Errorf("LC_TIME not forwarded via prefix match: got %q", got["LC_TIME"])
+	}
+}
+
+func TestBuildStdioEnv_CfgEnvOverridesAllowlistedParent(t *testing.T) {
+	t.Setenv("PATH", "/parent/bin")
+
+	env := buildStdioEnv(map[string]string{"PATH": "/tool/bin"}, nil, testLogger())
+
+	// cfg.Env is appended last; with last-value-wins env semantics the tool's
+	// value takes effect. Assert the final occurrence of PATH is the tool value.
+	last := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			last = strings.TrimPrefix(kv, "PATH=")
+		}
+	}
+	if last != "/tool/bin" {
+		t.Errorf("cfg.Env should win for PATH: last value = %q", last)
+	}
+}

--- a/internal/tool/env_test.go
+++ b/internal/tool/env_test.go
@@ -99,6 +99,60 @@ func TestBuildStdioEnv_LCPrefixMatching(t *testing.T) {
 	}
 }
 
+func TestBuildStdioEnv_WindowsMixedCaseNames(t *testing.T) {
+	// Windows env var names are case-insensitive and conventionally mixed-case.
+	// They must match the (uppercase) allowlist and be forwarded with their
+	// original spelling intact.
+	t.Setenv("Path", `C:\Windows\System32`)
+	t.Setenv("SystemRoot", `C:\Windows`)
+	t.Setenv("ComSpec", `C:\Windows\System32\cmd.exe`)
+	t.Setenv("windir", `C:\Windows`) // lowercase; not in allowlist, must be dropped
+
+	got := envToMap(t, buildStdioEnv(nil, nil, testLogger()))
+
+	if got["Path"] != `C:\Windows\System32` {
+		t.Errorf("Path (mixed-case) not forwarded with original spelling: got %q", got["Path"])
+	}
+	if got["SystemRoot"] != `C:\Windows` {
+		t.Errorf("SystemRoot (mixed-case) not forwarded with original spelling: got %q", got["SystemRoot"])
+	}
+	if got["ComSpec"] != `C:\Windows\System32\cmd.exe` {
+		t.Errorf("ComSpec (mixed-case) not forwarded with original spelling: got %q", got["ComSpec"])
+	}
+	// Forwarded entries carry the parent's original spelling, never a
+	// normalized/uppercased key. (Assert the exact key we set is present,
+	// which the equality checks above already establish.)
+	// windir is not in the allowlist, so it must not leak.
+	if _, ok := got["windir"]; ok {
+		t.Error("windir is not allowlisted and must not be forwarded")
+	}
+}
+
+func TestBuildStdioEnv_MixedCaseSecretStillExcluded(t *testing.T) {
+	// The exclusion filter must be case-insensitive too: a mixed-case
+	// DENKEEPER_* name must never reach the child, whether inherited or passed.
+	t.Setenv("Denkeeper_Api_Key", "sk-secret")
+
+	got := envToMap(t, buildStdioEnv(nil, []string{"Denkeeper_Api_Key"}, testLogger()))
+
+	if _, ok := got["Denkeeper_Api_Key"]; ok {
+		t.Error("mixed-case Denkeeper_Api_Key leaked despite the exclusion filter")
+	}
+}
+
+func TestBuildStdioEnv_PassthroughCaseInsensitive(t *testing.T) {
+	// Operator lists the passthrough name in a different case than the parent
+	// env spelling; it must still match and forward with the parent's spelling.
+	t.Setenv("My_Custom_Var", "value1")
+
+	env := buildStdioEnv(nil, []string{"MY_CUSTOM_VAR"}, testLogger())
+	got := envToMap(t, env)
+
+	if got["My_Custom_Var"] != "value1" {
+		t.Errorf("case-insensitive passthrough failed: got %q", got["My_Custom_Var"])
+	}
+}
+
 func TestBuildStdioEnv_CfgEnvOverridesAllowlistedParent(t *testing.T) {
 	t.Setenv("PATH", "/parent/bin")
 

--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -269,11 +268,11 @@ func (m *Manager) RegisterServer(ctx context.Context, name string, cfg config.To
 // registerStdio spawns an MCP server subprocess and connects over stdio.
 func (m *Manager) registerStdio(ctx context.Context, name string, cfg config.ToolConfig) error {
 	cmd := exec.Command(cfg.Command, cfg.Args...) // #nosec G204 -- MCP tool servers are spawned from config-declared commands
-	// Inherit the current process environment and overlay tool-specific vars.
-	cmd.Env = os.Environ()
-	for k, v := range cfg.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
-	}
+	// Scope the subprocess environment to a non-secret allowlist plus any
+	// explicit passthrough vars, rather than inheriting the full secret-bearing
+	// parent environment. See buildStdioEnv (internal/tool/env.go).
+	passthrough := append(append([]string(nil), m.mcpCfg.EnvPassthrough...), cfg.EnvPassthrough...)
+	cmd.Env = buildStdioEnv(cfg.Env, passthrough, m.logger)
 
 	// Capture stderr so we can surface diagnostic output when the server
 	// fails to start (e.g. missing deps, bad config, crash on init).

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -255,6 +255,7 @@ MCP tool server definitions.
     scopes = []                      # OAuth scopes
     allow_loopback = false           # bypass SSRF loopback block
     disabled_tools = []              # MCP tool names to exclude from LLM
+    env_passthrough = []             # extra parent env vars to forward (stdio); DENKEEPER_* always filtered
 
 ### [mcp]
 
@@ -269,6 +270,7 @@ Global MCP settings.
     init_retry_attempts = 5          # initial connection retries
     init_retry_backoff = "2s"        # backoff between retries
     url_allowlist = []               # allowed hosts for SSE servers
+    env_passthrough = []             # extra parent env vars to forward into all stdio subprocesses; DENKEEPER_* always filtered
 
 ### [[schedules]]
 


### PR DESCRIPTION
## Security issue (#219, P1)

`registerStdio` in `internal/tool/manager.go` set `cmd.Env = os.Environ()` and appended the tool's `env`. In K8s/systemd deployments the parent environment holds every secret — `DENKEEPER_LLM_*_API_KEY`, `DENKEEPER_TELEGRAM_TOKEN`, `DENKEEPER_OIDC_CLIENT_SECRET`, `DENKEEPER_API_AUTH_SESSION_SECRET`, etc. Any stdio MCP tool subprocess could read all of them via `os.Environ()`. The existing `forbiddenEnvPatterns` denylist only guarded `${...}` placeholder resolution, not the inherited environment.

## Fix

New `buildStdioEnv` helper (`internal/tool/env.go`) builds a minimal explicit environment instead of inheriting everything:

- **Allowlist** of non-secret vars forwarded from the parent: `PATH`, `HOME`, `TMPDIR`, `USER`, `LOGNAME`, `SHELL`, `LANG`, `LC_*` (prefix), `TZ`, `TERM`; runtime vars `NODE_PATH`, `NODE_OPTIONS`, `PYTHONPATH`, `VIRTUAL_ENV`, `GOPATH`; Windows equivalents `SYSTEMROOT`, `COMSPEC`, `PATHEXT`, `TEMP`, `TMP`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `PROGRAMFILES`.
- **Hard exclusion filter** (`isExcludedEnvVar`) applied to every forwarded name — allowlist hits AND passthrough entries — dropping any `DENKEEPER_*` name or `forbiddenEnvPatterns` match. A secret can never reach the child even if allowlisted or passed through by accident; a passthrough attempt on a protected var is logged and dropped.
- The tool's own `env` (explicit, already placeholder-resolved) is appended last so it wins over any inherited value.

**Config escape hatch**: `env_passthrough = ["VAR", ...]` on `[mcp]` (global `MCPConfig`) and per-tool `[tools.*]` (`ToolConfig`). Both merge and run through the exclusion filter. The global list is threaded from `m.mcpCfg` where the Manager already holds its MCP config.

Only one spawn site was affected (`registerStdio`); `os` is no longer imported by `manager.go`.

## Test coverage (`internal/tool/env_test.go`, run with `-race`)

- `buildStdioEnv` forwards `PATH`/`HOME` and the tool's `cfg.Env` values.
- Excludes `DENKEEPER_*` secrets present in the parent env (`t.Setenv`).
- A `DENKEEPER_*` name supplied via `env_passthrough` is still filtered out.
- Non-secret var only reaches the child when listed in `env_passthrough`.
- `LC_*` prefix matching works.
- `cfg.Env` overrides an allowlisted parent var (last-wins).

`just hook` (fmt-check + vet + lint + lint-ui + test + test-ui) passes. Docs updated in CLAUDE.md and `website/static/llms-full.txt` (the TOML-key drift test enforces the latter).

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)