### PR TITLE
fix(web): close shared-pattern accessibility gaps in the dashboard

### DIFF
--- a/web/src/__tests__/inert.test.js
+++ b/web/src/__tests__/inert.test.js
@@ -1,0 +1,89 @@
+import { describe, test, expect } from 'vitest'
+import { inert } from '../inert.js'
+
+describe('inert action', () => {
+  test('sets the attribute when initialised truthy', () => {
+    const el = document.createElement('div')
+    inert(el, true)
+    expect(el.hasAttribute('inert')).toBe(true)
+  })
+
+  test('leaves the attribute off when initialised falsy', () => {
+    const el = document.createElement('div')
+    inert(el, false)
+    expect(el.hasAttribute('inert')).toBe(false)
+  })
+
+  test('update toggles the attribute both ways', () => {
+    const el = document.createElement('div')
+    const handle = inert(el, true)
+    handle.update(false)
+    expect(el.hasAttribute('inert')).toBe(false)
+    handle.update(true)
+    expect(el.hasAttribute('inert')).toBe(true)
+  })
+
+  test('returns focus to the opener when the panel closes', () => {
+    const trigger = document.createElement('button')
+    const panel = document.createElement('div')
+    const field = document.createElement('input')
+    panel.appendChild(field)
+    document.body.append(trigger, panel)
+
+    const handle = inert(panel, true)
+    trigger.focus()
+    handle.update(false) // open
+    field.focus()
+    expect(document.activeElement).toBe(field)
+
+    handle.update(true) // close
+    expect(document.activeElement).toBe(trigger)
+
+    trigger.remove()
+    panel.remove()
+  })
+
+  test('leaves focus alone when it is outside the closing panel', () => {
+    const outside = document.createElement('button')
+    const trigger = document.createElement('button')
+    const panel = document.createElement('div')
+    document.body.append(outside, trigger, panel)
+
+    const handle = inert(panel, true)
+    trigger.focus()
+    handle.update(false)
+    outside.focus()
+    handle.update(true)
+    expect(document.activeElement).toBe(outside)
+
+    outside.remove()
+    trigger.remove()
+    panel.remove()
+  })
+
+  test('blurs instead of restoring when the opener is gone', () => {
+    const trigger = document.createElement('button')
+    const panel = document.createElement('div')
+    const field = document.createElement('input')
+    panel.appendChild(field)
+    document.body.append(trigger, panel)
+
+    const handle = inert(panel, true)
+    trigger.focus()
+    handle.update(false)
+    field.focus()
+    trigger.remove()
+
+    handle.update(true)
+    expect(document.activeElement).not.toBe(field)
+
+    panel.remove()
+  })
+
+  test('ignores repeated updates with the same value', () => {
+    const el = document.createElement('div')
+    const handle = inert(el, true)
+    handle.update(true)
+    expect(el.hasAttribute('inert')).toBe(true)
+  })
+})

--- a/web/src/__tests__/pages/AuditLog.test.js
+++ b/web/src/__tests__/pages/AuditLog.test.js
@@ -170,6 +170,64 @@ describe('AuditLog page', () => {
     expect(toolsChip.getAttribute('aria-checked')).toBe('true')
   })
 
