### PR TITLE
refactor(llm): split IsRetryable into IsRetryable + IsUpstreamError

### DIFF
--- a/internal/llm/openrouter/openrouter.go
+++ b/internal/llm/openrouter/openrouter.go
@@ -231,7 +231,7 @@ func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (
 	// errors leave the pin intact — the provider is healthy, so discarding its
 	// warm cache affinity would needlessly scatter subsequent requests.
 	defer func() {
-		if retErr != nil && llm.IsRetryable(retErr) {
+		if retErr != nil && llm.IsUpstreamError(retErr) {
 			c.resetSticky()
 		}
 	}()
@@ -312,7 +312,7 @@ func (c *Client) chatCompletionStream(ctx context.Context, req llm.ChatRequest) 
 	// the served provider (captured from the stream below). Caller cancellation
 	// and 4xx client errors leave the pin intact.
 	defer func() {
-		if retErr != nil && llm.IsRetryable(retErr) {
+		if retErr != nil && llm.IsUpstreamError(retErr) {
 			c.resetSticky()
 		}
 	}()

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -78,10 +78,8 @@ func (e *LLMError) Retryable() bool {
 // LLMErrors are retryable based on their status code; other network/unknown
 // errors are assumed retryable.
 //
-// It doubles as the test for whether an error implicates the upstream
-// provider's health (429/5xx/network) versus the caller or request itself
-// (cancellation, 4xx client errors) — provider-internal state such as
-// sticky-routing preferences should only be discarded for the former.
+// For the distinct question of whether an error implicates the upstream
+// provider's health, use IsUpstreamError.
 func IsRetryable(err error) bool {
 	if errors.Is(err, ErrStreamIdleTimeout) {
 		return true
@@ -101,6 +99,21 @@ func IsRetryable(err error) bool {
 		return llmErr.Retryable()
 	}
 	return true // network error or unknown — assume retryable
+}
+
+// IsUpstreamError reports whether err implicates the upstream provider's
+// health — 429/5xx server errors, network faults, and stream stalls or
+// truncation — as opposed to the caller or the request itself (context
+// cancellation, 4xx client errors). Provider-internal state such as
+// sticky-routing preferences should only be discarded when this is true.
+//
+// It currently shares IsRetryable's truth table by delegation: every error
+// worth retrying today is also one that implicates the upstream. The two
+// questions are distinct (e.g. a 408 could be retryable without indicting
+// upstream health); when they diverge, inline the classification here and
+// update the truth-table tests — see issue #200.
+func IsUpstreamError(err error) bool {
+	return IsRetryable(err)
 }
 
 // IsRateLimit returns true if err is specifically a 429 rate-limit error.

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -987,26 +987,44 @@ func TestModelSupportsTools(t *testing.T) {
 // Retry classification: context errors
 // ---------------------------------------------------------------------------
 
+// retryClassificationCases pins the truth table shared by IsRetryable and
+// IsUpstreamError. Both predicates answer every case identically today (see
+// IsUpstreamError's delegation), so one want column serves both — when they
+// diverge, split it into wantRetry/wantUpstream and the failing test forces
+// the divergence to be written down. Shared deliberately: a case added for
+// one predicate cannot silently skip the other.
+var retryClassificationCases = []struct {
+	name string
+	err  error
+	want bool
+}{
+	{"bare canceled", context.Canceled, false},
+	{"bare deadline", context.DeadlineExceeded, false},
+	{"wrapped canceled", fmt.Errorf("sending request: %w", context.Canceled), false},
+	{"wrapped deadline", fmt.Errorf("sending stream request: %w", context.DeadlineExceeded), false},
+	{"bare idle timeout", ErrStreamIdleTimeout, true},
+	{"wrapped idle timeout", fmt.Errorf("reading stream: %w", ErrStreamIdleTimeout), true},
+	{"bare stream truncated", ErrStreamTruncated, true},
+	{"wrapped stream truncated", fmt.Errorf("LLM completion: %w", ErrStreamTruncated), true},
+	{"llm 400", &LLMError{StatusCode: 400, Message: "bad request"}, false},
+	{"llm 401", &LLMError{StatusCode: 401, Message: "unauthorized"}, false},
+	{"llm 429", &LLMError{StatusCode: 429, Message: "rate limited"}, true},
+	{"llm 503", &LLMError{StatusCode: 503, Message: "down"}, true},
+	{"plain network error", errors.New("connection refused"), true},
+}
+
 func TestIsRetryable_ContextErrors(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"bare canceled", context.Canceled, false},
-		{"bare deadline", context.DeadlineExceeded, false},
-		{"wrapped canceled", fmt.Errorf("sending request: %w", context.Canceled), false},
-		{"wrapped deadline", fmt.Errorf("sending stream request: %w", context.DeadlineExceeded), false},
-		{"wrapped idle timeout", fmt.Errorf("reading stream: %w", ErrStreamIdleTimeout), true},
-		{"bare stream truncated", ErrStreamTruncated, true},
-		{"wrapped stream truncated", fmt.Errorf("LLM completion: %w", ErrStreamTruncated), true},
-		{"llm 503", &LLMError{StatusCode: 503, Message: "down"}, true},
-		{"llm 401", &LLMError{StatusCode: 401, Message: "unauthorized"}, false},
-		{"plain network error", errors.New("connection refused"), true},
-	}
-	for _, c := range cases {
+	for _, c := range retryClassificationCases {
 		if got := IsRetryable(c.err); got != c.want {
 			t.Errorf("%s: IsRetryable = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsUpstreamError_MatchesIsRetryable(t *testing.T) {
+	for _, c := range retryClassificationCases {
+		if got := IsUpstreamError(c.err); got != c.want {
+			t.Errorf("%s: IsUpstreamError = %v, want %v", c.name, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Why

`llm.IsRetryable` answered two distinct questions with one truth table:

1. **Retry gate** — "is retrying / falling back worthwhile?" (the Router).
2. **Upstream-health signal** — "does this error implicate the upstream provider's health, so the sticky-routing pin should be discarded?" (the OpenRouter client).

Its doc comment said so explicitly ("It doubles as the test for whether an error implicates the upstream provider's health…"). The two predicates coincide exactly today, but the coincidence is accidental rather than structural — a 408 is plausibly retryable without indicting upstream health, and a future retry-budget, `Retry-After`, or unknown-error-posture change would silently alter sticky-routing behavior in a different subsystem.

## What

- **New `IsUpstreamError`** in `internal/llm/provider.go`, carrying the upstream-health prose that `IsRetryable` used to hold. It **delegates** to `IsRetryable` for now: a fix to the shared classification still reaches both, and the split is behavior-preserving by construction. Inlining it is the deliberate first step whenever the predicates actually diverge.
- **`IsRetryable`** keeps its classification body byte-for-byte; only the "doubles as…" paragraph goes, so its doc now answers exactly one question.
- **OpenRouter**: both sticky-reset defers (`chatCompletionInner`, `chatCompletionStream`) now call `llm.IsUpstreamError`. The adjacent comments already described upstream-health semantics and now match the predicate name.
- **Router: unchanged.** Both call sites were audited, not skipped — `fallbackMatchesError` classifies whether another attempt is worthwhile and touches no provider-internal state, so `IsRetryable` is correct there.

## Tests

The truth table moves to a package-level slice shared by `TestIsRetryable_ContextErrors` and the new `TestIsUpstreamError_MatchesIsRetryable`, so a case added for one predicate cannot silently skip the other. It gains the missing representatives: bare idle timeout, `LLMError{400}`, `LLMError{429}`. Each test asserts its own explicit `want` column rather than cross-comparing the two predicates — when they diverge, the slice grows a second column and the failing test forces the divergence to be written down.

The four existing sticky-routing tests are **unedited and still pass**, which is the behavior-preserving evidence: they pin reset-on-5xx / mid-stream-drop and preserve-on-4xx / cancel through public behavior.

## Verification

`just hook` green: fmt-check, vet, lint, lint-ui, test (`-race`), test-ui, openapi-check.

## Not in scope

Any behavior change. Both predicates return identical results for every error on day one; each intended divergence (408 handling, unknown-error posture, `Retry-After`-aware retry budgets, truncation attribution) is a follow-up with its own test edits.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)