### PR TITLE
feat(api,web): runtime enable/disable toggle for in-process web/script tools

### DIFF
--- a/internal/api/server_config.go
+++ b/internal/api/server_config.go
@@ -27,6 +27,8 @@ type serverConfigResponse struct {
 	MCPServerChatTimeout     string   `json:"mcp_server_chat_timeout"`
 	MCPServerStateless       bool     `json:"mcp_server_stateless"`
 	MCPServerEndpoint        string   `json:"mcp_server_endpoint"`
+	WebToolsEnabled          bool     `json:"web_tools_enabled"`
+	ScriptEnabled            bool     `json:"script_enabled"`
 	Version                  string   `json:"version"`
 	Commit                   string   `json:"commit"`
 	BuildDate                string   `json:"build_date"`
@@ -42,6 +44,8 @@ type serverConfigUpdateInput struct {
 	MCPServerSessionTimeout *string `json:"mcp_server_session_timeout,omitempty"`
 	MCPServerChatTimeout    *string `json:"mcp_server_chat_timeout,omitempty"`
 	MCPServerStateless      *bool   `json:"mcp_server_stateless,omitempty"`
+	WebToolsEnabled         *bool   `json:"web_tools_enabled,omitempty"`
+	ScriptEnabled           *bool   `json:"script_enabled,omitempty"`
 }
 
 // handleGetServerConfig godoc
@@ -72,6 +76,8 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter, _ *http.Request) {
 		MCPServerChatTimeout:     cfg.MCPServer.ChatTimeout,
 		MCPServerStateless:       cfg.MCPServer.Stateless,
 		MCPServerEndpoint:        s.mcpServerEndpoint(),
+		WebToolsEnabled:          s.deps.Config.Web.WebEnabled(),
+		ScriptEnabled:            s.deps.Config.Script.ScriptEnabled(),
 		Version:                  s.deps.Version,
 		Commit:                   s.deps.Commit,
 		BuildDate:                s.deps.BuildDate,
@@ -85,7 +91,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter, _ *http.Request) {
 
 // handlePatchServerConfig godoc
 // @Summary      Update server configuration
-// @Description  Partially updates server configuration (external_url, timezone). Changes are applied in-memory and persisted to the TOML config file.
+// @Description  Partially updates server configuration (external_url, timezone, MCP server, and the in-process web_tools_enabled / script_enabled toggles). Changes are applied in-memory and persisted to the TOML config file. Toggling web_tools_enabled or script_enabled returns restart_required: true, since the in-process MCP tools are (de)registered only at process start.
 // @Tags         server
 // @Accept       json
 // @Produce      json
@@ -109,8 +115,38 @@ func (s *Server) handlePatchServerConfig(w http.ResponseWriter, r *http.Request)
 	}
 
 	applyServerConfigInput(&s.deps.Config.API, &input)
+	restartRequired := applyInProcessToolInput(s.deps.Config, &input)
 	s.persistServerConfig(&input)
