### PR TITLE
fix(config): synthesize default agent in API-only mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ REST API (/api/v1/chat) ────┘                    ↕                  
 - `llm.Provider` — LLM backends (Anthropic, OpenRouter, OpenAI, Ollama)
 - `agent.MemoryStore` — conversation persistence (SQLite)
 
-**Multi-agent config**: `[[agents]]` in TOML. Each agent has `name`, `persona_dir`, `adapters`, `llm_provider`, `llm_model`, `session_tier`. If no `[[agents]]` section exists, a single `"default"` agent is synthesized. `llm_provider` overrides the global `default_provider` for that agent, enabling different agents to use different LLM backends.
+**Multi-agent config**: `[[agents]]` in TOML. Each agent has `name`, `persona_dir`, `adapters`, `llm_provider`, `llm_model`, `session_tier`. If no `[[agents]]` section exists, a single `"default"` agent is synthesized when at least one adapter token is set (headless mode, bound to those adapters) **or** `api.enabled` is explicitly true (API-only/WebSocket mode, with no adapter bindings). When nothing is configured (no tokens, no explicit `api.enabled`), no agent is synthesized so the web setup wizard can guide creation — synthesis runs before `api.enabled` is defaulted to true so it can tell "explicitly enabled" apart from the default. `llm_provider` overrides the global `default_provider` for that agent, enabling different agents to use different LLM backends.
 
 **Named provider instances**: `[[llm.providers]]` array allows multiple instances of the same provider type (e.g. two OpenAI-compatible endpoints). Each entry has `name`, `type` (`anthropic`/`openai`/`openrouter`/`ollama`), `api_key`, `base_url`, `organization`. Legacy `[llm.openai]` single-slot syntax is still supported and auto-converted. Per-agent `llm_provider` references instances by name.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1082,8 +1082,12 @@ func applyDefaults(cfg *Config) {
 	synthesizeLegacyProviders(cfg)
 	migrateCostsToProviders(cfg, userSetSoft, userCostSoft, userSetHard, userCostHard)
 	expandEnvVars(cfg)
-	applyMiscDefaults(cfg)
+	// synthesizeDefaultAgent must run before applyMiscDefaults: the latter
+	// defaults api.enabled to true, which would erase the distinction between
+	// "user explicitly enabled the API" and "API on by default". Env overrides
+	// (applyEnvOverrides) have already run, so env-only api.enabled is honored.
 	synthesizeDefaultAgent(cfg)
+	applyMiscDefaults(cfg)
 	applyAgentDefaults(cfg)
 	synthesizeChannels(cfg)
 	applyScheduleDefaults(cfg)
@@ -1574,9 +1578,16 @@ func applyBrowserDefaults(cfg *Config) {
 }
 
 // synthesizeDefaultAgent provides backward-compatible multi-agent support:
-// if no [[agents]] defined AND at least one adapter token is configured
-// (headless mode), synthesize a single "default" agent. When no adapters
-// are configured the user is expected to create agents via the web wizard.
+// if no [[agents]] are defined, synthesize a single "default" agent when either
+//   - at least one adapter token is configured (headless mode), or
+//   - the API server is explicitly enabled (API-only / WebSocket mode), in which
+//     case the agent has no adapter bindings — delivery flows over the REST/WS API.
+//
+// When nothing is configured (no adapter tokens and no explicit api.enabled) the
+// user is expected to create agents via the web wizard, so nothing is synthesized.
+// This relies on running before applyMiscDefaults defaults api.enabled to true;
+// otherwise the "explicitly enabled" signal (a non-nil, true API.Enabled) would be
+// indistinguishable from the default.
 func synthesizeDefaultAgent(cfg *Config) {
 	if len(cfg.Agents) != 0 {
 		return
@@ -1588,7 +1599,11 @@ func synthesizeDefaultAgent(cfg *Config) {
 	if cfg.Discord.Token != "" {
 		defaultAdapters = append(defaultAdapters, "discord")
 	}
-	if len(defaultAdapters) == 0 {
+	// apiExplicitlyEnabled is true only when the user (via TOML) or an env
+	// override set api.enabled = true. A nil pointer means "not set" (the misc
+	// defaults will turn it on later, but that must not trigger synthesis).
+	apiExplicitlyEnabled := cfg.API.Enabled != nil && *cfg.API.Enabled
+	if len(defaultAdapters) == 0 && !apiExplicitlyEnabled {
 		return
 	}
 	cfg.Agents = []AgentInstanceConfig{{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -127,6 +127,67 @@ allowed_users = [111222333]
 	}
 }
 
+func TestParse_APIOnlySynthesizesDefaultAgent(t *testing.T) {
+	// API-only mode: LLM provider + api.enabled=true, no [[agents]], no adapter
+	// tokens. The full pipeline must synthesize exactly one "default" agent with
+	// no adapter bindings (delivery flows over the REST/WS API).
+	tomlData := []byte(`
+[llm]
+default_provider = "openrouter"
+
+[llm.openrouter]
+api_key = "sk-or-test-key"
+
+[api]
+enabled = true
+`)
+
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("expected exactly 1 synthesized agent, got %d", len(cfg.Agents))
+	}
+	a := cfg.Agents[0]
+	if a.Name != "default" {
+		t.Errorf("Name = %q, want %q", a.Name, "default")
+	}
+	if len(a.Adapters) != 0 {
+		t.Errorf("Adapters = %v, want empty for API-only mode", a.Adapters)
+	}
+	if !cfg.API.IsEnabled() {
+		t.Error("API should be enabled")
+	}
+}
+
+func TestParse_EnvAPIEnabledSynthesizesDefaultAgent(t *testing.T) {
+	// Env-only api.enabled must be honored: applyEnvOverrides runs before
+	// synthesis, so DENKEEPER_API_ENABLED=true triggers the default agent even
+	// when the TOML has no [api] section and no adapter tokens.
+	t.Setenv("DENKEEPER_API_ENABLED", "true")
+	tomlData := []byte(`
+[llm]
+default_provider = "openrouter"
+
+[llm.openrouter]
+api_key = "sk-or-test-key"
+`)
+
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cfg.Agents) != 1 || cfg.Agents[0].Name != "default" {
+		t.Fatalf("expected 1 synthesized default agent, got %v", cfg.Agents)
+	}
+	if len(cfg.Agents[0].Adapters) != 0 {
+		t.Errorf("Adapters = %v, want empty for API-only mode", cfg.Agents[0].Adapters)
+	}
+}
+
 func TestParse_AgentDefaults(t *testing.T) {
 	tomlData := []byte(baseConfig)
 
@@ -2441,6 +2502,42 @@ func TestSynthesizeDefaultAgent_ExplicitAgentsNotOverridden(t *testing.T) {
 
 	if len(cfg.Agents) != 1 || cfg.Agents[0].Name != "custom" {
 		t.Errorf("explicit agents should not be overridden, got %v", cfg.Agents)
+	}
+}
+
+func TestSynthesizeDefaultAgent_APIEnabledNoAdapters(t *testing.T) {
+	enabled := true
+	cfg := &Config{
+		API:     APIConfig{Enabled: &enabled},
+		Session: SessionConfig{Tier: "autonomous"},
+	}
+	synthesizeDefaultAgent(cfg)
+
+	if len(cfg.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(cfg.Agents))
+	}
+	a := cfg.Agents[0]
+	if a.Name != "default" {
+		t.Errorf("Name = %q, want %q", a.Name, "default")
+	}
+	if len(a.Adapters) != 0 {
+		t.Errorf("Adapters = %v, want empty (API-only delivery needs no bindings)", a.Adapters)
+	}
+	if a.SessionTier != "autonomous" {
+		t.Errorf("SessionTier = %q, want %q", a.SessionTier, "autonomous")
+	}
+}
+
+func TestSynthesizeDefaultAgent_NothingConfigured(t *testing.T) {
+	// No adapter tokens and no explicit api.enabled (nil pointer): nothing is
+	// synthesized so the web setup wizard can guide agent creation.
+	cfg := &Config{
+		Session: SessionConfig{Tier: "autonomous"},
+	}
+	synthesizeDefaultAgent(cfg)
+
+	if len(cfg.Agents) != 0 {
+		t.Fatalf("expected 0 agents when nothing is configured, got %d", len(cfg.Agents))
 	}
 }
 

--- a/internal/integration/chat_test.go
+++ b/internal/integration/chat_test.go
@@ -35,6 +35,33 @@ func TestChat_JSONResponse(t *testing.T) {
 	}
 }
 
+// TestChat_APIOnlyDefaultAgent mirrors the API-only deployment shape from issue
+// #230: a single synthesized "default" agent with no adapter bindings. Chat must
+// resolve it via the fallback path and succeed rather than returning
+// "agent not found".
+func TestChat_APIOnlyDefaultAgent(t *testing.T) {
+	h := NewHarness(t, &HarnessOpts{
+		Agents: []agentSetup{
+			{Name: "default", Tier: "autonomous", Adapters: nil},
+		},
+	})
+
+	req := h.AuthedRequest(http.MethodPost, "/api/v1/chat", map[string]any{
+		"message": "hello",
+	})
+	rec := h.Do(req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	DecodeJSON(t, rec, &resp)
+	if resp["response"] != "Hello from mock!" {
+		t.Errorf("response = %v, want 'Hello from mock!'", resp["response"])
+	}
+}
+
 func TestChat_ExplicitSessionID(t *testing.T) {
 	h := NewHarness(t, nil)
 


### PR DESCRIPTION
Fixes #230

## Problem

With `api.enabled = true`, no adapter tokens, and no `[[agents]]` section, the server started but every `POST /api/v1/chat` failed with `{"error":"agent not found"}`.

**Cause: validation and synthesis disagreed.** `validateAdaptersAndProviders` accepts `api.enabled` as satisfying the "at least one adapter" requirement, but `synthesizeDefaultAgent` only checked `telegram.token`/`discord.token` and returned early — leaving zero agents. `handleChat` then resolved the fallback `"default"` agent, found none, and 404'd.

Repro TOML: `[llm]` with any provider + API key, `[api] enabled = true`, nothing else.

## Fix

`synthesizeDefaultAgent` now also synthesizes the `"default"` agent when `api.enabled` is explicitly true, with an **empty `Adapters` list** (API/WebSocket delivery needs no adapter bindings). Adapter-token behavior is unchanged.

To keep the web-setup-wizard path intact, "nothing configured" must still synthesize nothing. The catch: `applyMiscDefaults` defaults `api.enabled` to `true`, which would erase the "user explicitly enabled it" signal. **Ordering fix:** synthesis now runs *before* `applyMiscDefaults`, so it reads the raw pointer (`nil` = not set → no synthesis; non-nil true = explicit → synthesize). `applyEnvOverrides` still runs earlier, so env-only `DENKEEPER_API_ENABLED=true` is honored.

Downstream verified: an agent with empty `Adapters` produces no channel bindings (`synthesizeChannels` skips it), and `handleChat` → `FallbackAgent()` resolves `"default"` correctly.

## Test coverage

- `TestParse_APIOnlySynthesizesDefaultAgent` — full pipeline: minimal API-only TOML yields exactly one `"default"` agent with empty adapters.
- `TestParse_EnvAPIEnabledSynthesizesDefaultAgent` — env-only `DENKEEPER_API_ENABLED=true` triggers synthesis (ordering guard).
- `TestSynthesizeDefaultAgent_APIEnabledNoAdapters` / `_NothingConfigured` — explicit-enable synthesizes; nil pointer synthesizes nothing.
- Existing `TestSynthesizeDefaultAgent_TelegramOnly` / `_BothAdapters` preserve adapter-token behavior.
- `TestChat_APIOnlyDefaultAgent` (integration) — boots an API-only harness (default agent, no adapters) and asserts `POST /api/v1/chat` succeeds.

`just hook` and `just test-integration` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
