### PR TITLE
chore(api): regenerate stale OpenAPI spec to green the freshness gate

### DIFF
--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -5527,7 +5527,16 @@
                         "description": "Tool removed"
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Tool not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Removal failed",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -5705,7 +5714,16 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request",
+                        "description": "Invalid request body or update failed",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Tool not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {


### PR DESCRIPTION
`7487fa1` ("return 404 for tool-not-found on all tool endpoints") added
`@Failure` annotations to handleRemoveTool and handleUpdateDisabledTools
without regenerating the committed spec. `ec2d478` regenerated the spec
immediately afterwards, but off a branch that predated those annotations,
so the merged result was stale on arrival. The freshness gate (`2c2c179`)
landed after both, so main has been red on every push since — OpenAPI Spec
Freshness is the only failing job; the other nine pass.

Regenerate with the pinned swag 1.16.6. Mechanical `just openapi` output,
no functional change: DELETE /tools/{name} gains its documented 404/500
bodies, PUT /tools/{name}/disabled-tools gains 404 and the real 400
description.

Verified `swag` output is byte-identical across repeated runs, and that
every `@Router` annotation in internal/api now round-trips into the spec
(no silently dropped endpoints from the detached-annotation-block gotcha).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YLrpenXS4tW8KcMRCqbe4M