-	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+
+	resp := map[string]any{"status": "updated"}
+	if restartRequired {
+		// The [web]/[script] in-process MCP sessions are registered once at
+		// agent-build time; the hot-reload path does not re-register them, so
+		// the operator must restart the process for the toggle to take effect.
+		resp["restart_required"] = true
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// applyInProcessToolInput applies the [web]/[script] enabled toggles to the
+// in-memory config and reports whether either effective value changed. A change
+// needs a process restart to (de)register the in-process MCP tools, since the
+// hot-reload path does not re-run connectWebMCP/connectScriptMCP.
+func applyInProcessToolInput(cfg *config.Config, input *serverConfigUpdateInput) bool {
+	changed := false
+	if input.WebToolsEnabled != nil {
+		if cfg.Web.WebEnabled() != *input.WebToolsEnabled {
+			changed = true
+		}
+		cfg.Web.Enabled = input.WebToolsEnabled
+	}
+	if input.ScriptEnabled != nil {
+		if cfg.Script.ScriptEnabled() != *input.ScriptEnabled {
+			changed = true
+		}
+		cfg.Script.Enabled = input.ScriptEnabled
+	}
+	return changed
 }
 
 func validateServerConfigInput(input *serverConfigUpdateInput) string {
@@ -234,6 +270,8 @@ func (s *Server) persistServerConfig(input *serverConfigUpdateInput) {
 		return
 	}
 
+	s.persistInProcessToolConfig(input)
+
 	changes := make(map[string]any)
 	if input.ExternalURL != nil {
 		changes["external_url"] = *input.ExternalURL
@@ -265,6 +303,22 @@ func (s *Server) persistServerConfig(input *serverConfigUpdateInput) {
 	if len(changes) > 0 {
 		if err := config.UpdateAPIConfig(s.deps.ConfigPath, changes); err != nil {
 			s.logger.Warn("failed to persist server config", "error", err)
+		}
+	}
+}
+
+// persistInProcessToolConfig writes the [web]/[script] enabled toggles to their
+// top-level TOML sections. Persisted separately from the [api] changes because
+// they live in distinct tables.
+func (s *Server) persistInProcessToolConfig(input *serverConfigUpdateInput) {
+	if input.WebToolsEnabled != nil {
+		if err := config.UpdateWebConfig(s.deps.ConfigPath, map[string]any{"enabled": *input.WebToolsEnabled}); err != nil {
+			s.logger.Warn("failed to persist web config", "error", err)
+		}
+	}
+	if input.ScriptEnabled != nil {
+		if err := config.UpdateScriptConfig(s.deps.ConfigPath, map[string]any{"enabled": *input.ScriptEnabled}); err != nil {
+			s.logger.Warn("failed to persist script config", "error", err)
 		}
 	}
 }

--- a/internal/api/server_config_test.go
+++ b/internal/api/server_config_test.go
@@ -211,6 +211,164 @@ func TestUpdateAPIConfig_Persistence(t *testing.T) {
 	}
 }
 
+func TestGetServerConfig_InProcessToolsDefaultEnabled(t *testing.T) {
+	// Web.Enabled and Script.Enabled are nil (omitted from TOML) → default true.
+	deps := testDepsWithServerConfig()
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	req := authedRequest(http.MethodGet, "/api/v1/server/config")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp serverConfigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.WebToolsEnabled {
+		t.Error("web_tools_enabled = false, want true (nil-pointer default)")
+	}
+	if !resp.ScriptEnabled {
+		t.Error("script_enabled = false, want true (nil-pointer default)")
+	}
+}
+
+func TestGetServerConfig_InProcessToolsExplicitDisabled(t *testing.T) {
+	deps := testDepsWithServerConfig()
+	deps.Config.Web.Enabled = boolPtr(false)
+	deps.Config.Script.Enabled = boolPtr(false)
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	req := authedRequest(http.MethodGet, "/api/v1/server/config")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	var resp serverConfigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.WebToolsEnabled {
+		t.Error("web_tools_enabled = true, want false")
+	}
+	if resp.ScriptEnabled {
+		t.Error("script_enabled = true, want false")
+	}
+}
+
+func TestPatchServerConfig_DisableScript_PersistsAndRequestsRestart(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("[script]\ntimeout = \"2s\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDepsWithServerConfig()
+	deps.ConfigPath = cfgPath
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"script_enabled": false})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["restart_required"] != true {
+		t.Errorf("restart_required = %v, want true", resp["restart_required"])
+	}
+
+	if deps.Config.Script.ScriptEnabled() {
+		t.Error("in-memory Script still enabled, want disabled")
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("enabled = false")) {
+		t.Errorf("persisted config missing enabled = false; got:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte("timeout")) {
+		t.Errorf("persisted config lost script sibling; got:\n%s", data)
+	}
+}
+
+func TestPatchServerConfig_DisableWebTools_Persists(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("[web.search]\nprovider = \"duckduckgo\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDepsWithServerConfig()
+	deps.ConfigPath = cfgPath
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"web_tools_enabled": false})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if deps.Config.Web.WebEnabled() {
+		t.Error("in-memory Web still enabled, want disabled")
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("enabled = false")) {
+		t.Errorf("persisted config missing enabled = false; got:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte("duckduckgo")) {
+		t.Errorf("persisted config lost web.search sibling; got:\n%s", data)
+	}
+}
+
+func TestPatchServerConfig_NoChangeOmitsRestartRequired(t *testing.T) {
+	// Setting web_tools_enabled=true when it is already effectively true (nil
+	// default) is not a change, so no restart is required.
+	deps := testDepsWithServerConfig()
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"web_tools_enabled": true})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp["restart_required"]; ok {
+		t.Errorf("restart_required present, want omitted when value unchanged: %v", resp)
+	}
+}
+
 func TestReloadConfig_Success(t *testing.T) {
 	deps := testDepsWithServerConfig()
 	called := false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,6 +150,15 @@ type WebConfig struct {
 	Fetch   WebFetchConfig  `toml:"fetch"`
 }
 
+// WebEnabled returns whether the built-in web tools (web_search / web_fetch)
+// are enabled. An omitted field defaults to true.
+func (c *WebConfig) WebEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
 // WebSearchConfig configures the web search provider.
 type WebSearchConfig struct {
 	// Provider selects the search backend: "duckduckgo" (default) or "tavily".

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -743,6 +743,47 @@ func UpdateAPIConfig(path string, changes map[string]any) error {
 	return WriteRawConfig(path, raw)
 }
 
+// updateTopLevelSection applies partial updates to a top-level TOML table
+// (e.g. [web], [script]). Only keys present in changes are written; a key
+// mapped to a nil value is deleted so callers can restore the omitted-field
+// default. Existing sibling keys are preserved.
+func updateTopLevelSection(path, section string, changes map[string]any) error {
+	ConfigMu.Lock()
+	defer ConfigMu.Unlock()
+
+	raw, err := ReadRawConfig(path)
+	if err != nil {
+		return err
+	}
+
+	sec, ok := raw[section].(map[string]any)
+	if !ok {
+		sec = map[string]any{}
+	}
+	for k, v := range changes {
+		if v == nil {
+			delete(sec, k)
+		} else {
+			sec[k] = v
+		}
+	}
+	raw[section] = sec
+
+	return WriteRawConfig(path, raw)
+}
+
+// UpdateWebConfig persists partial updates to the top-level [web] section (the
+// built-in web_search / web_fetch tools).
+func UpdateWebConfig(path string, changes map[string]any) error {
+	return updateTopLevelSection(path, "web", changes)
+}
+
+// UpdateScriptConfig persists partial updates to the top-level [script] section
+// (the in-process run_javascript tool).
+func UpdateScriptConfig(path string, changes map[string]any) error {
+	return updateTopLevelSection(path, "script", changes)
+}
+
 // ---------------------------------------------------------------------------
 // Auth config persistence
 // ---------------------------------------------------------------------------

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -1003,3 +1003,83 @@ func TestConcurrentConfigWrites(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// In-process tool (web / script) config persistence
+// ---------------------------------------------------------------------------
+
+func TestUpdateWebConfig_DisablePreservesSiblings(t *testing.T) {
+	path := writeTestConfig(t, "[web.search]\nprovider = \"duckduckgo\"\n")
+
+	if err := UpdateWebConfig(path, map[string]any{"enabled": false}); err != nil {
+		t.Fatalf("UpdateWebConfig: %v", err)
+	}
+
+	got := readTestConfig(t, path)
+	if !strings.Contains(got, "enabled = false") {
+		t.Errorf("persisted config missing enabled = false; got:\n%s", got)
+	}
+	if !strings.Contains(got, "duckduckgo") {
+		t.Errorf("persisted config lost web.search sibling; got:\n%s", got)
+	}
+
+	// Assert the persisted value via the raw round-trip rather than Load(), which
+	// would apply full cross-section validation unrelated to this write.
+	raw, err := ReadRawConfig(path)
+	if err != nil {
+		t.Fatalf("ReadRawConfig: %v", err)
+	}
+	web, _ := raw["web"].(map[string]any)
+	if web["enabled"] != false {
+		t.Errorf("raw [web].enabled = %v, want false", web["enabled"])
+	}
+}
+
+func TestUpdateWebConfig_ReEnable(t *testing.T) {
+	path := writeTestConfig(t, "[web]\nenabled = false\n")
+
+	if err := UpdateWebConfig(path, map[string]any{"enabled": true}); err != nil {
+		t.Fatalf("UpdateWebConfig: %v", err)
+	}
+
+	raw, err := ReadRawConfig(path)
+	if err != nil {
+		t.Fatalf("ReadRawConfig: %v", err)
+	}
+	web, _ := raw["web"].(map[string]any)
+	if web["enabled"] != true {
+		t.Errorf("raw [web].enabled = %v, want true", web["enabled"])
+	}
+}
+
+func TestUpdateScriptConfig_DisablePreservesSiblings(t *testing.T) {
+	path := writeTestConfig(t, "[script]\ntimeout = \"2s\"\nmax_concurrent = 4\n")
+
+	if err := UpdateScriptConfig(path, map[string]any{"enabled": false}); err != nil {
+		t.Fatalf("UpdateScriptConfig: %v", err)
+	}
+
+	got := readTestConfig(t, path)
+	if !strings.Contains(got, "enabled = false") {
+		t.Errorf("persisted config missing enabled = false; got:\n%s", got)
+	}
+	if !strings.Contains(got, "max_concurrent") {
+		t.Errorf("persisted config lost script sibling; got:\n%s", got)
+	}
+
+	raw, err := ReadRawConfig(path)
+	if err != nil {
+		t.Fatalf("ReadRawConfig: %v", err)
+	}
+	script, _ := raw["script"].(map[string]any)
+	if script["enabled"] != false {
+		t.Errorf("raw [script].enabled = %v, want false", script["enabled"])
+	}
+}
+
+func TestWebEnabled_NilDefaultsTrue(t *testing.T) {
+	var wc WebConfig
+	if !wc.WebEnabled() {
+		t.Error("WebEnabled() with nil pointer = false, want true")
+	}
+}

--- a/web/src/__tests__/pages/ServerConfig.test.js
+++ b/web/src/__tests__/pages/ServerConfig.test.js
@@ -35,7 +35,7 @@ describe('ServerConfig page', () => {
     await waitFor(() => {
       expect(screen.getByText('WebSocket')).toBeInTheDocument()
     })
-    expect(screen.getByText('Enabled')).toBeInTheDocument()
+    expect(screen.getAllByText('Enabled').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('50')).toBeInTheDocument()
     expect(screen.getByText('5m')).toBeInTheDocument()
   })
@@ -416,10 +416,88 @@ describe('ServerConfig page', () => {
     await waitFor(() => {
       expect(screen.getByText('MCP Server')).toBeInTheDocument()
     })
-    const checkbox = screen.getByRole('checkbox')
+    const checkbox = screen.getByRole('checkbox', { name: 'MCP server' })
     await fireEvent.change(checkbox, { target: { checked: true } })
     await waitFor(() => {
       expect(patchCalled).toBe(true)
+    })
+  })
+
+  test('In-Process Tools section shows web and script toggles enabled', async () => {
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Web tools (web_search / web_fetch)')).toBeInTheDocument()
+    expect(screen.getByText('Deterministic compute (run_javascript)')).toBeInTheDocument()
+
+    const webToggle = screen.getByRole('checkbox', { name: 'Web tools' })
+    const scriptToggle = screen.getByRole('checkbox', { name: 'Deterministic compute' })
+    expect(webToggle.checked).toBe(true)
+    expect(scriptToggle.checked).toBe(true)
+  })
+
+  test('Web tools toggle PATCHes web_tools_enabled and shows restart hint', async () => {
+    let body = null
+    server.use(
+      http.patch('/api/v1/server/config', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ status: 'updated', restart_required: true })
+      }),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const webToggle = screen.getByRole('checkbox', { name: 'Web tools' })
+    await fireEvent.change(webToggle, { target: { checked: false } })
+
+    await waitFor(() => {
+      expect(body).toEqual({ web_tools_enabled: false })
+    })
+    await waitFor(() => {
+      expect(screen.getByText(/Restart the server/)).toBeInTheDocument()
+    })
+  })
+
+  test('Deterministic compute toggle PATCHes script_enabled', async () => {
+    let body = null
+    server.use(
+      http.patch('/api/v1/server/config', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ status: 'updated', restart_required: true })
+      }),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const scriptToggle = screen.getByRole('checkbox', { name: 'Deterministic compute' })
+    await fireEvent.change(scriptToggle, { target: { checked: false } })
+
+    await waitFor(() => {
+      expect(body).toEqual({ script_enabled: false })
+    })
+  })
+
+  test('In-process tool toggle error shows ErrorBanner', async () => {
+    server.use(
+      http.patch('/api/v1/server/config', () =>
+        HttpResponse.json({ error: 'Toggle failed' }, { status: 500 })
+      ),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const webToggle = screen.getByRole('checkbox', { name: 'Web tools' })
+    await fireEvent.change(webToggle, { target: { checked: false } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Toggle failed')).toBeInTheDocument()
     })
   })
 })

