### PR TITLE
feat(approval): config scope — TOML-declared auto-approve rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Tiers: `autonomous` (all actions), `supervised` (chat + tools with approval), `r
 
 **Supervised tool calls**: each MCP call needs approval. Engine checks `Manager.ShouldAutoApprove()` first (match → immediate execution, `tool_approval` event with `auto_approved`), else blocks on `WaitForResolution`. Dispatcher sends four buttons: Approve, Deny, Auto (session), Auto (always). Denied calls feed "Tool call was denied by the operator." to the LLM. Within one turn, a name+args exact match against an already-denied call is auto-denied (status `auto_denied`); dedup map resets on next user message.
 
-**Auto-approve rules**: `session` scope (in-memory, conversation-scoped) and `permanent` (SQLite, agent-scoped); session checked first. Created from Telegram buttons (`:approve_session`/`:approve_always`), web UI Always Approve, or REST. `approval.ExtractToolName()` keys rules from the approval summary.
+**Auto-approve rules**: three scopes, checked `config` → `session` → `permanent`. `session` (in-memory, conversation-scoped, 15m TTL) and `permanent` (SQLite, agent-scoped) are created at runtime from Telegram buttons (`:approve_session`/`:approve_always`), web UI Always Approve, or REST; `approval.ExtractToolName()` keys them from the approval summary. `config` is declared per agent in TOML (`[[agents]] auto_approve_tools = [...]`), held in memory on the Manager, and **replaced wholesale** by `SetConfigRules` — the only writer, called from the config-load path (startup + `POST /server/reload`). It cannot be weakened at runtime: `POST /auto-approve` 400s on `scope: "config"`, config rules are listed with an empty `id` so DELETE has nothing to address, and `RemoveAutoApproveRule`/`ClearSessionRules` touch different state. Ordering cannot change an approve/deny outcome (all three answer the same question) — it fixes **attribution** (`scope=config` stays stable across sessions) and skips the SQLite lookup for the hottest calls. Newly-blessed pairs auto-resolve queued approvals, same as the other two scopes. Validation is syntax-only at load (non-empty, no whitespace, unique — `ValidResourceName` deliberately not applied, MCP names have hyphens); names not matching an advertised tool are **warned about at wiring/reload and kept**, never dropped (a late-connecting remote server must not silently weaken policy). Stage-1 auto-approvals emit an `audit.CategoryApproval` / `auto_approve` event with `detail.scope` for **all** scopes.
 
 **Supervisor agents**: `supervisor = "agent-name"` on a supervised agent inserts an LLM reviewer between auto-approve and human approval: APPROVE / DENY (reason fed to LLM) / ESCALATE (→ human). One-shot LLM call via the supervisor's Router with tool details + recent history — no storage/skills/tool loops. Emits `audit.CategorySupervisor` events and `tool_approval` statuses `supervisor_approved`/`_denied`/`_escalated`/`_error` (error falls through to human). Web UI: supervisor controls in Agents, statuses in Chat, filter chip in AuditLog.
 
@@ -102,7 +102,7 @@ Config: `[costs] default_rate_per_1k_tokens` (fallback when model unknown; 0 = $
 | `GET ws` | — | WebSocket upgrade; auth via `?token=` or session cookie |
 | `GET models`, `GET models/details` | `agents:read` | details includes pricing info |
 | `approvals` CRUD | — | `POST .../approve` accepts `?auto_approve=session\|permanent` to simultaneously create an auto-approve rule |
-| `auto-approve` CRUD | `approvals:read/write` | `GET` accepts `?agent=` filter |
+| `auto-approve` CRUD | `approvals:read/write` | `GET` accepts `?agent=` filter and includes TOML `config`-scoped rules (empty `id`); `POST` with `scope: "config"` → 400 |
 | `schedules` (PATCH edit), `skills` (PUT edit), `kv`, `GET/PUT agents/{name}/persona/{section}` | — | plain CRUD |
 | `POST agents` | `admin` | body `{name, llm_provider, llm_model, session_tier, description, create_supervisor}`; optional `create_supervisor: {name, llm_model, timeout, context_messages}` atomically creates a companion supervisor when `session_tier="supervised"`; creates persona dir, persists `[[agents]]` to TOML |
 | `PATCH agents/{name}` | — | mutable: `name` (rename), `session_tier`, `llm_provider`, `llm_model`, `description`, `browser_url_allowlist`, `fallbacks`, `cost_limit_soft`, `cost_limit_hard`, `supervisor`, `supervisor_timeout`, `supervisor_context_messages` |
@@ -121,7 +121,7 @@ Config: `[costs] default_rate_per_1k_tokens` (fallback when model unknown; 0 = $
 | `tools` CRUD (PUT edit), `GET {name}/health`, `POST {name}/restart\|enable\|disable` | `tools:read`/`tools:write` | enable starts the MCP process, disable stops it; both persist to TOML; 404 convention in invariants |
 | `POST panic`, `POST resume`, `GET panic` | `admin` | emergency stop: cancel all in-flight requests + pause scheduler; resume clears; GET returns `{panicked, panic_time}` |
 
-Chat streaming events (SSE and WS): `thinking`, `tool_start`, `tool_end`, `tool_approval`, `usage`, `content`, `done`.
+Chat streaming events (SSE and WS): `thinking`, `tool_start`, `tool_end`, `tool_approval`, `usage`, `content`, `done`. `tool_approval` carries `approval_status` plus, on `auto_approved`, a machine-readable `approval_scope` (`config`/`session`/`permanent`) alongside the human-readable text.
 
 ## Web Dashboard & WebSocket Transport
 

--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -1202,6 +1202,42 @@ func wireSupervisors(agents []config.AgentInstanceConfig, engines map[string]*ag
 	}
 }
 
+// configAutoApproveRules collects the per-agent auto_approve_tools lists into
+// the agent → tools map that approval.Manager.SetConfigRules consumes.
+func configAutoApproveRules(cfg *config.Config) map[string][]string {
+	rules := make(map[string][]string, len(cfg.Agents))
+	for _, ac := range cfg.Agents {
+		if len(ac.AutoApproveTools) == 0 {
+			continue
+		}
+		rules[ac.Name] = ac.AutoApproveTools
+	}
+	return rules
+}
+
+// warnUnadvertisedAutoApprove logs a warning for every auto_approve_tools entry
+// that no currently-advertised tool matches. A typo'd name is inert — the real
+// tool keeps paying supervisor latency forever — so it must be loud. It is
+// never fatal and the rule is never dropped: a remote MCP server may still be
+// connecting, and matching happens by name at call time, so the rule starts
+// working the moment the tool appears.
+func warnUnadvertisedAutoApprove(agentName string, want, advertised []string, logger *slog.Logger) {
+	if len(want) == 0 {
+		return
+	}
+	known := make(map[string]bool, len(advertised))
+	for _, name := range advertised {
+		known[name] = true
+	}
+	for _, name := range want {
+		if known[name] {
+			continue
+		}
+		logger.Warn("auto_approve_tools entry does not match any advertised tool (typo, or the server has not connected yet) — the rule is kept",
+			"agent", agentName, "tool", name)
+	}
+}
+
 func buildAllAgents(ctx context.Context, agents []config.AgentInstanceConfig, abc agentBuildCtx) (map[string]*agent.Engine, []agent.Binding, error) {
 	engines := make(map[string]*agent.Engine, len(agents))
 	var bindings []agent.Binding
@@ -1306,6 +1342,8 @@ func buildAgentEngine(ctx context.Context, ac config.AgentInstanceConfig, abc ag
 	}
 
 	agentRouter.SetTools(agentToolMgr.ToolDefs)
+
+	warnUnadvertisedAutoApprove(ac.Name, ac.AutoApproveTools, agentToolMgr.ToolNames(), abc.logger)
 
 	wireNudgeAndReviewer(ctx, ac, e, p, abc)
 
@@ -1624,7 +1662,7 @@ func startAPIWithMCP(ctx context.Context, cfg *config.Config, a startAPIWithMCPA
 		ModelDetailLister: a.dispatcher.ListModelDetails,
 		OAuthDeps:         a.oauthDeps,
 		MCPHandler:        mcpSrv.Handler(),
-		ReloadFunc:        buildReloadFunc(a.path, cfg, a.dispatcher, a.logger),
+		ReloadFunc:        buildReloadFunc(a.path, cfg, a.dispatcher, a.approvalManager, a.logger),
 		RestartFunc:       selfRestartFunc,
 		AgentFactory: func(ac config.AgentInstanceConfig) (*agent.Engine, []agent.Binding, error) {
 			return buildAgentEngine(ctx, ac, a.abc)
@@ -1899,6 +1937,11 @@ func runServe(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// TOML-declared auto-approve rules. Applied after the build loop so every
+	// agent's tool manager is populated (the per-agent reconciliation warning
+	// already ran inside buildAgentEngine).
+	st.approvalManager.SetConfigRules(ctx, configAutoApproveRules(cfg))
+
 	wireSupervisors(cfg.Agents, engines, logger)
 
 	// Re-create dispatcher with the fully wired engines, bindings, and channels.
@@ -1996,13 +2039,17 @@ func wireSkillCommands(tgAdapter *telegram.Adapter, engines map[string]*agent.En
 // and overwrites cfg in place, allowing hot-reloading of most settings.
 // Per-agent engine knobs (supervisor timeout, max context messages, etc.) are
 // re-applied to live engines so they don't go stale after a reload.
-func buildReloadFunc(path string, cfg *config.Config, dispatcher *agent.Dispatcher, logger *slog.Logger) func() error {
+func buildReloadFunc(path string, cfg *config.Config, dispatcher *agent.Dispatcher, approvals *approval.Manager, logger *slog.Logger) func() error {
 	return func() error {
 		newCfg, err := config.Load(path)
 		if err != nil {
 			return fmt.Errorf("reloading config: %w", err)
 		}
 		*cfg = *newCfg
+
+		// Re-apply the TOML auto-approve policy wholesale: a reload that
+		// narrows a list must narrow the effective rules too.
+		approvals.SetConfigRules(context.Background(), configAutoApproveRules(cfg))
 
 		for _, ac := range cfg.Agents {
 			e := dispatcher.Agent(ac.Name)
@@ -2013,6 +2060,7 @@ func buildReloadFunc(path string, cfg *config.Config, dispatcher *agent.Dispatch
 			e.SetMaxToolRounds(ac.MaxToolRounds)
 			applySupervisorKnobs(e, ac)
 			e.SetLocation(agentLocation(cfg, ac))
+			warnUnadvertisedAutoApprove(ac.Name, ac.AutoApproveTools, e.ToolNames(), logger)
 		}
 
 		logger.Info("config reloaded from disk", "path", path)

--- a/denkeeper.toml.example
+++ b/denkeeper.toml.example
@@ -112,6 +112,13 @@ api_key = "YOUR_OPENROUTER_API_KEY"
 # adapters     = ["telegram"]
 # # llm_model  = "anthropic/claude-sonnet-4-20250514"   # optional override
 # # session_tier = "supervised"                          # optional override
+# #
+# # Tools listed here skip the entire approval chain (auto-approve rules →
+# # supervisor → human) for this agent. Only meaningful on the "supervised"
+# # tier. Checked before session and permanent rules, survives database
+# # resets, and is read-only at runtime — changing it means editing this file
+# # and reloading (POST /api/v1/server/reload), never the API or chat buttons.
+# # auto_approve_tools = ["run_javascript", "find-completed-tasks"]
 
 # [[agents]]
 # name         = "work-assistant"

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -961,6 +961,12 @@ type ChatEvent struct {
 	// "supervisor_approved", "supervisor_denied", "supervisor_escalated",
 	// "supervisor_error" (supervisor LLM call failed; falls through to human).
 	ApprovalStatus string `json:"approval_status,omitempty"`
+
+	// ApprovalScope names which auto-approve rule matched, machine-readable
+	// alongside the human-readable Text. Set only when ApprovalStatus is
+	// "auto_approved"; values are "config" (TOML-declared), "session" or
+	// "permanent". Consumers that only key on ApprovalStatus are unaffected.
+	ApprovalScope string `json:"approval_scope,omitempty"`
 }
 
 // ChatEventFunc is called for each intermediate pipeline event.
@@ -1918,8 +1924,10 @@ func (e *Engine) resolveSupervisedApproval(ctx context.Context, tc llm.ToolCall,
 				Round:          round,
 				Text:           fmt.Sprintf("Auto-approved (%s)", scope),
 				ApprovalStatus: "auto_approved",
+				ApprovalScope:  string(scope),
 			})
 		}
+		e.auditAutoApprove(ctx, tc.Function.Name, string(scope), round, convID)
 		return approvalApproved
 	}
 
@@ -1934,6 +1942,28 @@ func (e *Engine) resolveSupervisedApproval(ctx context.Context, tc llm.ToolCall,
 		return approvalDenied(result)
 	}
 	return approvalApproved
+}
+
+// auditAutoApprove records a Stage-1 auto-approval in the audit log. Emitted
+// for every scope, not just "config": before this, auto-approvals left only a
+// log line, so a rule quietly doing all the work (or quietly never being
+// created) was invisible in the audit trail. detail.scope makes config-blessed
+// calls distinguishable and filterable.
+func (e *Engine) auditAutoApprove(ctx context.Context, toolName, scope string, round int, convID string) {
+	detail, _ := json.Marshal(map[string]any{
+		"tool":  toolName,
+		"scope": scope,
+		"round": round,
+	})
+	e.emitAudit(ctx, audit.Event{
+		Category:       audit.CategoryApproval,
+		Action:         "auto_approve",
+		Summary:        toolName,
+		Detail:         string(detail),
+		Status:         audit.StatusOK,
+		Source:         "engine",
+		ConversationID: convID,
+	})
 }
 
 // resolveSupervisorReview handles supervisor agent review of a tool call.

--- a/internal/agent/engine_autoapprove_config_test.go
+++ b/internal/agent/engine_autoapprove_config_test.go
@@ -1,0 +1,167 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Temikus/denkeeper/internal/adapter"
+	"github.com/Temikus/denkeeper/internal/approval"
+	"github.com/Temikus/denkeeper/internal/audit"
+	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/llm"
+)
+
+// TestEngine_ConfigAutoApprove_ExecutesAndAttributesScope pins the end-to-end
+// behaviour of a TOML-declared auto-approve rule on a supervised agent: the
+// tool executes with no approval row, the tool_approval event carries the
+// machine-readable scope, and the auto-approval lands in the audit log.
+func TestEngine_ConfigAutoApprove_ExecutesAndAttributesScope(t *testing.T) {
+	e, execCount := newCacheTestEngine(t, config.ToolConfig{}, "supervised")
+
+	approvalStore, err := approval.NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating approval store: %v", err)
+	}
+	t.Cleanup(func() { _ = approvalStore.Close() })
+	mgr := approval.NewManager(approvalStore, testLogger())
+	mgr.SetConfigRules(context.Background(), map[string][]string{"default": {"lookup"}})
+	e.approvals = mgr
+
+	auditor := &collectingAuditor{}
+	e.SetAuditor(auditor)
+
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{
+				ToolCalls: []llm.ToolCall{
+					{ID: "call_1", Type: "function", Function: llm.FunctionCall{Name: "lookup", Arguments: `{"query":"x"}`}},
+				},
+				TokensUsed:   llm.TokenUsage{Total: 10},
+				FinishReason: "tool_calls",
+			},
+			{Content: "Found it.", TokensUsed: llm.TokenUsage{Total: 5}, FinishReason: "stop"},
+		},
+	}
+	router := llm.NewRouter("mock", "test-model", llm.NewCostTracker(llm.SessionLimits{}, nil))
+	router.RegisterProvider(provider)
+	e.router = router
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var events []ChatEvent
+	result, err := e.ChatWithEvents(ctx, adapter.IncomingMessage{
+		Adapter:    "test",
+		ExternalID: "chat-config-approve",
+		UserID:     "user-1",
+		Text:       "look it up",
+		Timestamp:  time.Now(),
+	}, func(ev ChatEvent) { events = append(events, ev) })
+	if err != nil {
+		t.Fatalf("ChatWithEvents: %v", err)
+	}
+	if result != "Found it." {
+		t.Errorf("result = %q, want %q", result, "Found it.")
+	}
+	if got := execCount.Load(); got != 1 {
+		t.Errorf("tool executed %d times, want 1", got)
+	}
+
+	// No approval row was ever created — the chain was skipped, not resolved.
+	all, err := mgr.List(ctx, "")
+	if err != nil {
+		t.Fatalf("listing approvals: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("approval rows = %d, want 0 (config rules skip submission entirely)", len(all))
+	}
+
+	var approvalEvent *ChatEvent
+	for i := range events {
+		if events[i].Type == "tool_approval" {
+			approvalEvent = &events[i]
+			break
+		}
+	}
+	if approvalEvent == nil {
+		t.Fatal("no tool_approval event emitted")
+	}
+	if approvalEvent.ApprovalStatus != "auto_approved" {
+		t.Errorf("ApprovalStatus = %q, want auto_approved", approvalEvent.ApprovalStatus)
+	}
+	if approvalEvent.ApprovalScope != string(approval.ScopeConfig) {
+		t.Errorf("ApprovalScope = %q, want %q", approvalEvent.ApprovalScope, approval.ScopeConfig)
+	}
+	if !strings.Contains(approvalEvent.Text, "config") {
+		t.Errorf("Text = %q, want the scope named in the human-readable text", approvalEvent.Text)
+	}
+
+	var autoApprove *audit.Event
+	for i := range auditor.events {
+		if auditor.events[i].Category == audit.CategoryApproval && auditor.events[i].Action == "auto_approve" {
+			autoApprove = &auditor.events[i]
+			break
+		}
+	}
+	if autoApprove == nil {
+		t.Fatal("no approval/auto_approve audit event emitted")
+	}
+	if autoApprove.Summary != "lookup" {
+		t.Errorf("audit Summary = %q, want lookup", autoApprove.Summary)
+	}
+	if autoApprove.Status != audit.StatusOK {
+		t.Errorf("audit Status = %v, want ok", autoApprove.Status)
+	}
+	if !strings.Contains(autoApprove.Detail, `"scope":"config"`) {
+		t.Errorf("audit Detail = %q, want scope config", autoApprove.Detail)
+	}
+	if !strings.Contains(autoApprove.Detail, `"tool":"lookup"`) {
+		t.Errorf("audit Detail = %q, want the tool name", autoApprove.Detail)
+	}
+}
+
+// TestEngine_AutoApprove_AuditsEveryScope pins that the audit event is emitted
+// for permanent rules too — it closes an observability gap that predates the
+// config scope, so it must not be config-only.
+func TestEngine_AutoApprove_AuditsEveryScope(t *testing.T) {
+	e, _ := newCacheTestEngine(t, config.ToolConfig{}, "supervised")
+
+	approvalStore, err := approval.NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating approval store: %v", err)
+	}
+	t.Cleanup(func() { _ = approvalStore.Close() })
+	mgr := approval.NewManager(approvalStore, testLogger())
+	if _, err := mgr.AddPermanentRule(context.Background(), "default", "lookup", "test"); err != nil {
+		t.Fatalf("AddPermanentRule: %v", err)
+	}
+	e.approvals = mgr
+
+	auditor := &collectingAuditor{}
+	e.SetAuditor(auditor)
+
+	tc := llm.ToolCall{ID: "c1", Function: llm.FunctionCall{Name: "lookup", Arguments: `{"query":"x"}`}}
+	var events []ChatEvent
+	outcome := e.resolveSupervisedApproval(context.Background(), tc, 1, "conv:1",
+		func(ev ChatEvent) { events = append(events, ev) })
+	if outcome.denied {
+		t.Fatal("permanent rule should auto-approve")
+	}
+
+	if len(events) != 1 || events[0].ApprovalScope != string(approval.ScopePermanent) {
+		t.Errorf("events = %+v, want one event with scope permanent", events)
+	}
+
+	found := false
+	for _, ev := range auditor.events {
+		if ev.Category == audit.CategoryApproval && ev.Action == "auto_approve" &&
+			strings.Contains(ev.Detail, `"scope":"permanent"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no approval/auto_approve audit event for a permanent-scoped auto-approval")
+	}
+}

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -1400,7 +1400,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all auto-approve rules, optionally filtered by agent name.",
+                "description": "Returns all auto-approve rules (session, permanent and config scopes), optionally filtered by agent name. Config-scoped rules come from the server TOML and carry an empty id — they cannot be deleted via this API.",
                 "produces": [
                     "application/json"
                 ],
