### PR TITLE
feat(web): configurable web_fetch page size — [web.fetch] max_response_chars

### DIFF
--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -990,10 +990,11 @@ func connectWebMCP(ctx context.Context, agentName string, cfg *config.Config, pe
 	fetcher := buildWebFetcher(cfg.Web.Fetch, logger)
 
 	srv := webmcp.New(webmcp.Deps{
-		SearchProvider: searchProvider,
-		Fetcher:        fetcher,
-		PermissionTier: permTier,
-		Logger:         logger,
+		SearchProvider:   searchProvider,
+		Fetcher:          fetcher,
+		PermissionTier:   permTier,
+		MaxResponseChars: cfg.Web.Fetch.MaxResponseChars,
+		Logger:           logger,
 	})
 	session, err := srv.Connect(ctx)
 	if err != nil {

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -3908,7 +3908,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the current server configuration including listen address, TLS, CORS, WebSocket settings, and build info.",
+                "description": "Returns the current server configuration including listen address, TLS, CORS, WebSocket settings, in-process tool settings (web/script), and build info.",
                 "produces": [
                     "application/json"
                 ],
@@ -3949,7 +3949,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Partially updates server configuration (external_url, timezone, MCP server, and the in-process web_tools_enabled / script_enabled toggles). Changes are applied in-memory and persisted to the TOML config file. Toggling web_tools_enabled or script_enabled returns restart_required: true, since the in-process MCP tools are (de)registered only at process start.",
+                "description": "Partially updates server configuration (external_url, timezone, MCP server, the in-process web_tools_enabled / script_enabled toggles, and web_fetch_max_response_chars). Changes are applied in-memory and persisted to the TOML config file. Changing web_tools_enabled, script_enabled, or web_fetch_max_response_chars returns restart_required: true, since the in-process MCP tools are registered — and their limits read — only at process start. web_fetch_max_response_chars must be between 1 and 100000.",
                 "consumes": [
                     "application/json"
                 ],
@@ -7158,6 +7158,9 @@
                 "version": {
                     "type": "string"
                 },
+                "web_fetch_max_response_chars": {
+                    "type": "integer"
+                },
                 "web_tools_enabled": {
                     "type": "boolean"
                 },
@@ -7198,6 +7201,10 @@
                 },
                 "timezone": {
                     "type": "string"
+                },
+                "web_fetch_max_response_chars": {
+                    "description": "WebFetchMaxResponseChars mirrors [web.fetch] max_response_chars; the\nbounds match config.validateWeb so the API and TOML paths agree.",
+                    "type": "integer"
                 },
                 "web_tools_enabled": {
                     "type": "boolean"

--- a/internal/api/server_config.go
+++ b/internal/api/server_config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -28,6 +29,7 @@ type serverConfigResponse struct {
 	MCPServerStateless       bool     `json:"mcp_server_stateless"`
 	MCPServerEndpoint        string   `json:"mcp_server_endpoint"`
 	WebToolsEnabled          bool     `json:"web_tools_enabled"`
+	WebFetchMaxResponseChars int      `json:"web_fetch_max_response_chars"`
 	ScriptEnabled            bool     `json:"script_enabled"`
 	Version                  string   `json:"version"`
 	Commit                   string   `json:"commit"`
@@ -45,12 +47,21 @@ type serverConfigUpdateInput struct {
 	MCPServerChatTimeout    *string `json:"mcp_server_chat_timeout,omitempty"`
 	MCPServerStateless      *bool   `json:"mcp_server_stateless,omitempty"`
 	WebToolsEnabled         *bool   `json:"web_tools_enabled,omitempty"`
-	ScriptEnabled           *bool   `json:"script_enabled,omitempty"`
+	// WebFetchMaxResponseChars mirrors [web.fetch] max_response_chars; the
+	// bounds match config.validateWeb so the API and TOML paths agree.
+	WebFetchMaxResponseChars *int  `json:"web_fetch_max_response_chars,omitempty"`
+	ScriptEnabled            *bool `json:"script_enabled,omitempty"`
 }
+
+// Bounds for web_fetch_max_response_chars, kept in step with config.validateWeb.
+const (
+	minWebFetchMaxResponseChars = 1
+	maxWebFetchMaxResponseChars = 100000
+)
 
 // handleGetServerConfig godoc
 // @Summary      Get server configuration
-// @Description  Returns the current server configuration including listen address, TLS, CORS, WebSocket settings, and build info.
+// @Description  Returns the current server configuration including listen address, TLS, CORS, WebSocket settings, in-process tool settings (web/script), and build info.
 // @Tags         server
 // @Produce      json
 // @Security     BearerAuth
@@ -77,6 +88,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter, _ *http.Request) {
 		MCPServerStateless:       cfg.MCPServer.Stateless,
 		MCPServerEndpoint:        s.mcpServerEndpoint(),
 		WebToolsEnabled:          s.deps.Config.Web.WebEnabled(),
+		WebFetchMaxResponseChars: s.deps.Config.Web.Fetch.MaxResponseChars,
 		ScriptEnabled:            s.deps.Config.Script.ScriptEnabled(),
 		Version:                  s.deps.Version,
 		Commit:                   s.deps.Commit,
@@ -91,7 +103,7 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter, _ *http.Request) {
 
 // handlePatchServerConfig godoc
 // @Summary      Update server configuration
-// @Description  Partially updates server configuration (external_url, timezone, MCP server, and the in-process web_tools_enabled / script_enabled toggles). Changes are applied in-memory and persisted to the TOML config file. Toggling web_tools_enabled or script_enabled returns restart_required: true, since the in-process MCP tools are (de)registered only at process start.
+// @Description  Partially updates server configuration (external_url, timezone, MCP server, the in-process web_tools_enabled / script_enabled toggles, and web_fetch_max_response_chars). Changes are applied in-memory and persisted to the TOML config file. Changing web_tools_enabled, script_enabled, or web_fetch_max_response_chars returns restart_required: true, since the in-process MCP tools are registered — and their limits read — only at process start. web_fetch_max_response_chars must be between 1 and 100000.
 // @Tags         server
 // @Accept       json
 // @Produce      json
@@ -128,9 +140,9 @@ func (s *Server) handlePatchServerConfig(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// applyInProcessToolInput applies the [web]/[script] enabled toggles to the
-// in-memory config and reports whether either effective value changed. A change
-// needs a process restart to (de)register the in-process MCP tools, since the
+// applyInProcessToolInput applies the [web]/[script] settings to the in-memory
+// config and reports whether any effective value changed. A change needs a
+// process restart to (de)register the in-process MCP tools, since the
 // hot-reload path does not re-run connectWebMCP/connectScriptMCP.
 func applyInProcessToolInput(cfg *config.Config, input *serverConfigUpdateInput) bool {
 	changed := false
@@ -139,6 +151,14 @@ func applyInProcessToolInput(cfg *config.Config, input *serverConfigUpdateInput)
 			changed = true
 		}
 		cfg.Web.Enabled = input.WebToolsEnabled
+	}
+	if input.WebFetchMaxResponseChars != nil {
+		// The webmcp server reads this once at agent-build time, so a change
+		// only reaches web_fetch after a restart — same as the toggles.
+		if cfg.Web.Fetch.MaxResponseChars != *input.WebFetchMaxResponseChars {
+			changed = true
+		}
+		cfg.Web.Fetch.MaxResponseChars = *input.WebFetchMaxResponseChars
 	}
 	if input.ScriptEnabled != nil {
 		if cfg.Script.ScriptEnabled() != *input.ScriptEnabled {
@@ -159,6 +179,12 @@ func validateServerConfigInput(input *serverConfigUpdateInput) string {
 	if input.Timezone != nil && *input.Timezone != "" {
 		if _, err := time.LoadLocation(*input.Timezone); err != nil {
 			return "invalid timezone: must be a valid IANA timezone name (e.g. America/New_York)"
+		}
+	}
+	if v := input.WebFetchMaxResponseChars; v != nil {
+		if *v < minWebFetchMaxResponseChars || *v > maxWebFetchMaxResponseChars {
+			return fmt.Sprintf("web_fetch_max_response_chars must be between %d and %d",
+				minWebFetchMaxResponseChars, maxWebFetchMaxResponseChars)
 		}
 	}
 	return validateMCPServerInput(input)
@@ -311,8 +337,17 @@ func (s *Server) persistServerConfig(input *serverConfigUpdateInput) {
 // top-level TOML sections. Persisted separately from the [api] changes because
 // they live in distinct tables.
 func (s *Server) persistInProcessToolConfig(input *serverConfigUpdateInput) {
+	webChanges := make(map[string]any)
 	if input.WebToolsEnabled != nil {
-		if err := config.UpdateWebConfig(s.deps.ConfigPath, map[string]any{"enabled": *input.WebToolsEnabled}); err != nil {
+		webChanges["enabled"] = *input.WebToolsEnabled
+	}
+	if input.WebFetchMaxResponseChars != nil {
+		// Nested so it lands in [web.fetch]; updateTopLevelSection merges the
+		// sub-table key-by-key, leaving timeout/user_agent/etc. intact.
+		webChanges["fetch"] = map[string]any{"max_response_chars": *input.WebFetchMaxResponseChars}
+	}
+	if len(webChanges) > 0 {
+		if err := config.UpdateWebConfig(s.deps.ConfigPath, webChanges); err != nil {
 			s.logger.Warn("failed to persist web config", "error", err)
 		}
 	}

--- a/internal/api/server_config_test.go
+++ b/internal/api/server_config_test.go
@@ -343,6 +343,136 @@ func TestPatchServerConfig_DisableWebTools_Persists(t *testing.T) {
 	}
 }
 
+func TestGetServerConfig_WebFetchMaxResponseChars(t *testing.T) {
+	deps := testDepsWithServerConfig()
+	deps.Config.Web.Fetch.MaxResponseChars = 24000
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	req := authedRequest(http.MethodGet, "/api/v1/server/config")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp serverConfigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.WebFetchMaxResponseChars != 24000 {
+		t.Errorf("web_fetch_max_response_chars = %d, want 24000", resp.WebFetchMaxResponseChars)
+	}
+}
+
+func TestPatchServerConfig_WebFetchMaxResponseChars_PersistsAndRequestsRestart(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("[web.fetch]\ntimeout = \"30s\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDepsWithServerConfig()
+	deps.Config.Web.Fetch.MaxResponseChars = 8000
+	deps.ConfigPath = cfgPath
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"web_fetch_max_response_chars": 24000})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if deps.Config.Web.Fetch.MaxResponseChars != 24000 {
+		t.Errorf("in-memory MaxResponseChars = %d, want 24000", deps.Config.Web.Fetch.MaxResponseChars)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["restart_required"] != true {
+		t.Errorf("restart_required = %v, want true (webmcp reads the limit at startup)", resp["restart_required"])
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("max_response_chars = 24000")) {
+		t.Errorf("persisted config missing max_response_chars = 24000; got:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte("timeout")) || !bytes.Contains(data, []byte("30s")) {
+		t.Errorf("persisted config lost the [web.fetch] timeout sibling; got:\n%s", data)
+	}
+}
+
+func TestPatchServerConfig_WebFetchMaxResponseChars_BelowRange(t *testing.T) {
+	deps := testDepsWithServerConfig()
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"web_fetch_max_response_chars": 0})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("web_fetch_max_response_chars")) {
+		t.Errorf("error should name the field; got: %s", rec.Body.String())
+	}
+}
+
+func TestPatchServerConfig_WebFetchMaxResponseChars_AboveRange(t *testing.T) {
+	deps := testDepsWithServerConfig()
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"web_fetch_max_response_chars": 100001})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestPatchServerConfig_WebFetchMaxResponseChars_UnchangedOmitsRestart(t *testing.T) {
+	deps := testDepsWithServerConfig()
+	deps.Config.Web.Fetch.MaxResponseChars = 24000
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	body, _ := json.Marshal(map[string]any{"web_fetch_max_response_chars": 24000})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/server/config", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer dk-test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := resp["restart_required"]; ok {
+		t.Errorf("restart_required present, want omitted when value unchanged: %v", resp)
+	}
+}
+
 func TestPatchServerConfig_NoChangeOmitsRestartRequired(t *testing.T) {
 	// Setting web_tools_enabled=true when it is already effectively true (nil
 	// default) is not a change, so no restart is required.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -175,6 +175,12 @@ type WebFetchConfig struct {
 	Timeout string `toml:"timeout"`
 	// MaxSizeBytes limits the response body size. Default: 5242880 (5MB).
 	MaxSizeBytes int64 `toml:"max_size_bytes"`
+	// MaxResponseChars caps the characters of converted-Markdown content returned
+	// per web_fetch call; longer pages paginate via start_index. Each pagination
+	// round costs a full LLM context re-read, so higher values (e.g. 24000-32000)
+	// usually serve a whole article in one call and reduce rounds. Keep well under
+	// the model's context window. Default: 8000. Max: 100000.
+	MaxResponseChars int `toml:"max_response_chars"`
 	// UserAgent is the HTTP User-Agent header. Default: "Denkeeper/1.0 (+https://denkeeper.io)".
 	UserAgent string `toml:"user_agent"`
 	// RespectRobotsTxt checks robots.txt before fetching. Default: false.
@@ -1606,6 +1612,9 @@ func applyWebDefaults(cfg *Config) {
 	if cfg.Web.Fetch.MaxSizeBytes == 0 {
 		cfg.Web.Fetch.MaxSizeBytes = 5242880 // 5MB
 	}
+	if cfg.Web.Fetch.MaxResponseChars == 0 {
+		cfg.Web.Fetch.MaxResponseChars = 8000
+	}
 	if cfg.Web.Fetch.UserAgent == "" {
 		cfg.Web.Fetch.UserAgent = "Denkeeper/1.0 (+https://denkeeper.io)"
 	}
@@ -2090,6 +2099,9 @@ func validateWeb(w *WebConfig) error {
 	}
 	if w.Search.MaxResults < 1 || w.Search.MaxResults > 20 {
 		return fmt.Errorf("config: web.search.max_results must be between 1 and 20, got %d", w.Search.MaxResults)
+	}
+	if w.Fetch.MaxResponseChars < 1 || w.Fetch.MaxResponseChars > 100000 {
+		return fmt.Errorf("config: web.fetch.max_response_chars must be between 1 and 100000, got %d", w.Fetch.MaxResponseChars)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2782,6 +2782,9 @@ func TestParse_WebEnabledByDefault(t *testing.T) {
 	if cfg.Web.Fetch.MaxSizeBytes != 5242880 {
 		t.Errorf("max_size_bytes = %d, want 5242880", cfg.Web.Fetch.MaxSizeBytes)
 	}
+	if cfg.Web.Fetch.MaxResponseChars != 8000 {
+		t.Errorf("max_response_chars = %d, want 8000", cfg.Web.Fetch.MaxResponseChars)
+	}
 	if cfg.Web.Fetch.UserAgent != "Denkeeper/1.0 (+https://denkeeper.io)" {
 		t.Errorf("user_agent = %q, want default", cfg.Web.Fetch.UserAgent)
 	}
@@ -2972,6 +2975,7 @@ enabled = true
 [web.fetch]
 timeout = "15s"
 max_size_bytes = 1048576
+max_response_chars = 24000
 user_agent = "CustomBot/2.0"
 respect_robots_txt = true
 respect_agents_txt = true
@@ -2989,6 +2993,9 @@ enabled = true
 	if cfg.Web.Fetch.MaxSizeBytes != 1048576 {
 		t.Errorf("max_size_bytes = %d, want 1048576", cfg.Web.Fetch.MaxSizeBytes)
 	}
+	if cfg.Web.Fetch.MaxResponseChars != 24000 {
+		t.Errorf("max_response_chars = %d, want 24000", cfg.Web.Fetch.MaxResponseChars)
+	}
 	if cfg.Web.Fetch.UserAgent != "CustomBot/2.0" {
 		t.Errorf("user_agent = %q, want %q", cfg.Web.Fetch.UserAgent, "CustomBot/2.0")
 	}
@@ -3000,6 +3007,47 @@ enabled = true
 	}
 	if !cfg.Web.Fetch.Jina.Enabled {
 		t.Error("jina.enabled should be true")
+	}
+}
+
+func TestValidate_WebFetchMaxResponseCharsNegative_Rejected(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[web.fetch]
+max_response_chars = -1
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for negative max_response_chars")
+	}
+	if !strings.Contains(err.Error(), "web.fetch.max_response_chars") {
+		t.Errorf("error should mention web.fetch.max_response_chars: %v", err)
+	}
+}
+
+func TestValidate_WebFetchMaxResponseCharsTooLarge_Rejected(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[web.fetch]
+max_response_chars = 100001
+`)
+	_, err := Parse(tomlData)
+	if err == nil {
+		t.Fatal("expected error for max_response_chars above 100000")
+	}
+	if !strings.Contains(err.Error(), "web.fetch.max_response_chars") {
+		t.Errorf("error should mention web.fetch.max_response_chars: %v", err)
+	}
+}
+
+func TestValidate_WebFetchMaxResponseChars_DisabledWebSkipsValidation(t *testing.T) {
+	tomlData := []byte(baseConfig + `
+[web]
+enabled = false
+
+[web.fetch]
+max_response_chars = -1
+`)
+	if _, err := Parse(tomlData); err != nil {
+		t.Fatalf("disabled web should skip validation, got: %v", err)
 	}
 }
 

--- a/internal/config/writer.go
+++ b/internal/config/writer.go
@@ -747,6 +747,11 @@ func UpdateAPIConfig(path string, changes map[string]any) error {
 // (e.g. [web], [script]). Only keys present in changes are written; a key
 // mapped to a nil value is deleted so callers can restore the omitted-field
 // default. Existing sibling keys are preserved.
+//
+// Sub-table values (e.g. changes["fetch"] for [web.fetch]) are merged key-by-key
+// rather than replaced wholesale — same semantics as UpdateAPIConfig's nested
+// handling — so updating one sub-key does not clobber its siblings. Scalars are
+// replaced.
 func updateTopLevelSection(path, section string, changes map[string]any) error {
 	ConfigMu.Lock()
 	defer ConfigMu.Unlock()
@@ -761,15 +766,35 @@ func updateTopLevelSection(path, section string, changes map[string]any) error {
 		sec = map[string]any{}
 	}
 	for k, v := range changes {
-		if v == nil {
+		switch val := v.(type) {
+		case nil:
 			delete(sec, k)
-		} else {
+		case map[string]any:
+			sec[k] = mergeSubTable(sec[k], val)
+		default:
 			sec[k] = v
 		}
 	}
 	raw[section] = sec
 
 	return WriteRawConfig(path, raw)
+}
+
+// mergeSubTable merges changes into an existing TOML sub-table, preserving keys
+// the caller did not mention. A nil change value deletes its key.
+func mergeSubTable(existing any, changes map[string]any) map[string]any {
+	merged, _ := existing.(map[string]any)
+	if merged == nil {
+		merged = map[string]any{}
+	}
+	for k, v := range changes {
+		if v == nil {
+			delete(merged, k)
+		} else {
+			merged[k] = v
+		}
+	}
+	return merged
 }
 
 // UpdateWebConfig persists partial updates to the top-level [web] section (the

--- a/internal/config/writer_test.go
+++ b/internal/config/writer_test.go
@@ -1052,6 +1052,59 @@ func TestUpdateWebConfig_ReEnable(t *testing.T) {
 	}
 }
 
+func TestUpdateWebConfig_SubTableMergePreservesSiblings(t *testing.T) {
+	path := writeTestConfig(t, "[web.fetch]\ntimeout = \"30s\"\nuser_agent = \"CustomBot/2.0\"\n")
+
+	if err := UpdateWebConfig(path, map[string]any{
+		"fetch": map[string]any{"max_response_chars": 24000},
+	}); err != nil {
+		t.Fatalf("UpdateWebConfig: %v", err)
+	}
+
+	raw, err := ReadRawConfig(path)
+	if err != nil {
+		t.Fatalf("ReadRawConfig: %v", err)
+	}
+	web, _ := raw["web"].(map[string]any)
+	fetch, _ := web["fetch"].(map[string]any)
+	if fetch["max_response_chars"] != int64(24000) {
+		t.Errorf("raw [web.fetch].max_response_chars = %v (%T), want 24000", fetch["max_response_chars"], fetch["max_response_chars"])
+	}
+	// The whole point of merging rather than replacing the sub-table.
+	if fetch["timeout"] != "30s" {
+		t.Errorf("raw [web.fetch].timeout = %v, want 30s (sibling clobbered)", fetch["timeout"])
+	}
+	if fetch["user_agent"] != "CustomBot/2.0" {
+		t.Errorf("raw [web.fetch].user_agent = %v, want CustomBot/2.0 (sibling clobbered)", fetch["user_agent"])
+	}
+}
+
+func TestUpdateWebConfig_SubTableCreatedWhenAbsent(t *testing.T) {
+	path := writeTestConfig(t, "[web]\nenabled = true\n")
+
+	if err := UpdateWebConfig(path, map[string]any{
+		"fetch": map[string]any{"max_response_chars": 16000},
+	}); err != nil {
+		t.Fatalf("UpdateWebConfig: %v", err)
+	}
+
+	raw, err := ReadRawConfig(path)
+	if err != nil {
+		t.Fatalf("ReadRawConfig: %v", err)
+	}
+	web, _ := raw["web"].(map[string]any)
+	fetch, _ := web["fetch"].(map[string]any)
+	if fetch == nil {
+		t.Fatalf("raw [web.fetch] not created; got web = %v", web)
+	}
+	if fetch["max_response_chars"] != int64(16000) {
+		t.Errorf("raw [web.fetch].max_response_chars = %v, want 16000", fetch["max_response_chars"])
+	}
+	if web["enabled"] != true {
+		t.Errorf("raw [web].enabled = %v, want true (scalar sibling clobbered)", web["enabled"])
+	}
+}
+
 func TestUpdateScriptConfig_DisablePreservesSiblings(t *testing.T) {
 	path := writeTestConfig(t, "[script]\ntimeout = \"2s\"\nmax_concurrent = 4\n")
 

--- a/internal/webmcp/handlers.go
+++ b/internal/webmcp/handlers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const maxResponseChars = 8000
+const defaultMaxResponseChars = 8000
 
 func (s *Server) registerTools() {
 	if s.deps.SearchProvider != nil {
@@ -29,7 +29,7 @@ func (s *Server) registerTools() {
 	if s.deps.Fetcher != nil {
 		s.mcpServer.AddTool(&mcp.Tool{
 			Name:        "web_fetch",
-			Description: "Fetch a URL and convert its content to Markdown. Use for reading web pages, documentation, articles. Returns truncated content with pagination support via start_index.",
+			Description: fmt.Sprintf("Fetch a URL and convert its content to Markdown. Use for reading web pages, documentation, articles. Returns up to %d characters per call; longer pages are paginated via start_index.", s.deps.MaxResponseChars),
 			InputSchema: json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -124,8 +124,8 @@ func (s *Server) handleWebFetch(ctx context.Context, req *mcp.CallToolRequest) (
 	}
 
 	hasMore := false
-	if len(content) > maxResponseChars {
-		content = content[:maxResponseChars]
+	if len(content) > s.deps.MaxResponseChars {
+		content = content[:s.deps.MaxResponseChars]
 		hasMore = true
 	}
 

--- a/internal/webmcp/server.go
+++ b/internal/webmcp/server.go
@@ -26,6 +26,10 @@ type Deps struct {
 	// PermissionTier returns the current effective tier for the agent.
 	PermissionTier func() string
 
+	// MaxResponseChars caps content characters returned per web_fetch call.
+	// Zero means the default (8000).
+	MaxResponseChars int
+
 	Logger *slog.Logger
 }
 
@@ -40,6 +44,9 @@ type Server struct {
 func New(deps Deps) *Server {
 	if deps.Logger == nil {
 		deps.Logger = slog.Default()
+	}
+	if deps.MaxResponseChars <= 0 {
+		deps.MaxResponseChars = defaultMaxResponseChars
 	}
 
 	s := &Server{

--- a/internal/webmcp/server_test.go
+++ b/internal/webmcp/server_test.go
@@ -169,6 +169,7 @@ func TestWebFetch_Success(t *testing.T) {
 }
 
 func TestWebFetch_Pagination(t *testing.T) {
+	const pageSize = 4000
 	longContent := strings.Repeat("x", 10000)
 	session := newTestServer(t, Deps{
 		Fetcher: &mockFetcher{
@@ -177,7 +178,8 @@ func TestWebFetch_Pagination(t *testing.T) {
 				Content: longContent,
 			},
 		},
-		PermissionTier: func() string { return "autonomous" },
+		PermissionTier:   func() string { return "autonomous" },
+		MaxResponseChars: pageSize,
 	})
 
 	// First page.
@@ -200,14 +202,14 @@ func TestWebFetch_Pagination(t *testing.T) {
 	if resp.TotalLength != 10000 {
 		t.Errorf("total_length = %d, want 10000", resp.TotalLength)
 	}
-	if len(resp.Content) != maxResponseChars {
-		t.Errorf("content length = %d, want %d", len(resp.Content), maxResponseChars)
+	if len(resp.Content) != pageSize {
+		t.Errorf("content length = %d, want %d", len(resp.Content), pageSize)
 	}
 
-	// Second page.
+	// Middle page.
 	result2 := callTool(t, session, "web_fetch", map[string]any{
 		"url":         "https://example.com",
-		"start_index": maxResponseChars,
+		"start_index": pageSize,
 	})
 	var resp2 struct {
 		Content string `json:"content"`
@@ -216,11 +218,116 @@ func TestWebFetch_Pagination(t *testing.T) {
 	if err := json.Unmarshal([]byte(extractText(result2)), &resp2); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
-	if len(resp2.Content) != 10000-maxResponseChars {
-		t.Errorf("second page content length = %d, want %d", len(resp2.Content), 10000-maxResponseChars)
+	if len(resp2.Content) != pageSize {
+		t.Errorf("second page content length = %d, want %d", len(resp2.Content), pageSize)
 	}
-	if resp2.HasMore {
-		t.Error("second page should not have more")
+	if !resp2.HasMore {
+		t.Error("second page should have more")
+	}
+
+	// Final page (tail shorter than the limit).
+	result3 := callTool(t, session, "web_fetch", map[string]any{
+		"url":         "https://example.com",
+		"start_index": 2 * pageSize,
+	})
+	var resp3 struct {
+		Content string `json:"content"`
+		HasMore bool   `json:"has_more"`
+	}
+	if err := json.Unmarshal([]byte(extractText(result3)), &resp3); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp3.Content) != 10000-2*pageSize {
+		t.Errorf("final page content length = %d, want %d", len(resp3.Content), 10000-2*pageSize)
+	}
+	if resp3.HasMore {
+		t.Error("final page should not have more")
+	}
+}
+
+func TestWebFetch_DefaultPageSize(t *testing.T) {
+	longContent := strings.Repeat("x", 10000)
+	session := newTestServer(t, Deps{
+		Fetcher: &mockFetcher{
+			result: &webfetch.FetchResult{
+				URL:     "https://example.com",
+				Content: longContent,
+			},
+		},
+		PermissionTier: func() string { return "autonomous" },
+	})
+
+	result := callTool(t, session, "web_fetch", map[string]any{"url": "https://example.com"})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", extractText(result))
+	}
+
+	var resp struct {
+		Content string `json:"content"`
+		HasMore bool   `json:"has_more"`
+	}
+	if err := json.Unmarshal([]byte(extractText(result)), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Content) != defaultMaxResponseChars {
+		t.Errorf("content length = %d, want default %d", len(resp.Content), defaultMaxResponseChars)
+	}
+	if !resp.HasMore {
+		t.Error("has_more should be true for long content")
+	}
+}
+
+func TestWebFetch_DescriptionIncludesPageSize(t *testing.T) {
+	session := newTestServer(t, Deps{
+		Fetcher:          &mockFetcher{},
+		PermissionTier:   func() string { return "autonomous" },
+		MaxResponseChars: 12345,
+	})
+
+	tools, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	for _, tool := range tools.Tools {
+		if tool.Name == "web_fetch" {
+			if !strings.Contains(tool.Description, "12345") {
+				t.Errorf("web_fetch description should include page size 12345: %s", tool.Description)
+			}
+			return
+		}
+	}
+	t.Fatal("web_fetch tool not registered")
+}
+
+func TestWebFetch_CustomLimitShortContent(t *testing.T) {
+	session := newTestServer(t, Deps{
+		Fetcher: &mockFetcher{
+			result: &webfetch.FetchResult{
+				URL:     "https://example.com",
+				Content: strings.Repeat("x", 40),
+			},
+		},
+		PermissionTier:   func() string { return "autonomous" },
+		MaxResponseChars: 100,
+	})
+
+	result := callTool(t, session, "web_fetch", map[string]any{"url": "https://example.com"})
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", extractText(result))
+	}
+
+	var resp struct {
+		Content string `json:"content"`
+		HasMore bool   `json:"has_more"`
+	}
+	if err := json.Unmarshal([]byte(extractText(result)), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Content) != 40 {
+		t.Errorf("content length = %d, want 40 (untruncated)", len(resp.Content))
+	}
+	if resp.HasMore {
+		t.Error("has_more should be false when content fits within the limit")
 	}
 }
 

--- a/web/src/__tests__/pages/ServerConfig.test.js
+++ b/web/src/__tests__/pages/ServerConfig.test.js
@@ -524,6 +524,7 @@ describe('ServerConfig page', () => {
   })
 
   test('web_fetch page size skips the PATCH when the value is unchanged', async () => {
+    vi.useFakeTimers()
     let patched = false
     server.use(
       http.patch('/api/v1/server/config', async () => {
@@ -541,8 +542,11 @@ describe('ServerConfig page', () => {
     const input = screen.getByLabelText('web_fetch page size')
     await fireEvent.change(input, { target: { value: '8000' } })
 
-    await new Promise((r) => setTimeout(r, 600))
+    // Outlast the 400ms debounce on the virtual clock rather than sleeping.
+    await vi.advanceTimersByTimeAsync(600)
     expect(patched).toBe(false)
+
+    vi.useRealTimers()
   })
 
   test('web_fetch page size restores the persisted value when the save fails', async () => {

--- a/web/src/__tests__/pages/ServerConfig.test.js
+++ b/web/src/__tests__/pages/ServerConfig.test.js
@@ -505,7 +505,64 @@ describe('ServerConfig page', () => {
     await waitFor(() => {
       expect(screen.getByText(/between 1 and 100000/)).toBeInTheDocument()
     })
+    expect(input).toHaveAttribute('aria-invalid', 'true')
     expect(patched).toBe(false)
+  })
+
+  test('web_fetch page size shows Saved confirmation on success', async () => {
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const input = screen.getByLabelText('web_fetch page size')
+    await fireEvent.change(input, { target: { value: '24000' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeInTheDocument()
+    })
+  })
+
+  test('web_fetch page size skips the PATCH when the value is unchanged', async () => {
+    let patched = false
+    server.use(
+      http.patch('/api/v1/server/config', async () => {
+        patched = true
+        return HttpResponse.json({ status: 'updated' })
+      }),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    // Re-committing the current value (spinner up then down, blur) must not
+    // trigger an atomic TOML rewrite on the server.
+    const input = screen.getByLabelText('web_fetch page size')
+    await fireEvent.change(input, { target: { value: '8000' } })
+
+    await new Promise((r) => setTimeout(r, 600))
+    expect(patched).toBe(false)
+  })
+
+  test('web_fetch page size restores the persisted value when the save fails', async () => {
+    server.use(
+      http.patch('/api/v1/server/config', () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const input = screen.getByLabelText('web_fetch page size')
+    await fireEvent.change(input, { target: { value: '24000' } })
+
+    // The rejected value must not linger on screen as though it were saved.
+    await waitFor(() => {
+      expect(input.value).toBe('8000')
+    })
   })
 
   test('Deterministic compute toggle PATCHes script_enabled', async () => {

--- a/web/src/__tests__/pages/ServerConfig.test.js
+++ b/web/src/__tests__/pages/ServerConfig.test.js
@@ -461,6 +461,53 @@ describe('ServerConfig page', () => {
     })
   })
 
+  test('web_fetch page size PATCHes web_fetch_max_response_chars and shows restart hint', async () => {
+    let body = null
+    server.use(
+      http.patch('/api/v1/server/config', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ status: 'updated', restart_required: true })
+      }),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const input = screen.getByLabelText('web_fetch page size')
+    expect(input.value).toBe('8000')
+    await fireEvent.change(input, { target: { value: '24000' } })
+
+    await waitFor(() => {
+      expect(body).toEqual({ web_fetch_max_response_chars: 24000 })
+    })
+    await waitFor(() => {
+      expect(screen.getByText(/Restart the server/)).toBeInTheDocument()
+    })
+  })
+
+  test('web_fetch page size rejects out-of-range values without PATCHing', async () => {
+    let patched = false
+    server.use(
+      http.patch('/api/v1/server/config', async () => {
+        patched = true
+        return HttpResponse.json({ status: 'updated' })
+      }),
+    )
+    render(ServerConfig)
+    await waitFor(() => {
+      expect(screen.getByText('In-Process Tools')).toBeInTheDocument()
+    })
+
+    const input = screen.getByLabelText('web_fetch page size')
+    await fireEvent.change(input, { target: { value: '100001' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/between 1 and 100000/)).toBeInTheDocument()
+    })
+    expect(patched).toBe(false)
+  })
+
   test('Deterministic compute toggle PATCHes script_enabled', async () => {
     let body = null
     server.use(

--- a/web/src/pages/ServerConfig.svelte
+++ b/web/src/pages/ServerConfig.svelte
@@ -156,6 +156,25 @@
     }
   }
 
+  async function saveWebFetchChars(raw) {
+    const value = Number(raw)
+    if (!Number.isInteger(value) || value < 1 || value > 100000) {
+      error = 'Page size must be a whole number between 1 and 100000'
+      return
+    }
+    savingWeb = true
+    error = ''
+    try {
+      const res = await api.updateServerConfig({ web_fetch_max_response_chars: value })
+      config.web_fetch_max_response_chars = value
+      if (res?.restart_required) toolsRestartHint = true
+    } catch (e) {
+      error = e.message
+    } finally {
+      savingWeb = false
+    }
+  }
+
   async function toggleScript() {
     savingScript = true
     error = ''
@@ -432,6 +451,32 @@
         </label>
       </div>
     </div>
+
+    {#if config.web_tools_enabled}
+      <div class="config-row">
+        <div class="config-label">
+          <div class="config-name">web_fetch page size</div>
+          <div class="config-desc">
+            Characters of converted page content returned per web_fetch call; longer
+            pages paginate via start_index. Each extra page costs the model a full
+            context re-read, so 24000&ndash;32000 usually serves a whole article in one
+            call. Keep well under the model's context window. 1&ndash;100000.
+          </div>
+        </div>
+        <div class="config-value-row">
+          <input
+            type="number"
+            class="input inline-input"
+            aria-label="web_fetch page size"
+            min="1"
+            max="100000"
+            value={config.web_fetch_max_response_chars}
+            disabled={savingWeb}
+            onchange={(e) => saveWebFetchChars(e.target.value)}
+          />
+        </div>
+      </div>
+    {/if}
   </div>
 
   <div class="config-card" style="margin-top: 14px;">

--- a/web/src/pages/ServerConfig.svelte
+++ b/web/src/pages/ServerConfig.svelte
@@ -37,12 +37,17 @@
   let savingWeb = $state(false)
   let savingScript = $state(false)
   let toolsRestartHint = $state(false)
+  let saveWebOk = $state(false)
+  let webFetchDraft = $state(null)
+  let webFetchError = $state('')
+  let webFetchSaveTimer = null
 
   async function fetchConfig() {
     loading = true
     error = ''
     try {
       config = await api.serverConfig()
+      webFetchDraft = config.web_fetch_max_response_chars
     } catch (e) {
       error = e.message
     } finally {
@@ -156,20 +161,43 @@
     }
   }
 
-  async function saveWebFetchChars(raw) {
-    const value = Number(raw)
-    if (!Number.isInteger(value) || value < 1 || value > 100000) {
-      error = 'Page size must be a whole number between 1 and 100000'
+  // The input edits a draft, not config, so a rejected value never masquerades
+  // as the persisted one. Bounds come from the element's min/max attributes,
+  // keeping one client-side source rather than a third copy of 1..100000.
+  function queueWebFetchSave(e) {
+    clearTimeout(webFetchSaveTimer)
+    // Read the element, not the bound draft: bind:value updates on `input`,
+    // while this fires on `change`. The binding exists so a failed save can
+    // put the persisted value back on screen.
+    const min = Number(e.target.min)
+    const max = Number(e.target.max)
+    const value = Number(e.target.value)
+    if (!Number.isInteger(value) || value < min || value > max) {
+      webFetchError = `Page size must be a whole number between ${min} and ${max}`
       return
     }
+    webFetchError = ''
+    // Track the committed value in state so a later revert is an actual state
+    // change — Svelte only rewrites the DOM when the bound expression differs.
+    webFetchDraft = value
+    if (value === config.web_fetch_max_response_chars) return
+    // Coalesce spinner and arrow-key steps: each PATCH is an atomic TOML
+    // read-modify-write with a .bak backup, so one write per step is real churn.
+    webFetchSaveTimer = setTimeout(() => saveWebFetchChars(value), 400)
+  }
+
+  async function saveWebFetchChars(value) {
     savingWeb = true
     error = ''
     try {
       const res = await api.updateServerConfig({ web_fetch_max_response_chars: value })
       config.web_fetch_max_response_chars = value
+      saveWebOk = true
+      setTimeout(() => { saveWebOk = false }, 3000)
       if (res?.restart_required) toolsRestartHint = true
     } catch (e) {
       error = e.message
+      webFetchDraft = config.web_fetch_max_response_chars
     } finally {
       savingWeb = false
     }
@@ -455,29 +483,38 @@
     {#if config.web_tools_enabled}
       <div class="config-row">
         <div class="config-label">
-          <div class="config-name">web_fetch page size</div>
-          <div class="config-desc">
-            Characters of converted page content returned per web_fetch call; longer
-            pages paginate via start_index. Each extra page costs the model a full
-            context re-read, so 24000&ndash;32000 usually serves a whole article in one
-            call. Keep well under the model's context window. 1&ndash;100000.
+          <label class="config-name" for="web-fetch-chars">web_fetch page size</label>
+          <div class="config-desc" id="web-fetch-chars-desc">
+            Characters of page content returned per web_fetch call; longer pages
+            paginate via start_index. Higher values (24000&ndash;32000) usually serve a
+            whole article in one call. 1&ndash;100000. Default: 8000.
           </div>
+          {#if webFetchError}
+            <div class="inline-error" role="alert">{webFetchError}</div>
+          {/if}
         </div>
         <div class="config-value-row">
           <input
+            id="web-fetch-chars"
             type="number"
-            class="input inline-input"
+            class="input inline-input inline-input-num"
             aria-label="web_fetch page size"
+            aria-describedby="web-fetch-chars-desc"
+            aria-invalid={!!webFetchError}
             min="1"
             max="100000"
-            value={config.web_fetch_max_response_chars}
+            bind:value={webFetchDraft}
             disabled={savingWeb}
-            onchange={(e) => saveWebFetchChars(e.target.value)}
+            onchange={queueWebFetchSave}
           />
         </div>
       </div>
     {/if}
   </div>
+
+  {#if saveWebOk}
+    <div class="save-ok" role="status">Saved</div>
+  {/if}
 
   <div class="config-card" style="margin-top: 14px;">
     <div class="config-row">
@@ -629,8 +666,16 @@
     align-items: flex-start;
     gap: 16px;
   }
+  /* First card in the page to hold more than one row; matches the divider
+     convention used in Providers/Tools/Agents/Channels. */
+  .config-row + .config-row {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+  }
   .config-label { flex: 1; }
-  .config-name { font-weight: 600; font-size: 14px; }
+  .config-name { font-weight: 600; font-size: 14px; display: block; }
+  .inline-error { color: var(--danger); font-size: 12px; margin-top: 6px; }
   .config-desc { font-size: 12px; color: var(--text-muted); margin-top: 4px; line-height: 1.4; }
 
   .config-value-row {
@@ -741,6 +786,8 @@
     padding: 4px 8px;
     font-size: 13px;
   }
+  /* 80px was sized for "30m"; six digits plus the native spinner need more. */
+  .inline-input-num { width: 104px; }
 
   .mcp-hint {
     margin-top: 10px;

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -302,6 +302,7 @@ export const handlers = [
     mcp_server_stateless: false,
     mcp_server_endpoint: 'http://:8080/api/v1/mcp',
     web_tools_enabled: true,
+    web_fetch_max_response_chars: 8000,
     script_enabled: true,
     external_url: 'https://den.example.com',
     timezone: 'UTC',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -307,6 +307,7 @@ Global MCP settings.
     [web.fetch]
     timeout = "30s"                  # HTTP timeout
     max_size_bytes = 5242880         # response size limit (5MB)
+    max_response_chars = 8000        # chars per web_fetch call (max 100000); 24000-32000 fits most articles in one call
     user_agent = ""                  # HTTP User-Agent header
     respect_robots_txt = false       # check robots.txt
     respect_agents_txt = false       # check agents.txt


### PR DESCRIPTION
Implements sprint 2026-08 item 2 (`design/sprint-2026-08/2-web-fetch-max-response-chars-plan.md`), from ops finding A2, plus a Server Config surface for the new knob.

## Problem

`web_fetch` truncated every page at a hardcoded `const maxResponseChars = 8000`, forcing the model to paginate long articles via `start_index`. Each pagination round re-pays the entire (growing) conversation context to receive the next ~2k tokens of content — A2 recorded one article fetched at `start_index` 0 / 10000 / 25000 / 35000: four full LLM rounds for a single source.

Every other fetch bound under `[web.fetch]` (`timeout`, `max_size_bytes`, `user_agent`, robots/agents policy) was already tunable. Page size was the one knob missing. The tool description also never told the model how big a page was, so it couldn't plan pagination.

## What changed

**Commit 1 — the knob**

| Area | Change |
|---|---|
| `internal/config/config.go` | `WebFetchConfig.MaxResponseChars`; `0 → 8000` in `applyWebDefaults`; `validateWeb` rejects outside `1..100000` |
| `internal/webmcp/server.go` | `Deps.MaxResponseChars` + defensive `0 → default` in `New` |
| `internal/webmcp/handlers.go` | Constant becomes `defaultMaxResponseChars`; handler and tool description read `s.deps.MaxResponseChars` |
| `cmd/denkeeper/main.go` | `connectWebMCP` passes `cfg.Web.Fetch.MaxResponseChars` |
| `website/static/llms-full.txt` | Config line documenting the knob and the recommended range |

```toml
[web.fetch]
max_response_chars = 24000   # default 8000, max 100000
```

**Commit 2 — the Server Config surface**

Editing `config.toml` and restarting was the only way to change it, while the Web tools card in Server Config already carried the enable toggle. The value now sits beside the toggle, following the MCP server card's precedent of editable sub-fields on the same `PATCH /api/v1/server/config` endpoint.

| Area | Change |
|---|---|
| `internal/config/writer.go` | `updateTopLevelSection` merges sub-table values key-by-key instead of replacing them |
| `internal/api/server_config.go` | `web_fetch_max_response_chars` on the GET response and PATCH input — validated, applied in-memory, persisted under `[web.fetch]`, `restart_required` on change |
| `web/src/pages/ServerConfig.svelte` | Number input in the Web tools card, shown only when web tools are on, with client-side range validation that reports inline and skips the PATCH |
| `internal/api/docs/swagger.json` | Regenerated — both schemas and both endpoint descriptions |

## Notes for review

- **The writer change is load-bearing, not a drive-by.** `[web.fetch]` is a sub-table, and `updateTopLevelSection` previously only handled flat scalars — persisting `max_response_chars` would have replaced the sub-table wholesale and silently dropped `timeout`, `user_agent`, and every other `[web.fetch]` sibling. The new merge mirrors `UpdateAPIConfig`'s already-documented nested behavior, and `TestPatchServerConfig_WebFetchMaxResponseChars_PersistsAndRequestsRestart` asserts the sibling survives a real PATCH. `[script]` sub-tables get the same treatment for free.
- **The shipped default stays 8000.** This PR makes the size configurable; changing the default is a separate behavioral decision. Nothing improves until it is raised and the process restarted — the config comment, TOML example, and UI helper text all steer toward the A2-recommended 24000–32000.
- **Restart-only, by design.** The Web MCP server is built once per agent at startup and `buildReloadFunc` re-applies only per-agent *engine* knobs, so every `[web]` setting is already restart-only. The PATCH therefore returns `restart_required: true` on a changed value and the UI shows the existing restart hint, rather than implying the change is live. A `func() int` closure reading live config would race against `*cfg = *newCfg` under `-race`; if `[web]` hot-reload lands, it should land for the whole section rather than special-casing one field.
- **Bounds are stated twice** (config `validateWeb` and the API handler's `minWebFetchMaxResponseChars`/`maxWebFetchMaxResponseChars`). Routing the handler through `validateWeb` would validate a whole `Config` and could reject an unrelated PATCH over a pre-existing problem elsewhere in `[web]`. The constants name the contract and carry a comment tying them to the config-side check — worth a second opinion if you'd rather they share one validator.
- **Upper bound 100000** (~25k tokens per tool result): past that a single tool result risks blowing the context window outright, at which point truncation protects the turn rather than costing rounds. Raw body size stays separately capped by `max_size_bytes`.
- **`0` means default, `-1` is rejected** — deliberately no "0 = unlimited": unbounded tool results into an LLM context is never correct. (Unlike `skills.max_bytes`, where negative-means-unlimited guards disk, not context.)
- **Rune splitting at the page boundary is unchanged.** `content[:max]` slices bytes and can split a multi-byte rune — pre-existing with the 8000 constant, and self-healing because the next page's `start_index` continues from the same byte offset. Noting it so nobody "fixes" it into rune-counting and breaks `start_index` arithmetic, which is byte-based on both sides.
- Pagination protocol (`start_index` / `has_more` / `total_length`) is untouched.

## Tests

`TestWebFetch_Pagination` no longer leans on the package constant — it parameterizes off `Deps` and walks three pages including a short tail. New: `_DefaultPageSize` (pins the defensive default in `New`), `_DescriptionIncludesPageSize` (pins the model-facing contract), `_CustomLimitShortContent`. Config: default assertion, custom round-trip, negative / too-large / disabled-web-skips-validation. Writer: sub-table merge preserves siblings, and creates the sub-table when absent without clobbering scalar siblings. API: GET exposure, persist-and-restart, below/above range rejection, unchanged-omits-restart. UI: PATCH round-trip with restart hint, and out-of-range reports inline without PATCHing.

`just hook` green: fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)