--- a/web/src/pages/ServerConfig.svelte
+++ b/web/src/pages/ServerConfig.svelte
@@ -33,6 +33,11 @@
   let saveMcpOk = $state(false)
   let mcpCopied = $state(false)
 
+  // In-process tools (web / script)
+  let savingWeb = $state(false)
+  let savingScript = $state(false)
+  let toolsRestartHint = $state(false)
+
   async function fetchConfig() {
     loading = true
     error = ''
@@ -133,6 +138,36 @@
       error = e.message
     } finally {
       savingMcp = false
+    }
+  }
+
+  async function toggleWebTools() {
+    savingWeb = true
+    error = ''
+    try {
+      const enabled = !config.web_tools_enabled
+      const res = await api.updateServerConfig({ web_tools_enabled: enabled })
+      config.web_tools_enabled = enabled
+      if (res?.restart_required) toolsRestartHint = true
+    } catch (e) {
+      error = e.message
+    } finally {
+      savingWeb = false
+    }
+  }
+
+  async function toggleScript() {
+    savingScript = true
+    error = ''
+    try {
+      const enabled = !config.script_enabled
+      const res = await api.updateServerConfig({ script_enabled: enabled })
+      config.script_enabled = enabled
+      if (res?.restart_required) toolsRestartHint = true
+    } catch (e) {
+      error = e.message
+    } finally {
+      savingScript = false
     }
   }
 
