### PR TITLE
chore(deps): bump Go to 1.26.5 to fix govulncheck stdlib findings

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.4"
+go = "1.26.5"
 hugo-extended = "latest"
 "golangci-lint" = "latest"
 swag = "latest"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & Development Commands
 
-This project uses [just](https://github.com/casey/just) as the user-facing command runner, [Task](https://taskfile.dev) (`Taskfile.yml`) underneath for per-target fingerprint caching, and [mise](https://mise.jdx.dev) for tool versioning (Go 1.26.2). `just` recipes for `build`, `test`, `lint`, `vet`, `fmt-check`, `lint-ui`, `build-ui`, `test-ui`, `openapi`, and `hook` delegate to `mise x -- task <name>`; Task skips any step whose declared sources/inputs haven't changed. Cache lives in `.task/` (gitignored). Bust a single step with `mise x -- task <name> --force`; bust the whole hook chain with `JUST_HOOK_FORCE=1 just hook`.
+This project uses [just](https://github.com/casey/just) as the user-facing command runner, [Task](https://taskfile.dev) (`Taskfile.yml`) underneath for per-target fingerprint caching, and [mise](https://mise.jdx.dev) for tool versioning (Go pinned in `.mise.toml`, currently 1.26.5). `just` recipes for `build`, `test`, `lint`, `vet`, `fmt-check`, `lint-ui`, `build-ui`, `test-ui`, `openapi`, and `hook` delegate to `mise x -- task <name>`; Task skips any step whose declared sources/inputs haven't changed. Cache lives in `.task/` (gitignored). Bust a single step with `mise x -- task <name> --force`; bust the whole hook chain with `JUST_HOOK_FORCE=1 just hook`.
 
 ```bash
 just build                    # Build binary → pkg/bin/denkeeper


### PR DESCRIPTION
## Why

The **Security Scan** job fails on every current branch (including all four open PRs #232–#235): govulncheck flags two Go standard-library vulnerabilities published after the last green main run on 2026-07-08:

- **GO-2026-5856** — Encrypted Client Hello privacy leak in `crypto/tls`
- **GO-2026-4970** — Root escape via symlink + trailing slash in `os` (reachable via our `os.Root`-based skill-file writes)

Both are fixed in **go1.26.5**.

## What

- Bump the effective Go pin in `.mise.toml` from 1.26.4 → 1.26.5. (Note: `mise.toml`'s `go = "latest"` is overridden by `.mise.toml`, which is why simply re-running the failed jobs kept installing 1.26.4.)
- Correct the stale Go version reference in CLAUDE.md.

## Verification

- `mise x -- go version` → go1.26.5
- `JUST_HOOK_FORCE=1 just hook` fully green on 1.26.5 (fmt-check, vet, lint, lint-ui, test, test-ui)
- Local `govulncheck ./...` no longer reports the two stdlib findings (one remaining module-level vuln is not called by our code and does not fail the scan)

After merge, the four open PRs need a Security Scan re-run (or branch update) to pick up the new toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xmc6R6k4o2RkSDQaCJ3Wo5