@@ -1452,7 +1452,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates a new auto-approve rule for a specific agent and tool. Scope can be 'session' (requires conversation_id) or 'permanent'.",
+                "description": "Creates a new auto-approve rule for a specific agent and tool. Scope can be 'session' (requires conversation_id) or 'permanent'. The third scope, 'config', is declared in the server TOML (agents.auto_approve_tools) and is rejected here with 400.",
                 "consumes": [
                     "application/json"
                 ],

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1653,7 +1653,7 @@ func (s *Server) handleResolveApproval(approved bool) http.HandlerFunc {
 
 // handleListAutoApprove godoc
 // @Summary List auto-approve rules
-// @Description Returns all auto-approve rules, optionally filtered by agent name.
+// @Description Returns all auto-approve rules (session, permanent and config scopes), optionally filtered by agent name. Config-scoped rules come from the server TOML and carry an empty id — they cannot be deleted via this API.
 // @Tags approvals
 // @Produce json
 // @Security BearerAuth
@@ -1679,7 +1679,7 @@ func (s *Server) handleListAutoApprove(w http.ResponseWriter, r *http.Request) {
 
 // handleCreateAutoApprove godoc
 // @Summary Create auto-approve rule
-// @Description Creates a new auto-approve rule for a specific agent and tool. Scope can be 'session' (requires conversation_id) or 'permanent'.
+// @Description Creates a new auto-approve rule for a specific agent and tool. Scope can be 'session' (requires conversation_id) or 'permanent'. The third scope, 'config', is declared in the server TOML (agents.auto_approve_tools) and is rejected here with 400.
 // @Tags approvals
 // @Accept json
 // @Produce json
@@ -1726,6 +1726,13 @@ func (s *Server) handleCreateAutoApprove(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		writeJSON(w, http.StatusCreated, rule)
+	case string(approval.ScopeConfig):
+		// Config rules are TOML-owned by design: keeping the write path
+		// file-only is what makes them code-reviewable and un-weakenable at
+		// runtime. Listing them is fine; creating one here is not.
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "config scope is managed in TOML (agents.auto_approve_tools)",
+		})
 	default:
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "scope must be 'session' or 'permanent'"})
 	}

