### PR TITLE
fix(security): restore secret-scanning allowlist, wire it into `just scan`

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -1,0 +1,20 @@
+# betterleaks secret-scanning config.
+#
+# This file IS live: betterleaks resolves config from (target path)/.betterleaks.toml
+# when no --config/-c flag or BETTERLEAKS_CONFIG env var is set, which is how the
+# `betterleaks git . --exit-code 1` step in .github/workflows/security.yml runs.
+# Deleting it re-opens the false positives below and reds the Secret Detection job.
+
+title = "denkeeper betterleaks config"
+
+[extend]
+useDefault = true
+
+# Allowlist the placeholder *value*, not the files that contain it. Scoping by path
+# instead (README.md, website/**.md) would blind the scanner to a genuine key pasted
+# into the docs; matching on the secret keeps every file scanned and only forgives
+# strings that literally say "your"/"example"/"test".
+[[allowlists]]
+description = "Documentation placeholder API keys (dk-your-secret-key, dk_yourkey, ...)"
+regexTarget = "secret"
+regexes = ['''(?i)^dk[_-](your|example|test|placeholder|xxx)''']

--- a/.mise.toml
+++ b/.mise.toml
@@ -7,3 +7,5 @@ task = "3.52.0"
 "go:github.com/air-verse/air" = "1.67.3"
 "aqua:casey/just" = "1.57.0"
 "aqua:anchore/grype" = "0.116.1"
+# Keep in sync with the betterleaks job in .github/workflows/security.yml.
+"aqua:betterleaks/betterleaks" = "1.1.2"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -216,9 +216,18 @@ tasks:
     cmds:
       - mise x -- grype dir:. --fail-on high --only-fixed
 
+  # Deliberately uncached (no sources): this scans git history, not the working
+  # tree, so a file fingerprint is the wrong cache key — a commit that touches
+  # no declared source would let a newly introduced secret through. Full history
+  # takes ~1s, so there is nothing to save.
+  scan:secrets:
+    desc: Scan git history for committed secrets (matches CI's betterleaks job; uses .betterleaks.toml)
+    cmds:
+      - mise x -- betterleaks git . --exit-code 1
+
   scan:
-    desc: Run all security scans (gosec + govulncheck + grype)
-    deps: [scan:gosec, scan:govulncheck, scan:grype]
+    desc: Run all security scans (gosec + govulncheck + grype + secrets)
+    deps: [scan:gosec, scan:govulncheck, scan:grype, scan:secrets]
 
   # ---- Documentation website ------------------------------------------
   website:install:

--- a/justfile
+++ b/justfile
@@ -218,9 +218,10 @@ release bump:
     git push origin "$tag"
     echo "Released ${tag}"
 
-# Run security scans (cached via Task; usage: just scan [gosec|govulncheck|grype], default: all).
+# Run security scans (cached via Task; usage: just scan [gosec|govulncheck|grype|secrets], default: all).
 # Pass --force to a specific scan (e.g. `mise x -- task scan:govulncheck --force`)
 # to re-check against a fresh vulnerability database when sources are unchanged.
+# `secrets` scans git history and is always uncached.
 scan tool="all":
     #!/usr/bin/env sh
     set -e
@@ -229,8 +230,9 @@ scan tool="all":
         gosec)       mise x -- task scan:gosec ;;
         govulncheck) mise x -- task scan:govulncheck ;;
         grype)       mise x -- task scan:grype ;;
+        secrets)     mise x -- task scan:secrets ;;
         *)
-            echo "Unknown scan: {{tool}}. Available: gosec, govulncheck, grype"
+            echo "Unknown scan: {{tool}}. Available: gosec, govulncheck, grype, secrets"
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Why

The `Secret Detection` CI job has been red since `ae066cf`, which removed `.gitleaks.toml` as "orphaned". It was not orphaned — betterleaks resolves config from `(target path)/.betterleaks.toml` **or `.gitleaks.toml`** when no `--config/-c` flag or `BETTERLEAKS_CONFIG` env var is set, which is exactly how the `betterleaks git . --exit-code 1` step in `security.yml` runs. Deleting it re-opened three false positives on documentation placeholder API keys (`dk-your-secret-key`, `dk_yourkey`).

## What changed

**1. Restore the allowlist as `.betterleaks.toml`** — named for the tool actually in use, with a header comment recording that the file is live, so it is not garbage-collected as dead weight a second time.

Rather than restoring the old file verbatim, this allowlists the placeholder **value** instead of the paths containing it:

```toml
[[allowlists]]
regexTarget = "secret"
regexes = ['''(?i)^dk[_-](your|example|test|placeholder|xxx)''']
```

The previous config allowlisted by `paths` (`README\.md`, `website/.*\.md`). Testing showed the path clause dominates, so a genuine high-entropy `dk_` key pasted into `README.md` was passed silently — restoring it as-was would have re-created a blind spot over the docs. Matching on the secret keeps every file scanned and forgives only strings that literally say `your`/`example`/`test`.

The old config's other two blocks are dropped: `test/e2e/fixtures/` no longer exists, and the two pinned historical commit SHAs are unnecessary — full history is clean without them.

**2. Wire secret scanning into `just scan`** — it previously lived only in CI, which is why this surfaced by hand rather than at scan time. betterleaks is pinned in `.mise.toml` to `1.1.2`, matching what `security.yml` installs.

The task is deliberately uncached (no `sources`), following the `openapi:check` precedent: it scans git history rather than the working tree, so a file fingerprint is the wrong cache key — a commit touching no declared source would let a newly introduced secret through. Full history is ~1.4s.

## Verification

| Case | Result |
|---|---|
| `dk-your-secret-key`, `dk_yourkey` in README | allowed |
| `dk_7Fq3xZm9Lp2WvR8tKc4YbN6HsJd1Ge5A` in README | **flagged** |
| `dk_Qw9ZxLm4Rt7Yb2Nc8Kp5Hf3Jd6Ge1As` in a `.go` file | **flagged** |
| Full repo, 690 commits, exact CI command | no leaks, exit 0 |
| Real secret committed to a throwaway repo | exit 1 — gate still bites |

`just scan secrets` passes. Note that `just scan gosec` and `just scan grype` fail on **pre-existing** dependency vulnerabilities on `main`, unrelated to this change and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)