### PR TITLE
ci: comment on PRs when their changes are released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,3 +181,40 @@ jobs:
           subject-name: ghcr.io/temikus/denkeeper
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+  stamp-prs:
+    name: Stamp Released PRs
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write # PR comments go through the issues API
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      # Map every commit in this release back to its PR via the GitHub API rather
+      # than parsing commit subjects — history mixes squash merges, merge commits
+      # and direct pushes to main, so subject parsing would miss cases.
+      - name: Comment on PRs included in this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PREV=$(git describe --tags --abbrev=0 "${VERSION}^" 2>/dev/null || true)
+          RANGE="${PREV:+${PREV}..}${VERSION}"
+          echo "Release range: ${RANGE}"
+          PRS=$(git log --format='%H' "${RANGE}" \
+            | xargs -I{} gh api "repos/${GITHUB_REPOSITORY}/commits/{}/pulls" --jq '.[].number' \
+            | sort -un)
+          if [ -z "${PRS}" ]; then
+            echo "No PRs associated with this range."
+            exit 0
+          fi
+          while read -r pr; do
+            echo "Commenting on #${pr}"
+            gh pr comment "${pr}" --repo "${GITHUB_REPOSITORY}" \
+              --body "🚀 Released in [\`${VERSION}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION})"
+          done <<< "${PRS}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,8 @@ Things you can't infer by reading the code at a glance:
 - **`internal/agentctx`**: context key package shared between `agent` and `configmcp` to avoid an import cycle. Use it when threading agent identity through MCP handlers.
 - **Date/week injection (two-point)**: the model never has to infer "today". (1) Scheduled messages render the fire time via `scheduler.FormatScheduledText` — `[Scheduled: heartbeat | 2026-07-07T10:45:00+10:00 Australia/Sydney | 2026-W28]` — computed inside the fire callback (both producers: `registerSchedules`/`buildScheduledMessage` in main.go and `configmcp.BuildScheduleJob`), with `msg.Timestamp` set from the same instant. (2) `buildSystemPrompt` appends a `## Current Date` section at **day resolution by design** — the system prompt is the prompt-cache prefix; a clock time would bust the cache every turn. Timezone precedence: agent `timezone` > `api.timezone` > UTC (`agentLocation` in main.go; engine knob `SetLocation`, hot-reloaded). Cron *evaluation* remains `api.timezone` and restart-only. Midnight-crossing runs can see header date ≠ prompt date — the fire-time header wins for dated keys (skill prose rule).
 
-CI/CD: golangci-lint, gosec, govulncheck, Grype, Gitleaks, GoReleaser, Homebrew tap, Docker (ghcr.io) with cosign + SLSA, GitHub Pages docs.
+- **Released-PR stamping** (`stamp-prs` in `release.yml`): comments the version on each PR in a release. Resolves commits to PRs via the GitHub API (`commits/{sha}/pulls`), not `(#N)` subject parsing — mixed merge strategies make parsing miss most of them.
+
+CI/CD: golangci-lint, gosec, govulncheck, Grype, Gitleaks, GoReleaser, Homebrew tap, Docker (ghcr.io) with cosign + SLSA, GitHub Pages docs, released-PR stamping.
 
 See `design/denkeeper-prd.md` for the full roadmap.


### PR DESCRIPTION
## What

Adds a `stamp-prs` job to the release workflow. When a `v*` tag is pushed (normally via `just release`), every PR included in that release gets a comment:

> 🚀 Released in [`v0.40.14`](...)

So contributors find out their merged work shipped without watching the tag feed.

## Why the GitHub API instead of parsing commit subjects

This history mixes squash merges (`chore(deps): ... (#244)`), merge commits (`Merge pull request #143`) and commits pushed straight to `main`. Parsing `(#N)` out of subjects silently misses most of it, so the job asks GitHub instead via `repos/{repo}/commits/{sha}/pulls`.

Dry run over the real `v0.40.12..v0.40.13` range: **13 PRs found, vs 6 that subject parsing would have caught.**

## Notes

- Range is `git describe --tags --abbrev=0 "${VERSION}^"..${VERSION}` — nearest tag *reachable from the new tag's parent*, hence `fetch-depth: 0`. This deliberately differs from the version-sorted lookup `just release` uses to pick its bump base; reachability is the right question for "what shipped on this line of history".
- `needs: release`, so a failed publish never announces.
- Tag name goes through `env:`, never interpolated into `run:`.
- Bot PRs (Renovate/Dependabot) get comments too — 11 of the 13 above. Easy to filter on author if that's noise.
- Re-pushing an existing tag re-comments. No idempotency guard, by choice (the label-based one was considered and dropped).

## Verification

- `yaml.safe_load` structural parse; job graph is `build-ui → test → release → stamp-prs`
- `shellcheck -s bash` clean on the extracted `run:` block
- Dry run against the live API with `gh pr comment` stubbed — resolved the 13 PRs above, one comment each
- `just hook` green

One transient test failure appeared on the first `just hook` run and did not reproduce across three subsequent forced full-suite runs. It scrolled out of my capture window before I could identify the package, so I can't name it — flagging rather than burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)