--- a/internal/approval/autoapprove.go
+++ b/internal/approval/autoapprove.go
@@ -15,13 +15,23 @@ const (
 	// ScopePermanent is a persisted rule scoped to an agent (survives restarts).
 	ScopePermanent AutoApproveScope = "permanent"
 
-	// ScopeConfig is reserved for future TOML-based policy rules.
-	// ScopeConfig AutoApproveScope = "config"
+	// ScopeConfig is a TOML-declared rule scoped to an agent
+	// (`[[agents]] auto_approve_tools`). Config rules live in memory on the
+	// Manager, are replaced wholesale by the config-load path (startup and
+	// hot-reload), and cannot be created or removed at runtime — they survive
+	// DB resets and ship with the agent definition.
+	ScopeConfig AutoApproveScope = "config"
 )
 
 // AutoApproveRule is a rule that allows a specific tool to bypass the approval
 // workflow for a given agent. Session-scoped rules are held in memory and
-// expire after a TTL; permanent rules are persisted in SQLite.
+// expire after a TTL; permanent rules are persisted in SQLite; config-scoped
+// rules are held in memory and sourced from the TOML config (no ID, no
+// timestamps — there is nothing to address for deletion).
+//
+// CreatedAt is `omitzero` because the in-memory scopes (session, config) have
+// no creation timestamp: without it the year-1 zero time would serialize as if
+// it were a real date.
 type AutoApproveRule struct {
 	ID             string           `db:"id"              json:"id"`
 	AgentName      string           `db:"agent_name"      json:"agent_name"`
@@ -29,7 +39,7 @@ type AutoApproveRule struct {
 	Scope          AutoApproveScope `db:"scope"           json:"scope"`
 	ConversationID string           `db:"conversation_id" json:"conversation_id,omitempty"`
 	ExpiresAt      *time.Time       `db:"-"               json:"expires_at,omitempty"`
-	CreatedAt      time.Time        `db:"created_at"      json:"created_at"`
+	CreatedAt      time.Time        `db:"created_at"      json:"created_at,omitzero"`
 	CreatedBy      string           `db:"created_by"      json:"created_by"`
 }
 

--- a/internal/approval/autoapprove_config_test.go
+++ b/internal/approval/autoapprove_config_test.go
@@ -1,0 +1,262 @@
+package approval
+
+import (
+	"context"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Config-scoped auto-approve rules (TOML-declared, read-only at runtime)
+// ---------------------------------------------------------------------------
+
+func TestShouldAutoApprove_ConfigRule(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"run_javascript"}})
+
+	ok, scope := m.ShouldAutoApprove(ctx, "default", "run_javascript", "conv1")
+	if !ok {
+		t.Fatal("expected auto-approve to match config rule")
+	}
+	if scope != ScopeConfig {
+		t.Errorf("scope = %q, want %q", scope, ScopeConfig)
+	}
+
+	// A tool that is not listed does not match.
+	if ok, scope := m.ShouldAutoApprove(ctx, "default", "send_email", "conv1"); ok {
+		t.Errorf("unlisted tool matched with scope %q", scope)
+	}
+
+	// Rules are agent-scoped: another agent does not inherit them.
+	if ok, scope := m.ShouldAutoApprove(ctx, "other", "run_javascript", "conv1"); ok {
+		t.Errorf("unlisted agent matched with scope %q", scope)
+	}
+}
+
+func TestShouldAutoApprove_ConfigRuleIgnoresConversation(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"web_search"}})
+
+	// Config rules are agent-scoped, so any conversation matches.
+	if ok, _ := m.ShouldAutoApprove(ctx, "default", "web_search", "some-other-conv"); !ok {
+		t.Error("config rule should match regardless of conversation")
+	}
+}
+
+func TestShouldAutoApprove_Precedence_ConfigBeatsSessionAndPermanent(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"web_search"}})
+	m.AddSessionRule(ctx, "default", "web_search", "conv1", "test")
+	if _, err := m.AddPermanentRule(ctx, "default", "web_search", "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// All three scopes answer yes; attribution must be the stable one.
+	ok, scope := m.ShouldAutoApprove(ctx, "default", "web_search", "conv1")
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if scope != ScopeConfig {
+		t.Errorf("scope = %q, want %q (config is checked first)", scope, ScopeConfig)
+	}
+}
+
+// TestShouldAutoApprove_ConfigNotWeakenedAtRuntime pins the security property:
+// the runtime rule-management surfaces write to different state, so nothing
+// short of a config reload can revoke a TOML-declared rule.
+func TestShouldAutoApprove_ConfigNotWeakenedAtRuntime(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"web_search"}})
+	m.AddSessionRule(ctx, "default", "web_search", "conv1", "test")
+	permanent, err := m.AddPermanentRule(ctx, "default", "web_search", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete every DB rule and clear the conversation's session rules.
+	if err := m.RemoveAutoApproveRule(ctx, permanent.ID); err != nil {
+		t.Fatalf("RemoveAutoApproveRule: %v", err)
+	}
+	m.ClearSessionRules("conv1")
+
+	ok, scope := m.ShouldAutoApprove(ctx, "default", "web_search", "conv1")
+	if !ok {
+		t.Fatal("config rule must survive removal of session and permanent rules")
+	}
+	if scope != ScopeConfig {
+		t.Errorf("scope = %q, want %q", scope, ScopeConfig)
+	}
+}
+
+func TestSetConfigRules_ReplaceRemovesStale(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"tool_a", "tool_b"}})
+	// Reload narrows the list.
+	m.SetConfigRules(ctx, map[string][]string{"default": {"tool_a"}})
+
+	if ok, _ := m.ShouldAutoApprove(ctx, "default", "tool_a", "conv1"); !ok {
+		t.Error("tool_a should still match after the narrowing reload")
+	}
+	if ok, _ := m.ShouldAutoApprove(ctx, "default", "tool_b", "conv1"); ok {
+		t.Error("tool_b should no longer match after the narrowing reload")
+	}
+
+	// An empty map drops everything.
+	m.SetConfigRules(ctx, nil)
+	if ok, _ := m.ShouldAutoApprove(ctx, "default", "tool_a", "conv1"); ok {
+		t.Error("no config rules should match after an empty reload")
+	}
+}
+
+func TestSetConfigRules_AutoResolvesPending(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	blessed := false
+	if _, err := m.Submit(ctx, "default", ActionKindToolCall,
+		`Execute tool "web_search" with args: {"q":"test"}`, `{"q":"test"}`,
+		"ext", "ws", "conv1", func(_ context.Context, _ string) error {
+			blessed = true
+			return nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	// A pending approval for a tool that is NOT blessed must stay pending.
+	untouched := false
+	if _, err := m.Submit(ctx, "default", ActionKindToolCall,
+		`Execute tool "other_tool" with args: {}`, `{}`,
+		"ext", "ws", "conv1", func(_ context.Context, _ string) error {
+			untouched = true
+			return nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"web_search"}})
+
+	if !blessed {
+		t.Error("pending approval for the newly-blessed tool should be auto-resolved")
+	}
+	if untouched {
+		t.Error("pending approval for an unrelated tool should NOT be auto-resolved")
+	}
+
+	pending, err := m.List(ctx, StatusPending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Errorf("pending approvals = %d, want 1 (only other_tool)", len(pending))
+	}
+}
+
+// TestSetConfigRules_AutoResolvesOnlyNewPairs pins that a reload which does not
+// change a rule does not re-resolve approvals queued for it — only pairs newly
+// present relative to the previous map are auto-resolved.
+func TestSetConfigRules_AutoResolvesOnlyNewPairs(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"web_search"}})
+
+	resolved := false
+	if _, err := m.Submit(ctx, "default", ActionKindToolCall,
+		`Execute tool "web_search" with args: {}`, `{}`,
+		"ext", "ws", "conv1", func(_ context.Context, _ string) error {
+			resolved = true
+			return nil
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same map again — web_search is not newly present.
+	m.SetConfigRules(ctx, map[string][]string{"default": {"web_search"}})
+
+	if resolved {
+		t.Error("an unchanged rule should not re-trigger auto-resolution")
+	}
+}
+
+func TestListAutoApproveRules_IncludesConfig(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{
+		"default": {"zeta_tool", "alpha_tool"},
+		"other":   {"other_tool"},
+	})
+
+	rules, err := m.ListAutoApproveRules(ctx, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("rules = %d, want 2 (agent filter must exclude 'other')", len(rules))
+	}
+
+	// Source is a map — the listing must be sorted by tool name.
+	if rules[0].ToolName != "alpha_tool" || rules[1].ToolName != "zeta_tool" {
+		t.Errorf("tool order = [%q %q], want [alpha_tool zeta_tool]", rules[0].ToolName, rules[1].ToolName)
+	}
+	for _, r := range rules {
+		if r.Scope != ScopeConfig {
+			t.Errorf("scope = %q, want %q", r.Scope, ScopeConfig)
+		}
+		if r.ID != "" {
+			t.Errorf("ID = %q, want empty (config rules cannot be addressed for deletion)", r.ID)
+		}
+		if r.CreatedBy != "config" {
+			t.Errorf("CreatedBy = %q, want config", r.CreatedBy)
+		}
+		if r.ExpiresAt != nil {
+			t.Errorf("ExpiresAt = %v, want nil (config rules never expire)", r.ExpiresAt)
+		}
+	}
+
+	// No filter returns both agents, sorted by agent then tool.
+	all, err := m.ListAutoApproveRules(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("unfiltered rules = %d, want 3", len(all))
+	}
+	want := []string{"default/alpha_tool", "default/zeta_tool", "other/other_tool"}
+	for i, r := range all {
+		if got := r.AgentName + "/" + r.ToolName; got != want[i] {
+			t.Errorf("rules[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestConfigRuleTools_Sorted(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+
+	m.SetConfigRules(ctx, map[string][]string{"default": {"zeta", "alpha", "mid"}})
+
+	got := m.ConfigRuleTools("default")
+	want := []string{"alpha", "mid", "zeta"}
+	if len(got) != len(want) {
+		t.Fatalf("ConfigRuleTools = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ConfigRuleTools = %v, want %v", got, want)
+		}
+	}
+
+	if tools := m.ConfigRuleTools("unknown"); tools != nil {
+		t.Errorf("ConfigRuleTools(unknown) = %v, want nil", tools)
+	}
+}

--- a/internal/approval/manager.go
+++ b/internal/approval/manager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -52,6 +53,13 @@ type Manager struct {
 
 	// sessionRules holds ephemeral auto-approve rules keyed by "agent\x00convID\x00tool".
 	sessionRules sync.Map
+
+	// configRules holds TOML-declared auto-approve rules (agent → set of tool
+	// names). Written only by SetConfigRules, which the config-load path calls
+	// at startup and on hot-reload; no incremental mutation API exists, so
+	// runtime rule management can never weaken this set.
+	configMu    sync.RWMutex
+	configRules map[string]map[string]struct{}
 }
 
 // NewManager creates a Manager backed by the given store.
@@ -479,10 +487,20 @@ func sessionRuleKey(agentName, conversationID, toolName string) string {
 }
 
 // ShouldAutoApprove checks whether the given tool call should be auto-approved.
-// It checks session rules (in-memory) first, then permanent rules (DB).
 // Returns (true, scope) on match, (false, "") on no match.
+//
+// All three scopes answer the same yes/no question, so the order cannot change
+// an approve/deny outcome — it decides scope attribution and cost. Config is
+// checked first so a TOML-blessed tool always reports scope=config in events
+// and audit (stable across sessions, never mis-attributed to a 15-minute
+// session rule) and so the hottest recurring calls skip the SQLite lookup.
 func (m *Manager) ShouldAutoApprove(ctx context.Context, agentName, toolName, conversationID string) (bool, AutoApproveScope) {
-	// 1. Session rules (in-memory, conversation-scoped, time-limited).
+	// 1. Config rules (TOML-declared, process-wide, replaced only by config load).
+	if m.matchConfigRule(agentName, toolName) {
+		return true, ScopeConfig
+	}
+
+	// 2. Session rules (in-memory, conversation-scoped, time-limited).
 	key := sessionRuleKey(agentName, conversationID, toolName)
 	if v, ok := m.sessionRules.Load(key); ok {
 		if expiresAt, isTime := v.(time.Time); isTime && time.Now().Before(expiresAt) {
@@ -492,16 +510,98 @@ func (m *Manager) ShouldAutoApprove(ctx context.Context, agentName, toolName, co
 		m.sessionRules.Delete(key)
 	}
 
-	// 2. Permanent rules (DB, agent-scoped).
+	// 3. Permanent rules (DB, agent-scoped).
 	if m.autoStore != nil {
 		if _, err := m.autoStore.MatchAutoApproveRule(ctx, agentName, toolName); err == nil {
 			return true, ScopePermanent
 		}
 	}
 
-	// 3. Future: config-based rules would be checked here.
-
 	return false, ""
+}
+
+// matchConfigRule reports whether a TOML-declared rule blesses agent+tool.
+func (m *Manager) matchConfigRule(agentName, toolName string) bool {
+	m.configMu.RLock()
+	defer m.configMu.RUnlock()
+	tools, ok := m.configRules[agentName]
+	if !ok {
+		return false
+	}
+	_, ok = tools[toolName]
+	return ok
+}
+
+// SetConfigRules replaces the entire set of TOML-declared auto-approve rules
+// with the given agent → tool-names map. This is the only writer: the
+// config-load path calls it at startup and on hot-reload, both of which re-read
+// the TOML from disk. There is deliberately no incremental add/remove API, so
+// no runtime surface (REST, chat buttons, web UI) can weaken the config policy.
+//
+// Pairs that are newly present relative to the previous map auto-resolve any
+// approvals already queued for them, the same courtesy AddSessionRule and
+// AddPermanentRule extend.
+func (m *Manager) SetConfigRules(ctx context.Context, rules map[string][]string) {
+	next := make(map[string]map[string]struct{}, len(rules))
+	for agentName, tools := range rules {
+		if len(tools) == 0 {
+			continue
+		}
+		set := make(map[string]struct{}, len(tools))
+		for _, toolName := range tools {
+			if toolName == "" {
+				continue
+			}
+			set[toolName] = struct{}{}
+		}
+		if len(set) > 0 {
+			next[agentName] = set
+		}
+	}
+
+	m.configMu.Lock()
+	prev := m.configRules
+	m.configRules = next
+	m.configMu.Unlock()
+
+	// Collect newly-added pairs (sorted, so the resolve order is deterministic).
+	type pair struct{ agent, tool string }
+	var added []pair
+	for agentName, tools := range next {
+		m.logger.Info("config auto-approve rules applied", "agent", agentName, "tools", len(tools))
+		for toolName := range tools {
+			if _, existed := prev[agentName][toolName]; existed {
+				continue
+			}
+			added = append(added, pair{agentName, toolName})
+		}
+	}
+	sort.Slice(added, func(i, j int) bool {
+		if added[i].agent != added[j].agent {
+			return added[i].agent < added[j].agent
+		}
+		return added[i].tool < added[j].tool
+	})
+	for _, p := range added {
+		m.autoResolvePending(ctx, p.agent, p.tool)
+	}
+}
+
+// ConfigRuleTools returns the sorted tool names blessed by config for an agent.
+// Returns nil when the agent has no config rules.
+func (m *Manager) ConfigRuleTools(agentName string) []string {
+	m.configMu.RLock()
+	defer m.configMu.RUnlock()
+	tools, ok := m.configRules[agentName]
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(tools))
+	for toolName := range tools {
+		names = append(names, toolName)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // AddSessionRule creates a time-limited auto-approve rule for the current conversation.
@@ -579,7 +679,9 @@ func (m *Manager) RemoveAutoApproveRule(ctx context.Context, id string) error {
 }
 
 // ListAutoApproveRules returns all auto-approve rules for the given agent.
-// Pass "" for all agents. Combines permanent (DB) and session (in-memory) rules.
+// Pass "" for all agents. Combines permanent (DB), session (in-memory) and
+// config (TOML-declared) rules. Config rules carry no ID and no timestamps —
+// they are read-only at runtime and there is nothing for DELETE to address.
 func (m *Manager) ListAutoApproveRules(ctx context.Context, agentName string) ([]AutoApproveRule, error) {
 	var rules []AutoApproveRule
 
@@ -622,7 +724,46 @@ func (m *Manager) ListAutoApproveRules(ctx context.Context, agentName string) ([
 		return true
 	})
 
+	// Config rules from memory. The source is a map, so sort by agent then
+	// tool — never emit unsorted.
+	rules = append(rules, m.listConfigRules(agentName)...)
+
 	return rules, nil
+}
+
+// listConfigRules renders the TOML-declared rules as AutoApproveRule values,
+// honoring the agent filter ("" = all agents), sorted by agent then tool.
+func (m *Manager) listConfigRules(agentName string) []AutoApproveRule {
+	m.configMu.RLock()
+	agents := make([]string, 0, len(m.configRules))
+	byAgent := make(map[string][]string, len(m.configRules))
+	for agent, tools := range m.configRules {
+		if agentName != "" && agent != agentName {
+			continue
+		}
+		names := make([]string, 0, len(tools))
+		for toolName := range tools {
+			names = append(names, toolName)
+		}
+		sort.Strings(names)
+		agents = append(agents, agent)
+		byAgent[agent] = names
+	}
+	m.configMu.RUnlock()
+
+	sort.Strings(agents)
+	var rules []AutoApproveRule
+	for _, agent := range agents {
+		for _, toolName := range byAgent[agent] {
+			rules = append(rules, AutoApproveRule{
+				AgentName: agent,
+				ToolName:  toolName,
+				Scope:     ScopeConfig,
+				CreatedBy: "config",
+			})
+		}
+	}
+	return rules
 }
 
 // ClearSessionRules removes all session-scoped auto-approve rules for a conversation.

--- a/internal/config/autoapprove_tools_test.go
+++ b/internal/config/autoapprove_tools_test.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// agents.auto_approve_tools — parsing, validation, persistence
+// ---------------------------------------------------------------------------
+
+func TestParse_AgentAutoApproveTools(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[[agents]]
+name = "default"
+persona_dir = "/agents/default"
+adapters = ["telegram"]
+session_tier = "supervised"
+supervisor = "guard"
+auto_approve_tools = ["run_javascript", "find-completed-tasks", "get-productivity-stats"]
+
+[[agents]]
+name = "guard"
+persona_dir = "/agents/guard"
+session_tier = "autonomous"
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := cfg.Agents[0].AutoApproveTools
+	want := []string{"run_javascript", "find-completed-tasks", "get-productivity-stats"}
+	if len(got) != len(want) {
+		t.Fatalf("auto_approve_tools = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("auto_approve_tools = %v, want %v", got, want)
+		}
+	}
+	if len(cfg.Agents[1].AutoApproveTools) != 0 {
+		t.Errorf("guard auto_approve_tools = %v, want empty", cfg.Agents[1].AutoApproveTools)
+	}
+}
+
+// A hyphenated MCP tool name must survive validation — ValidResourceName is
+// deliberately not applied to this field.
+func TestParse_AgentAutoApproveTools_HyphensAllowed(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[[agents]]
+name = "default"
+persona_dir = "/agents/default"
+adapters = ["telegram"]
+auto_approve_tools = ["find-completed-tasks"]
+`)
+	if _, err := Parse(tomlData); err != nil {
+		t.Fatalf("hyphenated tool name rejected: %v", err)
+	}
+}
+
+// The field is inert but legal on a non-supervised agent, so a tier flip does
+// not require re-entering the list.
+func TestParse_AgentAutoApproveTools_NonSupervisedTierAllowed(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[[agents]]
+name = "default"
+persona_dir = "/agents/default"
+adapters = ["telegram"]
+session_tier = "autonomous"
+auto_approve_tools = ["run_javascript"]
+`)
+	cfg, err := Parse(tomlData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Agents[0].AutoApproveTools) != 1 {
+		t.Errorf("auto_approve_tools = %v, want the list to be preserved", cfg.Agents[0].AutoApproveTools)
+	}
+}
+
+func TestParse_AgentAutoApproveTools_EmptyEntry(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[[agents]]
+name = "default"
+persona_dir = "/agents/default"
+adapters = ["telegram"]
+auto_approve_tools = ["run_javascript", ""]
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for empty auto_approve_tools entry")
+	}
+	if !strings.Contains(err.Error(), "auto_approve_tools[1]: tool name must not be empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParse_AgentAutoApproveTools_WhitespaceEntry(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[[agents]]
+name = "default"
+persona_dir = "/agents/default"
+adapters = ["telegram"]
+auto_approve_tools = ["run javascript"]
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for whitespace in auto_approve_tools entry")
+	}
+	if !strings.Contains(err.Error(), "must not contain whitespace") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParse_AgentAutoApproveTools_DuplicateEntry(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[[agents]]
+name = "default"
+persona_dir = "/agents/default"
+adapters = ["telegram"]
+auto_approve_tools = ["run_javascript", "run_javascript"]
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for duplicate auto_approve_tools entry")
+	}
+	if !strings.Contains(err.Error(), `duplicate tool name "run_javascript"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// The TOML writer round-trips the whole agent table, so an unrelated field
+// update must not drop the auto-approve allowlist.
+func TestUpdateAgentInConfig_PreservesAutoApproveTools(t *testing.T) {
+	path := writeTestConfig(t, `[api]
+enabled = true
+
+[[agents]]
+name = "default"
+session_tier = "supervised"
+auto_approve_tools = ["run_javascript", "find-completed-tasks"]
+`)
+
+	if err := UpdateAgentInConfig(path, "default", map[string]any{"llm_model": "new-model"}); err != nil {
+		t.Fatalf("UpdateAgentInConfig: %v", err)
+	}
+
+	content := readTestConfig(t, path)
+	if !strings.Contains(content, "run_javascript") || !strings.Contains(content, "find-completed-tasks") {
+		t.Errorf("auto_approve_tools lost on unrelated update; content:\n%s", content)
+	}
+	if !strings.Contains(content, "new-model") {
+		t.Errorf("llm_model not updated; content:\n%s", content)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/pelletier/go-toml/v2"
 
@@ -529,6 +530,20 @@ type AgentInstanceConfig struct {
 	// BrowserURLAllowlist overrides the global browser URL allowlist for this agent.
 	// If set, only these domains are reachable. Supports wildcards: "*.example.com".
 	BrowserURLAllowlist []string `toml:"browser_url_allowlist"`
+
+	// AutoApproveTools lists MCP tool names this agent may call without any
+	// approval — the whole chain (auto-approve → supervisor → human) is
+	// skipped. These "config"-scoped rules are checked before session and
+	// permanent rules, survive DB resets, and ship with the agent definition.
+	// They are read-only at runtime: the REST API rejects scope "config" on
+	// create and config rules carry no ID to delete, so changing the list
+	// means editing this file and reloading.
+	//
+	// Only meaningful when session_tier = "supervised" (autonomous agents skip
+	// approval entirely, restricted agents have no tool loop). Setting it on
+	// another tier is allowed but inert, so the list need not be re-entered
+	// when a tier is flipped via PATCH /api/v1/agents/{name}.
+	AutoApproveTools []string `toml:"auto_approve_tools"`
 
 	// CostLimitSoft overrides the global cost_limit_soft for this agent.
 	// Nil means inherit global. 0 means disabled.
@@ -2145,6 +2160,10 @@ func validateAgents(agents []AgentInstanceConfig) (map[string]bool, error) {
 			return nil, err
 		}
 
+		if err := validateAutoApproveTools(a); err != nil {
+			return nil, err
+		}
+
 		if err := validateAgentBindings(a, wildcards); err != nil {
 			return nil, err
 		}
@@ -2155,6 +2174,44 @@ func validateAgents(agents []AgentInstanceConfig) (map[string]bool, error) {
 	}
 
 	return names, nil
+}
+
+// validateAutoApproveTools checks an agent's auto_approve_tools entries.
+//
+// Only syntax is checked: MCP tool names are known after servers connect, and
+// a remote server may connect late or be temporarily down, so config load
+// cannot verify that a name exists. Unknown names are reconciled against the
+// advertised tool set at wiring time and logged as warnings there — never
+// dropped from the rule set, never fatal. Note that ValidResourceName is
+// deliberately not applied: MCP tool names legitimately contain hyphens
+// (e.g. "find-completed-tasks").
+func validateAutoApproveTools(a AgentInstanceConfig) error {
+	if len(a.AutoApproveTools) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(a.AutoApproveTools))
+	for i, name := range a.AutoApproveTools {
+		if name == "" {
+			return fmt.Errorf("config: agent %q: auto_approve_tools[%d]: tool name must not be empty", a.Name, i)
+		}
+		if strings.ContainsFunc(name, unicode.IsSpace) {
+			return fmt.Errorf("config: agent %q: auto_approve_tools[%d]: tool name %q must not contain whitespace", a.Name, i, name)
+		}
+		if seen[name] {
+			return fmt.Errorf("config: agent %q: auto_approve_tools[%d]: duplicate tool name %q", a.Name, i, name)
+		}
+		seen[name] = true
+	}
+
+	// Only flag an explicitly-set non-supervised tier: an empty session_tier
+	// inherits the global [session] tier, which may well be "supervised".
+	if a.SessionTier != "" && a.SessionTier != "supervised" {
+		slog.Info("auto_approve_tools set on a non-supervised agent — the list is dormant until the tier is supervised",
+			"agent", a.Name, "session_tier", a.SessionTier, "tools", len(a.AutoApproveTools))
+	}
+
+	return nil
 }
 
 // validateAgentBindings checks adapter bindings for a single agent.

--- a/internal/integration/auto_approve_test.go
+++ b/internal/integration/auto_approve_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -202,5 +203,67 @@ func TestAutoApprove_FilterByAgent(t *testing.T) {
 	}
 	if rules[0]["tool_name"] != "code_review" {
 		t.Errorf("tool = %v, want code_review", rules[0]["tool_name"])
+	}
+}
+
+func TestAutoApprove_ListIncludesConfigRule(t *testing.T) {
+	h := NewHarness(t, &HarnessOpts{
+		AutoApproveTools: map[string][]string{"default": {"find-completed-tasks"}},
+	})
+
+	rec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/auto-approve", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var rules []map[string]any
+	DecodeJSON(t, rec, &rules)
+	if len(rules) != 1 {
+		t.Fatalf("rules count = %d, want 1", len(rules))
+	}
+	if rules[0]["scope"] != "config" {
+		t.Errorf("scope = %v, want config", rules[0]["scope"])
+	}
+	if rules[0]["tool_name"] != "find-completed-tasks" {
+		t.Errorf("tool = %v, want find-completed-tasks", rules[0]["tool_name"])
+	}
+	// Config rules carry no ID — there is nothing for DELETE to address.
+	if id, ok := rules[0]["id"].(string); !ok || id != "" {
+		t.Errorf("id = %v, want empty string", rules[0]["id"])
+	}
+	if rules[0]["created_by"] != "config" {
+		t.Errorf("created_by = %v, want config", rules[0]["created_by"])
+	}
+	// No creation timestamp — the field is omitted rather than reported as
+	// the year-1 zero time, so the UI renders a dash.
+	if _, present := rules[0]["created_at"]; present {
+		t.Errorf("created_at = %v, want the field to be omitted", rules[0]["created_at"])
+	}
+}
+
+func TestAutoApprove_CreateConfigScopeRejected(t *testing.T) {
+	h := NewHarness(t, nil)
+
+	rec := h.Do(h.AuthedRequest(http.MethodPost, "/api/v1/auto-approve", map[string]any{
+		"agent": "default",
+		"tool":  "web_search",
+		"scope": "config",
+	}))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+
+	var resp map[string]string
+	DecodeJSON(t, rec, &resp)
+	if !strings.Contains(resp["error"], "managed in TOML") {
+		t.Errorf("error = %q, want it to point at the TOML field", resp["error"])
+	}
+
+	// Nothing was created.
+	listRec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/auto-approve", nil))
+	var rules []map[string]any
+	DecodeJSON(t, listRec, &rules)
+	if len(rules) != 0 {
+		t.Errorf("rules count = %d, want 0", len(rules))
 	}
 }

--- a/internal/integration/harness_test.go
+++ b/internal/integration/harness_test.go
@@ -191,6 +191,11 @@ type HarnessOpts struct {
 	// observe (or assert the absence of) adapter Send calls should provide a
 	// recording mock here.
 	Adapters []adapter.Adapter
+
+	// AutoApproveTools seeds config-scoped ("config") auto-approve rules,
+	// agent name → tool names, standing in for the [[agents]]
+	// auto_approve_tools TOML field that cmd/denkeeper wires at startup.
+	AutoApproveTools map[string][]string
 }
 
 type agentSetup struct {
@@ -249,6 +254,9 @@ func NewHarness(t *testing.T, opts *HarnessOpts) *Harness {
 		t.Fatalf("creating approval store: %v", err)
 	}
 	approvalMgr := approval.NewManager(approvalStore, logger)
+	if len(opts.AutoApproveTools) > 0 {
+		approvalMgr.SetConfigRules(context.Background(), opts.AutoApproveTools)
+	}
 
 	kvStore, err := kv.NewInMemoryStore()
 	if err != nil {

--- a/internal/integration/supervised_test.go
+++ b/internal/integration/supervised_test.go
@@ -25,6 +25,14 @@ import (
 // tool wired in, for testing the approval flow via direct chat (no channels).
 func supervisedHarness(t *testing.T, responses []*llm.ChatResponse) *Harness {
 	t.Helper()
+	return supervisedHarnessWithConfigRules(t, responses, nil)
+}
+
+// supervisedHarnessWithConfigRules is supervisedHarness plus config-scoped
+// ("config") auto-approve rules, as the TOML agents.auto_approve_tools field
+// would supply at startup.
+func supervisedHarnessWithConfigRules(t *testing.T, responses []*llm.ChatResponse, rules map[string][]string) *Harness {
+	t.Helper()
 
 	ts := startTestMCPServer(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -43,8 +51,9 @@ func supervisedHarness(t *testing.T, responses []*llm.ChatResponse) *Harness {
 		Agents: []agentSetup{
 			{Name: "default", Tier: "supervised"},
 		},
-		ToolManager: toolMgr,
-		Responses:   responses,
+		ToolManager:      toolMgr,
+		Responses:        responses,
+		AutoApproveTools: rules,
 	})
 }
 
@@ -195,6 +204,36 @@ func TestSupervised_AutoApprovePermanent(t *testing.T) {
 	}
 
 	// Chat — tool should execute immediately without manual approval.
+	chatRec := h.Do(h.AuthedRequest("POST", "/api/v1/chat",
+		map[string]string{"message": "please call echo"}))
+	if chatRec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", chatRec.Code, chatRec.Body.String())
+	}
+
+	var chatResp map[string]string
+	DecodeJSON(t, chatRec, &chatResp)
+	if !strings.Contains(chatResp["response"], "supervised-test") {
+		t.Fatalf("expected response to contain 'supervised-test', got: %s", chatResp["response"])
+	}
+
+	// No pending approvals should remain.
+	listRec := h.Do(h.AuthedRequest("GET", "/api/v1/approvals?status=pending", nil))
+	var pending []map[string]any
+	_ = json.NewDecoder(listRec.Body).Decode(&pending)
+	if len(pending) != 0 {
+		t.Errorf("expected 0 pending approvals, got %d", len(pending))
+	}
+
+	if h.MockLLM.CallCount() != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", h.MockLLM.CallCount())
+	}
+}
+
+func TestSupervised_AutoApproveConfig(t *testing.T) {
+	// The rule comes from TOML, not from any runtime API call.
+	h := supervisedHarnessWithConfigRules(t, supervisedToolCallResponses(),
+		map[string][]string{"default": {"echo"}})
+
 	chatRec := h.Do(h.AuthedRequest("POST", "/api/v1/chat",
 		map[string]string{"message": "please call echo"}))
 	if chatRec.Code != http.StatusOK {

--- a/internal/integration/supervisor_test.go
+++ b/internal/integration/supervisor_test.go
@@ -25,6 +25,14 @@ import (
 // natively support the supervisor field.
 func supervisorHarness(t *testing.T, responses []*llm.ChatResponse) *Harness {
 	t.Helper()
+	return supervisorHarnessWithConfigRules(t, responses, nil)
+}
+
+// supervisorHarnessWithConfigRules is supervisorHarness plus config-scoped
+// ("config") auto-approve rules, as the TOML agents.auto_approve_tools field
+// would supply at startup.
+func supervisorHarnessWithConfigRules(t *testing.T, responses []*llm.ChatResponse, rules map[string][]string) *Harness {
+	t.Helper()
 
 	ts := startTestMCPServer(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -44,8 +52,9 @@ func supervisorHarness(t *testing.T, responses []*llm.ChatResponse) *Harness {
 			{Name: "default", Tier: "supervised"},
 			{Name: "guard", Tier: "autonomous"},
 		},
-		ToolManager: toolMgr,
-		Responses:   responses,
+		ToolManager:      toolMgr,
+		Responses:        responses,
+		AutoApproveTools: rules,
 	})
 
 	// Wire the supervisor relationship.
@@ -223,5 +232,54 @@ func TestSupervisor_Escalate(t *testing.T) {
 	// 3 LLM calls: primary (tool_calls) + supervisor (ESCALATE) + primary (final).
 	if h.MockLLM.CallCount() != 3 {
 		t.Errorf("expected 3 LLM calls, got %d", h.MockLLM.CallCount())
+	}
+}
+
+// TestSupervisor_ConfigRuleSkipsSupervisor pins the whole point of the config
+// scope: a TOML-blessed tool bypasses the supervisor entirely. The response
+// sequence deliberately has no supervisor verdict — 2 LLM calls (tool_call,
+// final) proves the supervisor LLM was never invoked, in contrast to the 3 of
+// TestSupervisor_Approve.
+func TestSupervisor_ConfigRuleSkipsSupervisor(t *testing.T) {
+	h := supervisorHarnessWithConfigRules(t, []*llm.ChatResponse{
+		{
+			Content:      "",
+			FinishReason: "tool_calls",
+			ToolCalls: []llm.ToolCall{
+				{
+					ID:   "call_1",
+					Type: "function",
+					Function: llm.FunctionCall{
+						Name:      "echo",
+						Arguments: `{"input":"config-blessed"}`,
+					},
+				},
+			},
+			TokensUsed: llm.TokenUsage{Prompt: 10, Completion: 5, Total: 15},
+			Model:      "test-model",
+		},
+		{
+			Content:      "Tool returned: config-blessed",
+			FinishReason: "stop",
+			TokensUsed:   llm.TokenUsage{Prompt: 20, Completion: 10, Total: 30},
+			Model:        "test-model",
+		},
+	}, map[string][]string{"default": {"echo"}})
+
+	rec := h.Do(h.AuthedRequest("POST", "/api/v1/chat",
+		map[string]string{"message": "please call echo"}))
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var chatResp map[string]string
+	DecodeJSON(t, rec, &chatResp)
+	if !strings.Contains(chatResp["response"], "config-blessed") {
+		t.Fatalf("expected response to contain 'config-blessed', got: %s", chatResp["response"])
+	}
+
+	// 2 LLM calls: primary (tool_calls) + primary (final). No supervisor call.
+	if h.MockLLM.CallCount() != 2 {
+		t.Errorf("expected 2 LLM calls, got %d — the supervisor was invoked despite the config rule", h.MockLLM.CallCount())
 	}
 }

--- a/web/src/__tests__/pages/Approvals.test.js
+++ b/web/src/__tests__/pages/Approvals.test.js
@@ -204,6 +204,28 @@ describe('Approvals page', () => {
     })
   })
 
+  test('config-scoped rule renders read-only (no Revoke)', async () => {
+    // Config rules come from the server TOML: the API returns them with no id
+    // and no created_at, and they cannot be revoked at runtime.
+    server.use(
+      http.get('/api/v1/auto-approve', () =>
+        HttpResponse.json([
+          { id: 'rule-1', agent_name: 'default', tool_name: 'web_search', scope: 'permanent', created_at: '2026-01-01T00:00:00Z', created_by: 'api' },
+          { id: '', agent_name: 'default', tool_name: 'run_javascript', scope: 'config', created_by: 'config' },
+        ])
+      )
+    )
+
+    render(Approvals)
+    await waitFor(() => {
+      expect(screen.getByText('run_javascript')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('TOML-managed')).toBeInTheDocument()
+    // Only the permanent rule is revocable.
+    expect(screen.getAllByText('Revoke')).toHaveLength(1)
+  })
+
   test('polling every 10s calls approvals endpoint', async () => {
     let callCount = 0
     server.use(

--- a/web/src/pages/Approvals.svelte
+++ b/web/src/pages/Approvals.svelte
@@ -156,7 +156,7 @@
 
 <!-- Auto-Approve Rules Section -->
 <h2 class="section-title">Auto-Approve Rules</h2>
-<p class="section-desc">Rules that automatically approve tool calls without prompting. Timed rules expire after 15 minutes; permanent rules survive restarts.</p>
+<p class="section-desc">Rules that automatically approve tool calls without prompting. Timed rules expire after 15 minutes; permanent rules survive restarts; config rules come from an agent's <code>auto_approve_tools</code> in the server TOML and can only be changed there.</p>
 
 <ErrorBanner message={autoError} />
 
@@ -174,12 +174,14 @@
         <tr>
           <td class="tool-name-cell"><code>{rule.tool_name}</code></td>
           <td>{rule.agent_name}</td>
-          <td><span class="scope-badge" class:session={rule.scope === 'session'}>{rule.scope}</span></td>
+          <td><span class="scope-badge" class:session={rule.scope === 'session'} class:config={rule.scope === 'config'}>{rule.scope}</span></td>
           <td class="date">{fmtDate(rule.created_at)}</td>
           <td class="muted">{rule.created_by || '—'}</td>
           <td class="actions">
             {#if rule.scope === 'permanent'}
               <button class="btn-bad" onclick={() => revokeRule(rule.id)}>Revoke</button>
+            {:else if rule.scope === 'config'}
+              <span class="muted">TOML-managed</span>
             {:else}
               <span class="muted">session only</span>
             {/if}
@@ -261,10 +263,14 @@
 
   .section-title { font-size: 17px; font-weight: 600; margin-top: 40px; margin-bottom: 6px; }
   .section-desc { font-size: 13px; color: var(--text-muted); margin-bottom: 16px; }
+  .section-desc code { font-size: 12px; }
   .tool-name-cell code { font-size: 12px; }
   .scope-badge {
     display: inline-block;
     padding: 2px 8px;
+    /* Transparent border keeps every badge the same size, so the outlined
+       config variant lines up with the filled ones. */
+    border: 1px solid transparent;
     border-radius: 3px;
     font-size: 11px;
     font-weight: 600;
@@ -273,6 +279,7 @@
     color: var(--accent);
   }
   .scope-badge.session { background: rgba(100,100,100,0.1); color: var(--text-muted); }
+  .scope-badge.config  { background: none; border-color: var(--accent); color: var(--accent); }
   .muted { color: var(--text-muted); font-size: 12px; }
 
   .add-rule-area { margin-top: 12px; }

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -142,6 +142,7 @@ Multi-agent definitions. If absent, a single "default" agent is synthesized.
     max_context_messages = 0         # max messages in LLM context (0 = 50)
     max_tool_rounds = 0              # max tool-call rounds (0 = 50)
     supervisor = ""                  # supervisor agent name for tool call review
+    auto_approve_tools = []          # tools that skip the whole approval chain (supervised tier only; TOML-only, not editable via API)
     supervisor_timeout = ""          # supervisor call timeout
     supervisor_context_messages = 5  # recent messages in supervisor prompt
     supervisor_body_excerpt_len = 0  # max chars of skill body in supervisor prompt (0 = use default 500)


### PR DESCRIPTION
## Problem

Supervised agents pay 10–15s of supervisor-LLM latency (plus tokens) on every call to tools the operator has *already decided* are always safe. In one observed window: 14 supervisor reviews, 100% APPROVE, across three tools that never got a permanent rule.

The two existing remedies both live in mutable runtime state:

- **`session`** — in-memory, conversation-scoped, 15-minute TTL.
- **`permanent`** — SQLite rows, agent-scoped, created ad hoc from Telegram buttons, the web UI, or REST.

Permanent rules die with a DB reset, are invisible to code review, and don't travel with the agent definition. The practical result is that the "trivial ops task" of creating a few rules stays undone while the supervisor keeps rubber-stamping.

## What this adds

A third scope, `config`, declared per agent in TOML:

```toml
[[agents]]
name = "default"
session_tier = "supervised"
supervisor = "argus"
auto_approve_tools = ["run_javascript", "find-completed-tasks", "get-productivity-stats"]
```

Tools listed here skip the entire approval chain (auto-approve → supervisor → human). The rules survive DB resets, ship with the agent definition, and are code-reviewable.

Hot-reload works: `POST /api/v1/server/reload` re-reads the file and re-applies. No env-var override — keeping it file-only is what preserves the code-review property.

## Design notes

**Read-only at runtime comes from write-path isolation, not from ordering.** `SetConfigRules` is the only writer and is called solely from the config-load path (startup + reload, both of which re-read the TOML from disk). There is deliberately no incremental add/remove API. `POST /auto-approve` 400s on `scope: "config"`; config rules are listed *without* an ID so `DELETE` has nothing to address; `RemoveAutoApproveRule` touches only the DB store and `ClearSessionRules` only the session map. Pinned by `TestShouldAutoApprove_ConfigNotWeakenedAtRuntime`.

**Config is checked first, but that can't change an outcome.** All three scopes answer the same yes/no question, so ordering only decides *attribution* and cost — a TOML-blessed tool always reports `scope=config` in events and audit, stable across sessions rather than mis-attributed to a 15-minute session rule, and the hottest recurring calls skip the SQLite lookup.

**Typo'd names warn, never silently no-op — and never fail the boot.** A typo means the real tool keeps paying supervisor latency forever, which is exactly the failure this feature exists to prevent. But MCP tool names are only known after servers connect, so config load can't verify them. Two layers: syntactic validation at load (non-empty, no whitespace, unique — fatal), then reconciliation against the advertised tool set at wiring and reload time (Warn, non-fatal, rule kept). `ValidResourceName` is deliberately *not* applied: MCP names legitimately contain hyphens. Dropping unknown names was rejected as an alternative — it would turn a transient MCP outage at boot into a silently weaker approval policy.

**Setting the field on a non-supervised agent is legal but inert**, so the list doesn't have to be re-entered when a tier is flipped via `PATCH /agents/{name}`. Config load logs an Info note.

## Incidental fixes

- **Audit gap (pre-existing).** Stage-1 auto-approvals left only a `logger.Info`, which is how "the rules were never created" went unnoticed in the first place. They now emit an `approval`/`auto_approve` audit event with `detail.scope` for **all** scopes, filterable in the audit log.
- **`AutoApproveRule.CreatedAt` is now `omitzero`.** The in-memory scopes have no creation timestamp; without this the year-1 zero time serialized as if it were a real date and the dashboard rendered "1/1/1" — for existing session rows too.

## API & UI

- `GET /auto-approve` includes config rules (empty `id`, `created_by: "config"`, sorted by agent then tool); `POST` with `scope: "config"` → 400 pointing at the TOML field.
- `tool_approval` stream events gain `approval_scope` (`config`/`session`/`permanent`). `approval_status` is unchanged, so existing consumers are unaffected.
- Approvals page: `config` badge variant, `TOML-managed` label in place of Revoke, and a section description naming `auto_approve_tools`.

## Testing

`just check` and `just test-integration` both green.

- **`internal/approval`** (9 tests) — match/no-match, precedence over session+permanent, the not-weakened-at-runtime property, replace-narrows-on-reload, auto-resolve of pending approvals (and *only* for newly-added pairs), listing shape and sort order.
- **`internal/config`** (7 tests) — round-trip, hyphens allowed, non-supervised tier allowed, the three validation errors, and writer preservation asserted on raw TOML.
- **`internal/agent`** (2 tests) — tool executes with zero approval rows, event carries `approval_scope`, audit event has `scope:"config"`; plus a companion test pinning that the audit event fires for `permanent` too.
- **`internal/integration`** (4 tests) — `TestSupervisor_ConfigRuleSkipsSupervisor` proves the supervisor LLM is never invoked (2 LLM calls vs `TestSupervisor_Approve`'s 3); REST list/reject behaviour.
- **Web UI** — 754 vitest tests pass; new case asserts the config row is read-only.

## Known follow-up (not addressed here)

If an operator has *both* a TOML entry and a DB rule for the same agent+tool, the Approvals table shows two rows and clicking Revoke on the permanent one deletes the DB row without changing behaviour — the config rule still auto-approves. Surfacing that precedence in the UI is a product call, left out deliberately.

## Out of scope

Argument-pattern matching, script-hash approval for `run_javascript`, REST/web mutation of config rules, per-channel config rules, env-var override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
