### PR TITLE
ci: skip Claude review job on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   claude-review:
-    if: github.actor != 'dependabot[bot]'
+    # Fork PRs get no secrets and no id-token from a `pull_request` event, so the
+    # action cannot authenticate and the job fails unconditionally. Skip them here;
+    # a maintainer can still trigger a review by commenting `@claude` (claude.yml
+    # runs on issue_comment in base-repo context, where both are available).
+    if: ${{ github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The `Claude Code Review` job fails unconditionally on PRs opened from a fork — [PR #246](https://github.com/Temikus/denkeeper/pull/246) has failed 7/7 times, while every same-repo branch passes.

The job dies in `Run Claude Code Review` after 3 retries:

```
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
error: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

The message is misleading — `id-token: write` **is** already declared. The runner log shows what actually happens:

```
##[group]GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
Secret source: None
...
CLAUDE_CODE_OAUTH_TOKEN:        <- empty
```

For a `pull_request` event from a fork, GitHub unconditionally withholds all repo secrets and caps the token to read-only, dropping `id-token` entirely. With `CLAUDE_CODE_OAUTH_TOKEN` empty, the action falls back to OIDC to mint a GitHub token — the one path a fork can't reach. Nothing in the PR diff is involved, and re-running always fails identically.

## Change

Gate the job on `github.event.pull_request.head.repo.fork == false`, so fork PRs report the check as skipped instead of permanently red.

Maintainers can still get a review on a fork PR by commenting `@claude` — `claude.yml` runs on `issue_comment`, which executes in base-repo context where secrets and OIDC are both available.

## Alternative considered

`pull_request_target` would restore credentials, but it runs with write-capable permissions while checking out untrusted fork code in a public repo. Not worth the exposure for a review convenience.