+  test('each chip bar is a single tab stop with arrow-key navigation', async () => {
+    render(AuditLog)
+    await waitFor(() => {
+      expect(screen.getByText('Audit log')).toBeInTheDocument()
+    })
+
+    const group = screen.getByRole('radiogroup', { name: 'Category filter' })
+    const chips = [...group.querySelectorAll('[role="radio"]')]
+    // "All" is selected on load, so it owns the group's single tab stop.
+    expect(chips[0]).toHaveAttribute('tabindex', '0')
+    expect(chips.slice(1).every(c => c.getAttribute('tabindex') === '-1')).toBe(true)
+
+    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
+    await waitFor(() => {
+      expect(chips[1]).toHaveAttribute('aria-checked', 'true')
+    })
+    expect(chips[1]).toHaveAttribute('tabindex', '0')
+    expect(chips[0]).toHaveAttribute('tabindex', '-1')
+
+    await fireEvent.keyDown(chips[1], { key: 'Home' })
+    await waitFor(() => {
+      expect(chips[0]).toHaveAttribute('aria-checked', 'true')
+    })
+  })
+
+  test('arrow-keying across chips coalesces into a single refetch', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/v1/audit', () => {
+        calls++
+        return HttpResponse.json({ events: [], total: 0 })
+      }),
+    )
+    render(AuditLog)
+    await waitFor(() => expect(calls).toBe(1))
+
+    const group = screen.getByRole('radiogroup', { name: 'Category filter' })
+    const chips = [...group.querySelectorAll('[role="radio"]')]
+    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
+    await fireEvent.keyDown(chips[1], { key: 'ArrowRight' })
+    await fireEvent.keyDown(chips[2], { key: 'ArrowRight' })
+
+    // Selection follows focus, so all three chips changed the filter; the
+    // page must not fire one request per keypress.
+    expect(chips[3]).toHaveAttribute('aria-checked', 'true')
+    await waitFor(() => expect(calls).toBeGreaterThan(1))
+    expect(calls).toBeLessThanOrEqual(2)
+  })
+
+  test('status and range chip bars are labelled radiogroups', async () => {
+    render(AuditLog)
+    await waitFor(() => {
+      expect(screen.getByText('Audit log')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('radiogroup', { name: 'Status filter' })).toBeInTheDocument()
+    expect(screen.getByRole('radiogroup', { name: 'Time range' })).toBeInTheDocument()
+  })
+
   test('shows load more button when events < total', async () => {
     server.use(
       http.get('/api/v1/audit', () => HttpResponse.json({ events: auditEvents, total: 100 })),

--- a/web/src/__tests__/pages/Channels.test.js
+++ b/web/src/__tests__/pages/Channels.test.js
@@ -389,9 +389,11 @@ describe('Channels page', () => {
     await fireEvent.click(screen.getByText('Save'))
 
     await waitFor(() => {
-      // The inline-panel collapses (loses .open class) rather than unmounting.
+      // The inline-panel collapses (loses .open class) rather than unmounting,
+      // and goes inert so its fields leave the tab order.
       const panel = document.querySelector('.inline-panel')
       expect(panel).not.toHaveClass('open')
+      expect(panel).toHaveAttribute('inert')
     })
   })
 

--- a/web/src/__tests__/pages/Schedules.test.js
+++ b/web/src/__tests__/pages/Schedules.test.js
@@ -141,6 +141,55 @@ describe('Schedules page', () => {
     })
   })
 
+  test('collapsed add form is inert so its fields stay out of the tab order', async () => {
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByText('+ Add Schedule')).toBeInTheDocument()
+    })
+
+    const panel = document.querySelector('.inline-panel')
+    expect(panel).not.toHaveClass('open')
+    expect(panel).toHaveAttribute('inert')
+
+    await fireEvent.click(screen.getByText('+ Add Schedule'))
+    await waitFor(() => {
+      expect(panel).toHaveClass('open')
+    })
+    expect(panel).not.toHaveAttribute('inert')
+
+    await fireEvent.click(screen.getByText('Cancel'))
+    await waitFor(() => {
+      expect(panel).toHaveAttribute('inert')
+    })
+  })
+
+  test('agent chips are a single tab stop with arrow-key navigation', async () => {
+    server.use(
+      http.get('/api/v1/schedules', () =>
+        HttpResponse.json([
+          { name: 'alice-job', expression: '@daily', agent: 'alice', channel: 'telegram:1', enabled: true },
+          { name: 'bob-job', expression: '@daily', agent: 'bob', channel: 'telegram:2', enabled: true },
+        ])
+      )
+    )
+
+    render(Schedules)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-filter')).toBeInTheDocument()
+    })
+
+    const chips = [...screen.getByTestId('agent-filter').querySelectorAll('[role="radio"]')]
+    // Only the selected ("All agents") chip is reachable with Tab.
+    expect(chips.map(c => c.getAttribute('tabindex'))).toEqual(['0', '-1', '-1'])
+
+    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
+    await waitFor(() => {
+      expect(screen.queryByText('bob-job')).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId('agent-chip-alice')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('agent-chip-alice')).toHaveAttribute('tabindex', '0')
+  })
+
   test('agent chips filter sections client-side without a refetch', async () => {
     let getCount = 0
     server.use(

--- a/web/src/__tests__/pages/Tools.test.js
+++ b/web/src/__tests__/pages/Tools.test.js
@@ -302,10 +302,25 @@ describe('Tools add form', () => {
     const cancelBtn = document.querySelector('.form-actions .btn-ghost')
     await fireEvent.click(cancelBtn)
 
-    // The inline panel should close (CSS hides it via class:open)
+    // The inline panel should close (CSS hides it via class:open) and go
+    // inert so its inputs drop out of the keyboard tab order.
     await waitFor(() => {
       const panel = document.querySelector('.inline-panel')
       expect(panel.classList.contains('open')).toBe(false)
+      expect(panel).toHaveAttribute('inert')
+    })
+  })
+
+  test('inline tool form is inert until it is opened', async () => {
+    render(Tools)
+    await waitFor(() => screen.getByText('+ Add Tool'))
+
+    const panel = document.querySelector('.inline-panel')
+    expect(panel).toHaveAttribute('inert')
+
+    await fireEvent.click(screen.getByText('+ Add Tool'))
+    await waitFor(() => {
+      expect(panel).not.toHaveAttribute('inert')
     })
   })
 })

--- a/web/src/components/FilterChips.svelte
+++ b/web/src/components/FilterChips.svelte
@@ -1,0 +1,89 @@
+<script>
+  /**
+   * Accessible filter chip bar.
+   *
+   * Renders an ARIA radiogroup and implements the keyboard contract that role
+   * advertises: the whole group is a single tab stop (roving tabindex) and
+   * Arrow / Home / End move the selection between chips. Styling lives in
+   * shared.css (.filter-chips / .chip / .chip-dot) so every chip bar in the
+   * dashboard looks and behaves the same.
+   *
+   * items: [{ value, label, dot?, testid? }]
+   */
+  let {
+    items = [],
+    value = '',
+    label = '',
+    size = '',
+    testid = undefined,
+    onselect = () => {},
+  } = $props()
+
+  let buttons = $state([])
+
+  // The chip that owns the group's tab stop: the selected one, or the first
+  // chip when nothing matches the current value.
+  let activeIndex = $derived.by(() => {
+    const i = items.findIndex((it) => it.value === value)
+    return i >= 0 ? i : 0
+  })
+
+  function move(index) {
+    const item = items[index]
+    if (!item) return
+    onselect(item.value)
+    buttons[index]?.focus()
+  }
+
+  function handleKeydown(e) {
+    if (items.length === 0) return
+    const current = buttons.indexOf(e.target)
+    const from = current >= 0 ? current : activeIndex
+    let next
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = (from + 1) % items.length
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = (from - 1 + items.length) % items.length
+        break
+      case 'Home':
+        next = 0
+        break
+      case 'End':
+        next = items.length - 1
+        break
+      default:
+        return
+    }
+    e.preventDefault()
+    move(next)
+  }
+</script>
+
+<!-- The group is deliberately not focusable: the radios carry the roving
+     tabindex, and the keydown handler sees their events by bubbling. -->
+<!-- svelte-ignore a11y_interactive_supports_focus -->
+<div
+  class="filter-chips"
+  class:filter-chips-sm={size === 'sm'}
+  role="radiogroup"
+  aria-label={label}
+  data-testid={testid}
+  onkeydown={handleKeydown}
+>
+  {#each items as item, i (item.value)}
+    <button
+      class="chip"
+      class:active={value === item.value}
+      role="radio"
+      aria-checked={value === item.value}
+      tabindex={i === activeIndex ? 0 : -1}
+      data-testid={item.testid}
+      bind:this={buttons[i]}
+      onclick={() => onselect(item.value)}
+    >{#if item.dot}<span class="chip-dot" style="background: {item.dot}"></span>{/if}{item.label}</button>
+  {/each}
+</div>

--- a/web/src/components/KebabMenu.svelte
+++ b/web/src/components/KebabMenu.svelte
@@ -51,6 +51,7 @@
   }
 
   .kebab-trigger {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -64,10 +65,28 @@
     cursor: pointer;
     transition: all 0.12s ease;
   }
+  /* WCAG 2.5.5 / Apple HIG: 44x44 tap zone around the 32px visual button.
+     Touch input only — with a mouse the invisible overlay would overhang the
+     controls packed next to it in dense rows. */
+  @media (pointer: coarse) {
+    .kebab-trigger::before {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 44px;
+      height: 44px;
+    }
+  }
   .kebab-trigger:hover {
     background: var(--hover-overlay);
     border-color: var(--border);
     color: var(--text);
+  }
+  .kebab-trigger:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
 
   .kebab-dropdown {

--- a/web/src/components/__tests__/FilterChips.test.js
+++ b/web/src/components/__tests__/FilterChips.test.js
@@ -1,0 +1,132 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/svelte'
+import FilterChips from '../FilterChips.svelte'
+
+const items = [
+  { value: '', label: 'All' },
+  { value: 'a', label: 'Alpha', testid: 'chip-alpha' },
+  { value: 'b', label: 'Beta', dot: '#123456' },
+]
+
+function setup(props = {}) {
+  const onselect = vi.fn()
+  const result = render(FilterChips, {
+    props: { items, value: '', label: 'Test filter', onselect, ...props },
+  })
+  return { ...result, onselect }
+}
+
+describe('FilterChips', () => {
+  test('renders a labelled radiogroup with one radio per item', () => {
+    const { container } = setup()
+    const group = container.querySelector('[role="radiogroup"]')
+    expect(group).toHaveAttribute('aria-label', 'Test filter')
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(3)
+  })
+
+  test('marks the selected chip with aria-checked and .active', () => {
+    const { container } = setup({ value: 'a' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    expect(chips[1]).toHaveAttribute('aria-checked', 'true')
+    expect(chips[1]).toHaveClass('active')
+    expect(chips[0]).toHaveAttribute('aria-checked', 'false')
+  })
+
+  test('roving tabindex: only the selected chip is a tab stop', () => {
+    const { container } = setup({ value: 'b' })
+    const chips = [...container.querySelectorAll('[role="radio"]')]
+    expect(chips.map(c => c.getAttribute('tabindex'))).toEqual(['-1', '-1', '0'])
+  })
+
+  test('roving tabindex falls back to the first chip when nothing matches', () => {
+    const { container } = setup({ value: 'no-such-value' })
+    const chips = [...container.querySelectorAll('[role="radio"]')]
+    expect(chips.map(c => c.getAttribute('tabindex'))).toEqual(['0', '-1', '-1'])
+  })
+
+  test('clicking a chip selects it', async () => {
+    const { container, onselect } = setup()
+    await fireEvent.click(container.querySelectorAll('[role="radio"]')[1])
+    expect(onselect).toHaveBeenCalledWith('a')
+  })
+
+  test('ArrowRight moves selection to the next chip', async () => {
+    const { container, onselect } = setup({ value: '' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
+    expect(onselect).toHaveBeenCalledWith('a')
+  })
+
+  test('ArrowDown behaves like ArrowRight', async () => {
+    const { container, onselect } = setup({ value: '' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[0], { key: 'ArrowDown' })
+    expect(onselect).toHaveBeenCalledWith('a')
+  })
+
+  test('ArrowLeft wraps around to the last chip', async () => {
+    const { container, onselect } = setup({ value: '' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[0], { key: 'ArrowLeft' })
+    expect(onselect).toHaveBeenCalledWith('b')
+  })
+
+  test('ArrowUp moves to the previous chip', async () => {
+    const { container, onselect } = setup({ value: 'b' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[2], { key: 'ArrowUp' })
+    expect(onselect).toHaveBeenCalledWith('a')
+  })
+
+  test('ArrowRight wraps from the last chip to the first', async () => {
+    const { container, onselect } = setup({ value: 'b' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[2], { key: 'ArrowRight' })
+    expect(onselect).toHaveBeenCalledWith('')
+  })
+
+  test('Home and End jump to the first and last chip', async () => {
+    const { container, onselect } = setup({ value: 'a' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[1], { key: 'End' })
+    expect(onselect).toHaveBeenCalledWith('b')
+    await fireEvent.keyDown(chips[1], { key: 'Home' })
+    expect(onselect).toHaveBeenCalledWith('')
+  })
+
+  test('arrow navigation moves DOM focus to the target chip', async () => {
+    const { container } = setup({ value: '' })
+    const chips = container.querySelectorAll('[role="radio"]')
+    chips[0].focus()
+    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(chips[1])
+  })
+
+  test('ignores unrelated keys', async () => {
+    const { container, onselect } = setup()
+    const chips = container.querySelectorAll('[role="radio"]')
+    await fireEvent.keyDown(chips[0], { key: 'a' })
+    expect(onselect).not.toHaveBeenCalled()
+  })
+
+  test('renders an optional colour dot and per-item testid', () => {
+    const { container } = setup()
+    expect(container.querySelector('[data-testid="chip-alpha"]')).toBeInTheDocument()
+    const dots = container.querySelectorAll('.chip-dot')
+    expect(dots).toHaveLength(1)
+    expect(dots[0].style.background).toBe('rgb(18, 52, 86)')
+  })
+
+  test('applies the compact size modifier', () => {
+    const { container } = setup({ size: 'sm' })
+    expect(container.querySelector('.filter-chips')).toHaveClass('filter-chips-sm')
+  })
+
+  test('renders nothing and ignores keys with an empty item list', async () => {
+    const { container, onselect } = setup({ items: [] })
+    const group = container.querySelector('[role="radiogroup"]')
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(0)
+    await fireEvent.keyDown(group, { key: 'ArrowRight' })
+    expect(onselect).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/inert.js
+++ b/web/src/inert.js
@@ -1,0 +1,54 @@
+/**
+ * Svelte action that keeps the `inert` content attribute in sync with a
+ * boolean, and hands focus back to whatever opened the panel when it closes.
+ *
+ * Collapsed inline panels stay mounted so the open/close animation can run,
+ * but while hidden their inputs must not be reachable by keyboard or exposed
+ * to assistive tech. `inert` does both; shared.css also flips `visibility` so
+ * the guarantee holds even where `inert` is unsupported.
+ *
+ * Applied as an action rather than `inert={...}` so the state lands on the
+ * content attribute: Svelte assigns the DOM property, which is invisible to
+ * environments that do not implement it.
+ *
+ * Focus handling: making an ancestor inert while focus is inside it drops
+ * focus to <body>, so a keyboard user who hits Cancel would restart their
+ * next Tab from the top of the page. The action remembers the element that
+ * was focused when the panel opened (the trigger) and restores it on close.
+ *
+ * Usage: <div class="inline-panel" class:open={open} use:inert={!open}>
+ */
+export function inert(node, isInert) {
+  let current = !!isInert
+  let opener = null
+
+  node.toggleAttribute('inert', current)
+
+  function restoreFocus() {
+    if (!node.contains(document.activeElement)) return
+    const target = opener
+    opener = null
+    if (target && target !== document.body && target.isConnected && typeof target.focus === 'function') {
+      target.focus()
+    } else {
+      document.activeElement?.blur?.()
+    }
+  }
+
+  return {
+    update(next) {
+      const value = !!next
+      if (value === current) return
+      if (value) {
+        // Closing: restore focus before the panel becomes unreachable.
+        restoreFocus()
+      } else {
+        // Opening: remember the trigger so Cancel/Save can return focus.
+        const active = document.activeElement
+        opener = active && active !== document.body && !node.contains(active) ? active : null
+      }
+      current = value
+      node.toggleAttribute('inert', current)
+    },
+  }
+}

--- a/web/src/pages/Agents.svelte
+++ b/web/src/pages/Agents.svelte
@@ -488,7 +488,8 @@
 {#if !($isMobile && mobileShowDetail)}
   <div class="page-header">
     <h1 class="page-title">Agents</h1>
-    <button class="btn-primary btn-sm mobile-fab" onclick={openAddForm} data-testid="add-agent-btn">+ Add Agent</button>
+    <button class="btn-primary btn-sm mobile-fab" onclick={openAddForm} data-testid="add-agent-btn"
+      aria-label="Add agent">{$isMobile ? '+' : '+ Add Agent'}</button>
   </div>
 {/if}
 <ErrorBanner message={error} />
@@ -1327,12 +1328,6 @@
     .list { width: 100%; }
     .list.mobile-cards { display: flex; flex-direction: column; gap: 12px; }
     .stat-cards { grid-template-columns: repeat(2, 1fr); }
-
-    .mobile-fab {
-      width: 36px; height: 36px; border-radius: 50%;
-      padding: 0; display: flex; align-items: center; justify-content: center;
-      font-size: 20px; line-height: 1;
-    }
   }
 
   /* Mobile agent cards */

--- a/web/src/pages/AuditLog.svelte
+++ b/web/src/pages/AuditLog.svelte
@@ -4,6 +4,7 @@
   import ErrorBanner from '../components/ErrorBanner.svelte'
   import AuditSession from '../components/AuditSession.svelte'
   import AuditRow from '../components/AuditRow.svelte'
+  import FilterChips from '../components/FilterChips.svelte'
 
   let events = $state([])
   let stats = $state(null)
@@ -56,17 +57,26 @@
     return new Date(now - (offsets[range] || 86400000)).toISOString()
   }
 
+  // Guards against out-of-order responses: filters can change faster than the
+  // API answers (arrow-keying across the chips), and a stale reply would
+  // otherwise repaint the list with a filter the user has already left.
+  let loadSeq = 0
+
   async function load(append = false) {
+    const seq = ++loadSeq
     try {
       error = ''
       if (!append) refreshing = true
       const since = sinceFromRange(timeRange)
       const res = await api.auditEvents({ category, status, search, since, limit: String(limit), offset: String(append ? offset : 0) })
+      if (seq !== loadSeq) return
       if (append) { events = [...events, ...res.events] }
       else { events = res.events; offset = 0 }
       total = res.total
-    } catch (e) { error = e.message }
-    finally { loading = false; refreshing = false }
+    } catch (e) {
+      if (seq === loadSeq) error = e.message
+    }
+    finally { if (seq === loadSeq) { loading = false; refreshing = false } }
   }
 
   async function loadStats() {
@@ -75,11 +85,17 @@
 
   function refresh() { load(); loadStats() }
   function loadMore() { offset += limit; load(true) }
+
+  // Chips select on arrow-key focus, so a keyboard user sweeping the bar would
+  // fire one request per chip. Coalesce them the way the search box does.
+  let filterTimeout
   function setFilter(key, value) {
     if (key === 'category') category = value
     else if (key === 'status') status = value
     else if (key === 'timeRange') timeRange = value
-    refresh()
+    refreshing = true
+    clearTimeout(filterTimeout)
+    filterTimeout = setTimeout(refresh, 120)
   }
   function toggleFollow() {
     follow = !follow
@@ -192,7 +208,7 @@
   }
 
   onMount(() => { refresh() })
-  onDestroy(() => { clearInterval(refreshTimer); clearTimeout(searchTimeout) })
+  onDestroy(() => { clearInterval(refreshTimer); clearTimeout(searchTimeout); clearTimeout(filterTimeout) })
 </script>
 
 <div class="audit-page">
@@ -242,23 +258,14 @@
   <!-- Filters -->
   <div class="filters">
     <span class="filter-label">Type</span>
-    <div class="filter-chips" role="radiogroup" aria-label="Category filter">
-      {#each categories as c}
-        <button class="chip" class:active={category === c.value} role="radio" aria-checked={category === c.value} onclick={() => setFilter('category', c.value)}>{c.label}</button>
-      {/each}
-    </div>
+    <FilterChips items={categories} value={category} label="Category filter" size="sm"
+      onselect={(v) => setFilter('category', v)} />
     <span class="filter-label">Status</span>
-    <div class="filter-chips" role="radiogroup" aria-label="Status filter">
-      {#each statuses as s}
-        <button class="chip" class:active={status === s.value} role="radio" aria-checked={status === s.value} onclick={() => setFilter('status', s.value)}>{s.label}</button>
-      {/each}
-    </div>
+    <FilterChips items={statuses} value={status} label="Status filter" size="sm"
+      onselect={(v) => setFilter('status', v)} />
     <span class="filter-label">Range</span>
-    <div class="filter-chips" role="radiogroup" aria-label="Time range">
-      {#each timeRanges as t}
-        <button class="chip" class:active={timeRange === t.value} role="radio" aria-checked={timeRange === t.value} onclick={() => setFilter('timeRange', t.value)}>{t.label}</button>
-      {/each}
-    </div>
+    <FilterChips items={timeRanges} value={timeRange} label="Time range" size="sm"
+      onselect={(v) => setFilter('timeRange', v)} />
   </div>
 
   <!-- Search -->
@@ -354,14 +361,6 @@
     gap: 6px 10px; margin-bottom: 8px; font-size: 11px; align-items: center;
   }
   .filter-label { color: var(--text-muted); font-weight: 500; }
-  .filter-chips { display: flex; flex-wrap: wrap; gap: 4px; }
-  .chip {
-    padding: 3px 9px; background: transparent;
-    border: 0.5px solid rgba(44,24,16,0.2); border-radius: 999px;
-    font-size: 11px; color: var(--text); cursor: pointer; transition: all 0.1s;
-  }
-  .chip:hover { border-color: var(--accent); }
-  .chip.active { background: var(--accent); color: white; border-color: var(--accent); }
 
   /* Search card */
   .search-card {

--- a/web/src/pages/Channels.svelte
+++ b/web/src/pages/Channels.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte'
   import { api } from '../api.js'
+  import { inert } from '../inert.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
 
   let channels = $state([])
@@ -131,11 +132,12 @@
 
 <div class="page-header">
   <h1 class="page-title">Channels</h1>
-  <button class="btn-primary btn-sm" onclick={openAdd} data-testid="add-channel-btn">+ Add Channel</button>
+  <button class="btn-primary btn-sm" onclick={openAdd} data-testid="add-channel-btn"
+    aria-expanded={showForm} aria-controls="channel-form-panel">+ Add Channel</button>
 </div>
 <ErrorBanner message={error} />
 
-<div class="inline-panel" class:open={showForm}>
+<div class="inline-panel" id="channel-form-panel" class:open={showForm} use:inert={!showForm}>
   <div class="inline-panel-inner">
     <div class="inline-form" data-testid="channel-form">
       <h2 class="form-title">{editingName ? 'Edit Channel' : 'Add Channel'}</h2>

--- a/web/src/pages/KV.svelte
+++ b/web/src/pages/KV.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte'
   import { api } from '../api.js'
+  import { inert } from '../inert.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
 
   let agents = $state([])
@@ -117,7 +118,7 @@
 
 <div class="page-header">
   <h1 class="page-title">KV Store</h1>
-  <button class="btn-primary" onclick={() => showSetForm = !showSetForm} aria-expanded={showSetForm} disabled={!selectedAgent}>
+  <button class="btn-primary" onclick={() => showSetForm = !showSetForm} aria-expanded={showSetForm} aria-controls="kv-set-panel" disabled={!selectedAgent}>
     {showSetForm ? 'Cancel' : 'Set Key'}
   </button>
 </div>
@@ -142,7 +143,7 @@
   </label>
 </div>
 
-<div class="inline-panel" class:open={showSetForm}>
+<div class="inline-panel" id="kv-set-panel" class:open={showSetForm} use:inert={!showSetForm}>
   <div class="inline-panel-inner">
     <form class="inline-form" onsubmit={(e) => { e.preventDefault(); doSet() }}>
       <h2 class="form-title">Set Key</h2>

--- a/web/src/pages/Providers.svelte
+++ b/web/src/pages/Providers.svelte
@@ -295,7 +295,7 @@
 <ErrorBanner message={error} />
 
 {#if showAddForm}
-<div class="inline-panel" data-testid="provider-form">
+<div class="form-card" data-testid="provider-form">
   <h3 class="form-title">Add Provider</h3>
   {#if formError}
     <div class="inline-error" role="alert">{formError}</div>
@@ -847,8 +847,8 @@
     font-weight: 500;
   }
 
-  /* Inline add form */
-  .inline-panel {
+  /* Inline add form (own card; not the collapsible .inline-panel pattern) */
+  .form-card {
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);

--- a/web/src/pages/Schedules.svelte
+++ b/web/src/pages/Schedules.svelte
@@ -1,9 +1,11 @@
 <script>
   import { onMount, tick } from 'svelte'
   import { api } from '../api.js'
+  import { inert } from '../inert.js'
   import { isMobile } from '../store.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
   import KebabMenu from '../components/KebabMenu.svelte'
+  import FilterChips from '../components/FilterChips.svelte'
   import { agentColor } from '../agentColor.js'
   import { relativeTime, shortAbsolute } from '../relativeTime.js'
 
@@ -73,6 +75,16 @@
   })
 
   const visibleGroups = $derived(filterAgent ? groups.filter(g => g.agent === filterAgent) : groups)
+
+  const agentChips = $derived([
+    { value: '', label: `All agents (${schedules.length})` },
+    ...groups.map(g => ({
+      value: g.agent,
+      label: `${g.agent} (${g.schedules.length})`,
+      dot: agentColor(g.agent),
+      testid: `agent-chip-${g.agent}`,
+    })),
+  ])
 
   async function loadData() {
     loading = true
@@ -225,7 +237,8 @@
   <div class="page-header">
     <h1 class="page-title">Schedules</h1>
     <button class="btn-primary" class:mobile-fab={$isMobile} onclick={openAdd}
-      data-testid="add-schedule-btn" aria-label="Add schedule">{$isMobile ? '+' : '+ Add Schedule'}</button>
+      data-testid="add-schedule-btn" aria-label="Add schedule"
+      aria-expanded={showForm} aria-controls="schedule-form-panel">{$isMobile ? '+' : '+ Add Schedule'}</button>
   </div>
 
   <p class="tz-note">Cron schedules run in <strong>{timezone}</strong> time. <a href="#/server">Change</a></p>
@@ -237,7 +250,7 @@
   {/if}
 
   <!-- Inline Add/Edit Panel -->
-  <div class="inline-panel" class:open={showForm} bind:this={panelEl}>
+  <div class="inline-panel" id="schedule-form-panel" class:open={showForm} use:inert={!showForm} bind:this={panelEl}>
     <div class="inline-panel-inner">
       <div class="inline-form" data-testid="schedule-form">
         <h2 class="form-title">{editingName ? 'Edit Schedule' : 'Add Schedule'}</h2>
@@ -321,15 +334,9 @@
     <p class="muted">No schedules configured. Add one to automate recurring tasks.</p>
   {:else}
     {#if groups.length > 1}
-      <div class="filter-chips" role="radiogroup" aria-label="Filter by agent" data-testid="agent-filter">
-        <button class="chip" class:active={filterAgent === ''} role="radio" aria-checked={filterAgent === ''}
-          onclick={() => filterAgent = ''}>All agents ({schedules.length})</button>
-        {#each groups as g (g.agent)}
-          <button class="chip" class:active={filterAgent === g.agent} role="radio" aria-checked={filterAgent === g.agent}
-            data-testid="agent-chip-{g.agent}" onclick={() => filterAgent = g.agent}>
-            <span class="chip-dot" style="background: {agentColor(g.agent)}"></span>{g.agent} ({g.schedules.length})
-          </button>
-        {/each}
+      <div class="filter-bar">
+        <FilterChips items={agentChips} value={filterAgent} label="Filter by agent"
+          testid="agent-filter" onselect={(v) => filterAgent = v} />
       </div>
     {/if}
 
@@ -352,7 +359,7 @@
                   {#if s.session_tier}
                     <span class="tier-badge tier-{s.session_tier}">{s.session_tier}</span>
                   {/if}
-                  <label class="switch">
+                  <label class="switch switch-sm">
                     <input type="checkbox" checked={s.enabled} disabled={togglingName === s.name}
                       onchange={() => toggleEnabled(s)} aria-label="Toggle {s.name}" />
                     <span class="switch-slider"></span>
@@ -412,7 +419,7 @@
                     {/if}
                   </td>
                   <td>
-                    <label class="switch">
+                    <label class="switch switch-sm">
                       <input type="checkbox" checked={s.enabled} disabled={togglingName === s.name}
                         onchange={() => toggleEnabled(s)} aria-label="Toggle {s.name}" />
                       <span class="switch-slider"></span>
@@ -462,18 +469,8 @@
   .form-title { font-size: 16px; font-weight: 600; margin-bottom: 16px; }
   .load-warning { font-size: 12px; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 8px 12px; margin-bottom: 12px; }
 
-  /* Agent filter chips */
-  .filter-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
-  .chip {
-    display: inline-flex; align-items: center; gap: 6px;
-    padding: 4px 11px; background: transparent;
-    border: 1px solid var(--border); border-radius: 999px;
-    font-size: 12px; color: var(--text); cursor: pointer; transition: all 0.1s;
-  }
-  .chip:hover { border-color: var(--accent); }
-  .chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-  .chip.active { background: var(--accent); color: white; border-color: var(--accent); }
-  .chip-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  /* Agent filter chips (styling + keyboard behaviour: FilterChips/shared.css) */
+  .filter-bar { margin-bottom: 16px; }
 
   /* Agent sections */
   .agent-section {
@@ -512,13 +509,6 @@
   tr.paused .name, tr.paused .cron,
   .cell.paused .name, .cell.paused .cron { opacity: 0.55; }
 
-  /* Round add-FAB when the header button renders in mobile mode */
-  .mobile-fab {
-    width: 36px; height: 36px; border-radius: 50%;
-    padding: 0; display: flex; align-items: center; justify-content: center;
-    font-size: 20px; line-height: 1;
-  }
-
   /* Mobile card list — replaces the per-section table under isMobile */
   .cell-list { list-style: none; margin: 0; padding: 0; }
   .cell { display: flex; flex-direction: column; gap: 4px; padding: 12px 16px; }
@@ -538,22 +528,9 @@
   .cell-bottom .abs { display: inline; white-space: nowrap; }
   .cell-bottom .paused-label { font-size: 11px; }
 
-  /* Pill toggle switch — Tools-style, compact for table rows; green = enabled status */
-  .switch { position: relative; display: inline-block; width: 36px; height: 20px; flex-shrink: 0; }
-  .switch input { opacity: 0; width: 0; height: 0; }
-  .switch-slider {
-    position: absolute; cursor: pointer; inset: 0;
-    background: var(--border); border-radius: 20px; transition: background 0.2s;
-  }
-  .switch-slider::before {
-    content: ""; position: absolute; height: 14px; width: 14px;
-    left: 3px; bottom: 3px; background: white; border-radius: 50%;
-    transition: transform 0.2s;
-  }
+  /* Pill toggle switch — base pattern lives in shared.css; here the "on"
+     state is green because it reads as enabled/disabled status, not accent. */
   .switch input:checked + .switch-slider { background: var(--success); }
-  .switch input:checked + .switch-slider::before { transform: translateX(16px); }
-  .switch input:disabled + .switch-slider { opacity: 0.6; cursor: wait; }
-  .switch input:focus-visible + .switch-slider { outline: 2px solid var(--accent); outline-offset: 2px; }
 
   /* Icon action buttons */
   .actions { white-space: nowrap; }

--- a/web/src/pages/ServerConfig.svelte
+++ b/web/src/pages/ServerConfig.svelte
@@ -322,9 +322,9 @@
       <div class="config-value-row">
         <span class="status-dot" class:status-on={config.mcp_server_enabled} class:status-off={!config.mcp_server_enabled}></span>
         <span class="config-value">{config.mcp_server_enabled ? 'Enabled' : 'Disabled'}</span>
-        <label class="switch">
+        <label class="switch switch-sm">
           <input type="checkbox" aria-label="MCP server" checked={config.mcp_server_enabled} onchange={toggleMcp} disabled={savingMcp} />
-          <span class="slider"></span>
+          <span class="switch-slider"></span>
         </label>
       </div>
     </div>
@@ -426,9 +426,9 @@
       <div class="config-value-row">
         <span class="status-dot" class:status-on={config.web_tools_enabled} class:status-off={!config.web_tools_enabled}></span>
         <span class="config-value">{config.web_tools_enabled ? 'Enabled' : 'Disabled'}</span>
-        <label class="switch">
+        <label class="switch switch-sm">
           <input type="checkbox" aria-label="Web tools" checked={config.web_tools_enabled} onchange={toggleWebTools} disabled={savingWeb} />
-          <span class="slider"></span>
+          <span class="switch-slider"></span>
         </label>
       </div>
     </div>
@@ -446,9 +446,9 @@
       <div class="config-value-row">
         <span class="status-dot" class:status-on={config.script_enabled} class:status-off={!config.script_enabled}></span>
         <span class="config-value">{config.script_enabled ? 'Enabled' : 'Disabled'}</span>
-        <label class="switch">
+        <label class="switch switch-sm">
           <input type="checkbox" aria-label="Deterministic compute" checked={config.script_enabled} onchange={toggleScript} disabled={savingScript} />
-          <span class="slider"></span>
+          <span class="switch-slider"></span>
         </label>
       </div>
     </div>
@@ -682,36 +682,7 @@
   .status-on { background: var(--success); }
   .status-off { background: var(--text-muted); }
 
-  .switch {
-    position: relative;
-    display: inline-block;
-    width: 36px;
-    height: 20px;
-    flex-shrink: 0;
-  }
-  .switch input { opacity: 0; width: 0; height: 0; }
-  .slider {
-    position: absolute;
-    cursor: pointer;
-    inset: 0;
-    background: var(--border);
-    border-radius: 20px;
-    transition: background 0.2s;
-  }
-  .slider::before {
-    content: '';
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    left: 3px;
-    bottom: 3px;
-    background: #fff;
-    border-radius: 50%;
-    transition: transform 0.2s;
-  }
-  .switch input:checked + .slider { background: var(--accent); }
-  .switch input:checked + .slider::before { transform: translateX(16px); }
-  .switch input:disabled + .slider { opacity: 0.5; cursor: not-allowed; }
+  /* Pill toggle switch — shared pattern (.switch / .switch-slider) in shared.css. */
 
   .inline-select {
     width: auto;

--- a/web/src/pages/SetupWizard.svelte
+++ b/web/src/pages/SetupWizard.svelte
@@ -257,8 +257,9 @@ Remember you're a guest. You have access to someone's life — treat it with res
       <input type="url" class="input" bind:value={providerBaseURL} disabled={providerSaving} placeholder={providerType === 'ollama' ? 'http://localhost:11434' : `https://api.${providerType}.com`} data-testid="wizard-provider-baseurl" />
 
       <label class="toggle-row">
-        <span class="toggle-switch" class:on={providerSetDefault} role="switch" aria-checked={providerSetDefault} tabindex="0" onclick={() => providerSetDefault = !providerSetDefault} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); providerSetDefault = !providerSetDefault } }}>
-          <span class="toggle-knob"></span>
+        <span class="switch switch-sm">
+          <input type="checkbox" bind:checked={providerSetDefault} />
+          <span class="switch-slider"></span>
         </span>
         <span>Set as default provider</span>
       </label>
@@ -469,7 +470,7 @@ Remember you're a guest. You have access to someone's life — treat it with res
     background: var(--bg);
   }
 
-  /* Toggle switch */
+  /* Toggle switch — pill pattern (.switch / .switch-slider) lives in shared.css */
   .toggle-row {
     display: flex;
     align-items: center;
@@ -477,27 +478,6 @@ Remember you're a guest. You have access to someone's life — treat it with res
     font-size: 13px;
     cursor: pointer;
   }
-  .toggle-switch {
-    display: inline-flex;
-    align-items: center;
-    width: 36px;
-    height: 20px;
-    border-radius: 10px;
-    background: var(--border);
-    padding: 2px;
-    cursor: pointer;
-    transition: background 0.15s;
-    flex-shrink: 0;
-  }
-  .toggle-switch.on { background: var(--accent); }
-  .toggle-knob {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: #fff;
-    transition: transform 0.15s;
-  }
-  .toggle-switch.on .toggle-knob { transform: translateX(16px); }
 
   /* Permission tier radio buttons */
   .tier-options {

--- a/web/src/pages/Skills.svelte
+++ b/web/src/pages/Skills.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte'
   import { api } from '../api.js'
+  import { inert } from '../inert.js'
   import { pendingSkillTest } from '../chatStore.js'
   import { navigate } from '../router.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
@@ -153,7 +154,8 @@
 <div class="page">
   <div class="page-header">
     <h1 class="page-title">Skills</h1>
-    <button class="btn-primary" onclick={openAdd}>+ Add Skill</button>
+    <button class="btn-primary" onclick={openAdd}
+      aria-expanded={showForm} aria-controls="skill-form-panel">+ Add Skill</button>
   </div>
 
   <div class="toolbar">
@@ -168,7 +170,7 @@
   <ErrorBanner message={error} />
 
   <!-- Inline Add/Edit Panel -->
-  <div class="inline-panel" class:open={showForm}>
+  <div class="inline-panel" id="skill-form-panel" class:open={showForm} use:inert={!showForm}>
     <div class="inline-panel-inner">
       <div class="inline-form">
         {#if editingSkill}

--- a/web/src/pages/Tools.svelte
+++ b/web/src/pages/Tools.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from 'svelte'
   import { api } from '../api.js'
+  import { inert } from '../inert.js'
   import KebabMenu from '../components/KebabMenu.svelte'
 
   let tools = []
@@ -593,7 +594,8 @@
   <div class="section">
     <div class="page-header">
       <h1>MCP Tools</h1>
-      <button class="btn-primary" onclick={openAddToolForm}>+ Add Tool</button>
+      <button class="btn-primary" onclick={openAddToolForm}
+        aria-expanded={showToolForm && !editingToolName} aria-controls="tool-form-panel">+ Add Tool</button>
     </div>
 
     {#snippet toolFormFields()}
@@ -774,7 +776,7 @@
     {/snippet}
 
     <!-- Add tool panel (top-level, only for adding new tools) -->
-    <div class="inline-panel" class:open={showToolForm && !editingToolName}>
+    <div class="inline-panel" id="tool-form-panel" class:open={showToolForm && !editingToolName} use:inert={!(showToolForm && !editingToolName)}>
       <div class="inline-panel-inner">
         <div class="inline-form">
           <h2 class="form-title">Add MCP Tool</h2>
@@ -952,11 +954,12 @@
   <div class="section">
     <div class="page-header">
       <h1>Plugins</h1>
-      <button class="btn-primary" onclick={() => { showPluginForm = !showPluginForm }}>+ Add Plugin</button>
+      <button class="btn-primary" onclick={() => { showPluginForm = !showPluginForm }}
+        aria-expanded={showPluginForm} aria-controls="plugin-form-panel">+ Add Plugin</button>
     </div>
 
     <!-- Inline form -->
-    <div class="inline-panel" class:open={showPluginForm}>
+    <div class="inline-panel" id="plugin-form-panel" class:open={showPluginForm} use:inert={!showPluginForm}>
       <div class="inline-panel-inner">
         <div class="inline-form">
           <h2 class="form-title">Add Plugin</h2>
@@ -1376,44 +1379,8 @@
     color: var(--text-muted);
   }
 
-  /* Pill toggle switch */
-  .switch {
-    position: relative;
-    display: inline-block;
-    width: 44px;
-    height: 24px;
-    flex-shrink: 0;
-  }
-  .switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-  .switch-slider {
-    position: absolute;
-    cursor: pointer;
-    inset: 0;
-    background: var(--border);
-    border-radius: 24px;
-    transition: background 0.2s;
-  }
-  .switch-slider::before {
-    content: "";
-    position: absolute;
-    height: 18px;
-    width: 18px;
-    left: 3px;
-    bottom: 3px;
-    background: white;
-    border-radius: 50%;
-    transition: transform 0.2s;
-  }
-  .switch input:checked + .switch-slider {
-    background: var(--accent);
-  }
-  .switch input:checked + .switch-slider::before {
-    transform: translateX(20px);
-  }
+  /* Pill toggle switch — pattern (sizes, focus ring, 44px tap zone)
+     lives in shared.css. */
 
   /* Collapsible toggle row inside settings cards */
   .settings-card-toggle {
@@ -1805,17 +1772,9 @@
     gap: 8px;
   }
 
+  /* Nudges the compact switch onto the baseline of the row title. */
   .switch-sm {
-    width: 36px;
-    height: 20px;
     margin-top: 4px;
-  }
-  .switch-sm .switch-slider::before {
-    height: 14px;
-    width: 14px;
-  }
-  .switch-sm input:checked + .switch-slider::before {
-    transform: translateX(16px);
   }
 
   /* Unsafe options section (inside connection settings) */

--- a/web/src/shared.css
+++ b/web/src/shared.css
@@ -124,10 +124,16 @@
 .inline-panel {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows 0.2s ease;
+  /* `visibility` keeps the collapsed form out of the tab order (it is still in
+     the DOM so the open/close animation can run). Pages also set `inert` while
+     closed; the two are belt-and-braces. Transitioning visibility flips it to
+     `visible` immediately on open and defers `hidden` until the collapse ends. */
+  visibility: hidden;
+  transition: grid-template-rows 0.2s ease, visibility 0.2s ease;
 }
 .inline-panel.open {
   grid-template-rows: 1fr;
+  visibility: visible;
 }
 .inline-panel-inner {
   overflow: hidden;
@@ -205,6 +211,118 @@
 .inline-form .hint {
   font-size: 11px;
   color: var(--text-muted);
+}
+
+/* ---------- Pill toggle switch ------------------------------------------- */
+/* Markup contract:
+     <label class="switch"><input type="checkbox" ...><span class="switch-slider"></span></label>
+   The native checkbox is visually hidden but still focusable, so the focus ring
+   is drawn on the slider. `.switch-sm` is the compact variant for dense rows. */
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.switch-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--border);
+  border-radius: 999px;
+  transition: background 0.2s;
+}
+.switch-slider::before {
+  content: "";
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+/* WCAG 2.5.5 / Apple HIG: expand the tap zone to at least 44x44 without
+   changing the rendered size of the pill. Touch input only — on a mouse the
+   invisible overlay would reach into neighbouring table rows, which are
+   shorter than 44px, and steal their clicks. */
+@media (pointer: coarse) {
+  .switch-slider::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 100%;
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+.switch input:checked + .switch-slider { background: var(--accent); }
+.switch input:checked + .switch-slider::before { transform: translateX(20px); }
+.switch input:disabled + .switch-slider { opacity: 0.6; cursor: wait; }
+.switch input:focus-visible + .switch-slider {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.switch.switch-sm { width: 36px; height: 20px; }
+.switch.switch-sm .switch-slider::before { height: 14px; width: 14px; }
+.switch.switch-sm input:checked + .switch-slider::before { transform: translateX(16px); }
+
+/* ---------- Filter chips -------------------------------------------------- */
+/* Rendered by components/FilterChips.svelte, which owns the radiogroup
+   keyboard contract (single tab stop + Arrow/Home/End). */
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.filter-chips.filter-chips-sm { gap: 4px; }
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  /* WCAG 2.5.8 minimum target size. */
+  min-height: 24px;
+  padding: 4px 11px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+.chip:hover { border-color: var(--accent); }
+.chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.chip.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+
+.filter-chips-sm .chip { padding: 3px 9px; font-size: 11px; }
+
+/* Chips stay compact on a mouse; touch gets a comfortable target. */
+@media (pointer: coarse) {
+  .chip,
+  .filter-chips-sm .chip { min-height: 32px; }
+}
+
+.chip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 /* ---------- Utilities ---------------------------------------------------- */
@@ -348,6 +466,25 @@
   .btn-ghost,
   .btn-save {
     min-height: 44px;
+  }
+  /* Round add-FAB used by page headers on mobile. 44x44 meets the minimum
+     touch-target size. */
+  .mobile-fab {
+    width: 44px;
+    height: 44px;
+    min-height: 44px;
+    border-radius: 50%;
+    padding: 0;
+    /* .btn-sm adds a right margin that would push the FAB off the edge. */
+    margin-right: 0;
+    background: var(--accent);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    line-height: 1;
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
Closes #228

Four pattern-level accessibility gaps in shared web-dashboard patterns, fixed as one sweep. Where a fix was genuinely shared it was hoisted into `shared.css` or a shared component rather than duplicated per page.

## 1. Touch targets below 44px

- **Pill switch** (`.switch`, Tools + Schedules): the whole pattern moved into `shared.css` with a `.switch-slider::after` overlay that grows the hit area to at least 44×44 without changing the rendered pill.
- **`KebabMenu` trigger**: same treatment via `::before` around the 32px button.
- **Mobile FABs** (Agents, Schedules): the duplicated `.mobile-fab` rule moved into `shared.css` at 44×44 (was 36×36). Agents' FAB now renders `+` on mobile like Schedules instead of clipping "+ Add Agent" into a circle.

The switch and kebab overlays are scoped to `@media (pointer: coarse)`. With a mouse an invisible 44px box overhangs neighbouring table rows — Schedules' desktop rows are ~40px tall — and would steal their clicks; touch is where the guideline applies.

Chips also picked up a `min-height` (24px, 32px on coarse pointers) so the smallest controls on the page clear the AA target size.

## 2. No visible focus indicator on toggle switches

`.switch input:focus-visible + .switch-slider` now lives in `shared.css`, so every switch in the app has the ring (Tools had none). The kebab trigger gained a `:focus-visible` ring too.

## 3. Collapsed inline panels remained keyboard-focusable

- `shared.css`: `.inline-panel` collapses with `visibility: hidden` (transitioned, so the open animation still runs) and `.open` restores it.
- New `web/src/inert.js` action sets the `inert` content attribute while the panel is closed; applied to all six collapsible panels (Schedules, Skills, Channels, KV, Tools ×2).
- The action also returns focus to the trigger when the panel closes — making an ancestor `inert` while focus is inside it drops focus to `<body>`, which would have been a new regression for keyboard users hitting Cancel.
- Triggers gained `aria-expanded`/`aria-controls`, since the panels persist in the DOM.
- `Providers.svelte` reused the `.inline-panel` class name for a static card (not the collapsible pattern); renamed to `.form-card` so it does not inherit the collapsed state.

## 4. Filter chips: radiogroup role without roving tabindex

New `web/src/components/FilterChips.svelte` keeps `role="radiogroup"`/`role="radio"` and implements the contract that role advertises: one tab stop (roving tabindex on the selected chip) plus Arrow/Home/End with selection following focus. Both chip bars use it — AuditLog (3 bars) and Schedules (agent filter) — and the chip styling moved to `shared.css` so they match. Because selection now follows focus, AuditLog coalesces filter changes into a single refetch and drops out-of-order responses.

## Additional instances found while grepping

- `ServerConfig.svelte` had a third copy of the switch (`.slider`, 36×20, no focus ring) — folded into the shared pattern.
- `SetupWizard.svelte` had a hand-rolled `role="switch"` span with no focus style — replaced with the shared markup, which also clears a Svelte `a11y_label_has_associated_control` warning.

## Tests

- `web/src/components/__tests__/FilterChips.test.js` (16): roving tabindex incl. fallback, Arrow/Home/End with wrap-around, focus movement, click selection, dot/testid rendering, empty list.
- `web/src/__tests__/inert.test.js` (7): attribute toggling and focus return to the opener.
- `Schedules.test.js`: collapsed panel is inert / open panel is not; chips are a single tab stop and respond to arrows.
- `AuditLog.test.js`: roving tabindex + arrow/Home navigation across a chip bar; arrow sweeps coalesce into one refetch.
- `Tools.test.js`, `Channels.test.js`: panels go inert when collapsed.

`just hook` passes (fmt-check, vet, lint, lint-ui, test, test-ui — 750 UI tests). UI coverage stays above the thresholds (lines 78.2% vs 76, branches 60.9% vs 58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsdhCwSR1uZ5dcYziVBvWp