@@ -288,7 +323,7 @@
         <span class="status-dot" class:status-on={config.mcp_server_enabled} class:status-off={!config.mcp_server_enabled}></span>
         <span class="config-value">{config.mcp_server_enabled ? 'Enabled' : 'Disabled'}</span>
         <label class="switch">
-          <input type="checkbox" checked={config.mcp_server_enabled} onchange={toggleMcp} disabled={savingMcp} />
+          <input type="checkbox" aria-label="MCP server" checked={config.mcp_server_enabled} onchange={toggleMcp} disabled={savingMcp} />
           <span class="slider"></span>
         </label>
       </div>
@@ -376,6 +411,53 @@
   {/if}
   {#if saveMcpOk}
     <div class="save-ok">Saved</div>
+  {/if}
+
+  <h2 class="section-title">In-Process Tools</h2>
+  <div class="config-card">
+    <div class="config-row">
+      <div class="config-label">
+        <div class="config-name">Web tools (web_search / web_fetch)</div>
+        <div class="config-desc">
+          Built-in tools that let agents search the web and fetch page content.
+          Disable to remove them from every agent's toolset.
+        </div>
+      </div>
+      <div class="config-value-row">
+        <span class="status-dot" class:status-on={config.web_tools_enabled} class:status-off={!config.web_tools_enabled}></span>
+        <span class="config-value">{config.web_tools_enabled ? 'Enabled' : 'Disabled'}</span>
+        <label class="switch">
+          <input type="checkbox" aria-label="Web tools" checked={config.web_tools_enabled} onchange={toggleWebTools} disabled={savingWeb} />
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <div class="config-card" style="margin-top: 14px;">
+    <div class="config-row">
+      <div class="config-label">
+        <div class="config-name">Deterministic compute (run_javascript)</div>
+        <div class="config-desc">
+          In-process sandboxed JavaScript tool for deterministic formatting and
+          classification off the token path. Disable to remove it from every agent's toolset.
+        </div>
+      </div>
+      <div class="config-value-row">
+        <span class="status-dot" class:status-on={config.script_enabled} class:status-off={!config.script_enabled}></span>
+        <span class="config-value">{config.script_enabled ? 'Enabled' : 'Disabled'}</span>
+        <label class="switch">
+          <input type="checkbox" aria-label="Deterministic compute" checked={config.script_enabled} onchange={toggleScript} disabled={savingScript} />
+          <span class="slider"></span>
+        </label>
+      </div>
+    </div>
+  </div>
+
+  {#if toolsRestartHint}
+    <div class="mcp-hint">
+      Saved. Restart the server (Process Control below) for the change to take effect.
+    </div>
   {/if}
 
   <h2 class="section-title">External Access</h2>

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -301,6 +301,8 @@ export const handlers = [
     mcp_server_chat_timeout: '2m',
     mcp_server_stateless: false,
     mcp_server_endpoint: 'http://:8080/api/v1/mcp',
+    web_tools_enabled: true,
+    script_enabled: true,
     external_url: 'https://den.example.com',
     timezone: 'UTC',
     version: 'v0.25.0',


### PR DESCRIPTION
## The gap

The in-process tool config sections — `[web]` (web_search / web_fetch via `internal/webmcp/`) and `[script]` (run_javascript via `internal/scriptmcp/`) — were TOML/env-only. Both default-on via nil-pointer-true semantics (`WebEnabled()` / `ScriptEnabled()`). External `[tools.*]` MCP servers already have full enable/disable plumbing (REST + TOML persistence); the in-process tools were the last gap. An operator couldn't turn off `run_javascript` without hand-editing TOML.

Fixes #209.

## What changed

- **REST** (`internal/api/server_config.go`): `GET /api/v1/server/config` now surfaces `web_tools_enabled` and `script_enabled` (via new `config.WebConfig.WebEnabled()` mirroring the existing `ScriptEnabled()`). `PATCH` accepts both fields and applies them to the in-memory config.
- **Persistence**: new `config.UpdateWebConfig` / `UpdateScriptConfig` writers (thin wrappers over a shared `updateTopLevelSection` helper) persist `enabled` to the top-level `[web]` / `[script]` TOML tables — same atomic read-modify-write + `.bak` pattern as the existing writers, preserving sibling keys. Nil-pointer-true semantics are preserved: an absent key still reads as enabled.
- **Web UI** (`web/src/pages/ServerConfig.svelte`): a new "In-Process Tools" section with two toggles — "Web tools (web_search / web_fetch)" and "Deterministic compute (run_javascript)" — reusing the existing MCP-toggle markup (`.config-card` / `.switch` / `.status-dot`), CSS variables, disabled-while-in-flight guards, and the shared `ErrorBanner`. On a successful toggle it shows a restart hint pointing at the existing Process Control action. Checkboxes carry `aria-label`s.

## Apply-semantics decision: `restart_required`

I read the hot-reload path (`buildReloadFunc` in `cmd/denkeeper/main.go`). It reloads config and re-applies engine knobs (context/tool-round/supervisor/location) but **does not** re-run `connectWebMCP` / `connectScriptMCP`. Those in-process MCP sessions are registered once at agent-build time (`RegisterSession("web-<agent>" / "script-<agent>")`) and are never deregistered/re-registered on reload. So toggling `enabled` + calling reload would NOT hot-apply.

Hot-applying would require invasive per-agent session deregistration/re-registration plumbing (the external-tool `LifecycleManager` path doesn't cover in-process sessions). Per the issue's "least invasive option that actually works" guidance, I chose to **persist + signal a restart**: `PATCH` returns `restart_required: true` when a toggle changes the effective value (computed by comparing the current effective value before mutating — a no-op PATCH omits the field), and the UI surfaces a restart hint next to the existing Process Control / Restart action. No new hot-reload plumbing.

## Test coverage

- **Go — config writer** (`internal/config/writer_test.go`): `UpdateWebConfig` / `UpdateScriptConfig` persist `enabled` and preserve sibling keys (asserted via raw TOML round-trip, not `Load`, to avoid unrelated cross-section validation); re-enable path; `WebEnabled()` nil-default.
- **Go — handler** (`internal/api/server_config_test.go`): GET surfaces both fields at the nil-pointer default (enabled) and when explicitly disabled; PATCH disabling script/web persists to TOML and mutates in-memory config; PATCH returns `restart_required: true` on a real change and omits it on a no-op.
- **Web** (`web/src/__tests__/pages/ServerConfig.test.js`): renders both toggles enabled by default; each toggle PATCHes the correct field; restart hint appears; toggle error surfaces in `ErrorBanner`. (28/28 ServerConfig vitest tests pass.)
- `just hook` is green (fmt-check, vet, lint, lint-ui, test, test-ui).
- A `ui-reviewer` pass returned a "compliant" verdict (inline toggles, reuses the existing pattern, correct in-flight/error handling); its remaining notes were minor optional polish, acceptable as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)