### PR TITLE
fix(oauth): clean up MCP tool tokens on every lifecycle removal path

### DIFF
--- a/cmd/denkeeper/oauth_init.go
+++ b/cmd/denkeeper/oauth_init.go
@@ -61,6 +61,7 @@ func initOAuthSupport(ctx context.Context, cfg *config.Config, toolMgr *tool.Man
 	toolMgr.SetOAuthSupport(&tool.OAuthSupport{
 		HandlerFactory: factory,
 		CallbackURL:    callbackURL,
+		TokenStore:     store,
 	})
 
 	go pending.StartCleanup(ctx, time.Minute)

--- a/internal/tool/lifecycle.go
+++ b/internal/tool/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"sync"
 
 	"github.com/Temikus/denkeeper/internal/config"
@@ -101,6 +102,12 @@ func (lm *LifecycleManager) AddTool(ctx context.Context, name string, cfg config
 		return err
 	}
 
+	// The name passed checkConflict, so any persisted OAuth token under it is
+	// an orphan from a previously deleted tool. Purge before RegisterServer
+	// (which reads the store) so the new tool starts unauthenticated instead
+	// of adopting the old token.
+	lm.toolMgr.CleanupOAuthToken(name)
+
 	if err := lm.toolMgr.RegisterServer(ctx, name, cfg); err != nil {
 		return fmt.Errorf("starting tool %q: %w", name, err)
 	}
@@ -158,9 +165,18 @@ func (lm *LifecycleManager) UpdateTool(ctx context.Context, name string, cfg con
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
-	// Verify the tool exists.
-	if _, ok := lm.toolMgr.ServerInfo(name); !ok {
+	// Verify the tool exists and capture its old config.
+	oldCfg, ok := lm.toolMgr.ServerToolConfig(name)
+	if !ok {
 		return fmt.Errorf("tool %q not found", name)
+	}
+
+	// A stored token belongs to the OAuth identity it was issued for. If the
+	// update changes that identity, discard the token so the tool re-auths —
+	// before UnregisterServer, so a live handler's in-memory state clears too.
+	// Updates that leave the identity untouched keep the token.
+	if oauthIdentityChanged(oldCfg, cfg) {
+		lm.toolMgr.CleanupOAuthToken(name)
 	}
 
 	// Remove old server.
@@ -381,6 +397,10 @@ func (lm *LifecycleManager) RemovePlugin(ctx context.Context, name string) error
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
 
+	// Plugins never authenticate via OAuth, but a token row orphaned by an
+	// old same-named tool may exist; clear it so the name is clean for reuse.
+	lm.toolMgr.CleanupOAuthToken(name)
+
 	// Try to unregister from tool manager (may not be there if no tools capability).
 	_ = lm.toolMgr.UnregisterServer(name)
 
@@ -478,6 +498,23 @@ func (lm *LifecycleManager) checkLimit() error {
 		return fmt.Errorf("maximum number of tools reached (%d)", lm.maxTools)
 	}
 	return nil
+}
+
+// oauthIdentityChanged reports whether an update alters the fields a stored
+// OAuth token is bound to: auth mode, client credentials, scopes, or server
+// URL. Tokens are keyed by tool name only, so when any of these change the
+// old token must be discarded — nothing else stops the updated tool from
+// reusing a token issued to a different identity. Transitions into OAuth
+// also report true, purging rows orphaned by pre-cleanup versions.
+func oauthIdentityChanged(oldCfg, newCfg config.ToolConfig) bool {
+	if oldCfg.Auth != "oauth" && newCfg.Auth != "oauth" {
+		return false
+	}
+	return oldCfg.Auth != newCfg.Auth ||
+		oldCfg.ClientID != newCfg.ClientID ||
+		oldCfg.ClientSecret != newCfg.ClientSecret ||
+		oldCfg.URL != newCfg.URL ||
+		!slices.Equal(oldCfg.Scopes, newCfg.Scopes)
 }
 
 func validateToolName(name string) error {

--- a/internal/tool/manager.go
+++ b/internal/tool/manager.go
@@ -101,6 +101,17 @@ type OAuthSupport struct {
 	// a build-tag-gated init in manager_oauth.go.
 	HandlerFactory OAuthHandlerFactory
 	CallbackURL    string
+
+	// TokenStore deletes persisted tokens directly, independent of any live
+	// handler. Satisfied by *oauth.TokenStore. Needed because tokens are
+	// keyed by tool name alone: a tool that is disabled, config-errored, or
+	// pending at removal time has no oauthHandler, yet may still own a row.
+	TokenStore TokenDeleter
+}
+
+// TokenDeleter removes a persisted OAuth token by tool name.
+type TokenDeleter interface {
+	Delete(toolName string) error
 }
 
 // OAuthHandlerFactory creates an OAuthHandler and its corresponding
@@ -896,11 +907,15 @@ func (m *Manager) Execute(ctx context.Context, call llm.ToolCall) (string, error
 	return text, nil
 }
 
-// UnregisterServer stops the MCP server for the given config name,
-// removes its tools from the tool map, and closes the connection.
-// Returns an error if the server is not registered.
 // CleanupOAuthToken removes the OAuth token for a tool, if any.
 // Called during tool removal to avoid leaving orphaned tokens.
+//
+// A live OAuth connection clears through its handler, which also drops the
+// in-memory token source. Handlers exist only on live connections, though —
+// a tool that is disabled, config-errored, pending, or not registered at all
+// may still own a persisted row keyed by its name, so those fall through to
+// a direct store delete. Otherwise the row survives and a tool later created
+// with the same name silently adopts the stale token.
 func (m *Manager) CleanupOAuthToken(name string) {
 	m.mu.RLock()
 	sc, ok := m.servers[name]
@@ -909,6 +924,16 @@ func (m *Manager) CleanupOAuthToken(name string) {
 	if ok && sc.oauthHandler != nil {
 		if err := sc.oauthHandler.ClearToken(); err != nil {
 			m.logger.Warn("oauth: failed to clean up token on removal",
+				slog.String("tool", name),
+				slog.String("error", err.Error()))
+		} else {
+			return
+		}
+	}
+
+	if m.oauth != nil && m.oauth.TokenStore != nil {
+		if err := m.oauth.TokenStore.Delete(name); err != nil {
+			m.logger.Warn("oauth: failed to delete stored token on removal",
 				slog.String("tool", name),
 				slog.String("error", err.Error()))
 		}
@@ -938,6 +963,9 @@ func (m *Manager) ServerResolvedURL(name string) string {
 	return ""
 }
 
+// UnregisterServer stops the MCP server for the given config name,
+// removes its tools from the tool map, and closes the connection.
+// Returns an error if the server is not registered.
 func (m *Manager) UnregisterServer(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/tool/oauth_cleanup_test.go
+++ b/internal/tool/oauth_cleanup_test.go
@@ -1,0 +1,283 @@
+package tool
+
+// Tests for OAuth token cleanup across tool lifecycle transitions (issue #284):
+// tokens are keyed by tool name alone, so any removal path that skips cleanup
+// leaves a row that a later same-named tool would silently adopt.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/Temikus/denkeeper/internal/config"
+)
+
+// recordingTokenDeleter records store-level token deletions.
+type recordingTokenDeleter struct {
+	deleted []string
+	err     error
+}
+
+func (d *recordingTokenDeleter) Delete(toolName string) error {
+	d.deleted = append(d.deleted, toolName)
+	return d.err
+}
+
+// clearRecordingHandler is an oauthHandler that records ClearToken calls.
+type clearRecordingHandler struct {
+	fakeOAuthHandler
+	clearCalls int
+	clearErr   error
+}
+
+func (h *clearRecordingHandler) ClearToken() error {
+	h.clearCalls++
+	return h.clearErr
+}
+
+func newOAuthTestManager(deleter *recordingTokenDeleter) *Manager {
+	m := NewManager(testLogger())
+	m.SetOAuthSupport(&OAuthSupport{
+		HandlerFactory: func(name string, cfg config.ToolConfig, httpClient *http.Client) (oauthHandler, any, error) {
+			return &fakeOAuthHandler{}, nil, nil
+		},
+		CallbackURL: "http://localhost:8080/api/v1/tools/oauth/callback",
+		TokenStore:  deleter,
+	})
+	return m
+}
+
+func TestCleanupOAuthToken_LiveHandler_ClearsViaHandler(t *testing.T) {
+	deleter := &recordingTokenDeleter{}
+	m := newOAuthTestManager(deleter)
+	handler := &clearRecordingHandler{}
+	m.servers["fastmail"] = &serverConn{
+		name:         "fastmail",
+		transport:    "sse",
+		cfg:          config.ToolConfig{Auth: "oauth"},
+		oauthHandler: handler,
+	}
+
+	m.CleanupOAuthToken("fastmail")
+
+	if handler.clearCalls != 1 {
+		t.Errorf("ClearToken calls = %d, want 1", handler.clearCalls)
+	}
+	if len(deleter.deleted) != 0 {
+		t.Errorf("store deletions = %v, want none (handler already cleared)", deleter.deleted)
+	}
+}
+
+func TestCleanupOAuthToken_DisabledTool_DeletesFromStore(t *testing.T) {
+	// The issue #284 gap: RegisterDisabled builds a serverConn without an
+	// oauthHandler, so cleanup used to skip the persisted token entirely.
+	deleter := &recordingTokenDeleter{}
+	m := newOAuthTestManager(deleter)
+	m.RegisterDisabled("fastmail", config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+	}, "disabled by user", false)
+
+	m.CleanupOAuthToken("fastmail")
+
+	if !slices.Contains(deleter.deleted, "fastmail") {
+		t.Errorf("store deletions = %v, want fastmail", deleter.deleted)
+	}
+}
+
+func TestCleanupOAuthToken_UnregisteredName_DeletesFromStore(t *testing.T) {
+	deleter := &recordingTokenDeleter{}
+	m := newOAuthTestManager(deleter)
+
+	m.CleanupOAuthToken("ghost")
+
+	if !slices.Contains(deleter.deleted, "ghost") {
+		t.Errorf("store deletions = %v, want ghost", deleter.deleted)
+	}
+}
+
+func TestCleanupOAuthToken_HandlerError_FallsBackToStore(t *testing.T) {
+	deleter := &recordingTokenDeleter{}
+	m := newOAuthTestManager(deleter)
+	handler := &clearRecordingHandler{clearErr: errors.New("clear failed")}
+	m.servers["fastmail"] = &serverConn{
+		name:         "fastmail",
+		transport:    "sse",
+		cfg:          config.ToolConfig{Auth: "oauth"},
+		oauthHandler: handler,
+	}
+
+	m.CleanupOAuthToken("fastmail")
+
+	if handler.clearCalls != 1 {
+		t.Errorf("ClearToken calls = %d, want 1", handler.clearCalls)
+	}
+	if !slices.Contains(deleter.deleted, "fastmail") {
+		t.Errorf("store deletions = %v, want fastmail as fallback", deleter.deleted)
+	}
+}
+
+func TestCleanupOAuthToken_NoOAuthSupport_NoPanic(t *testing.T) {
+	m := NewManager(testLogger())
+	m.RegisterDisabled("fastmail", config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+	}, "disabled by user", false)
+
+	m.CleanupOAuthToken("fastmail")
+	m.CleanupOAuthToken("ghost")
+}
+
+// newOAuthLifecycleMgr builds a LifecycleManager whose Manager has OAuth
+// support with a recording token deleter and a tokenless handler factory
+// (so SSE OAuth registrations short-circuit to pending_auth, no network).
+func newOAuthLifecycleMgr(t *testing.T) (*LifecycleManager, *recordingTokenDeleter) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "denkeeper.toml")
+	seed := "[tools]\n[tools.fastmail]\ntransport = \"sse\"\nurl = \"https://mcp.example.com/mcp\"\nauth = \"oauth\"\n"
+	if err := os.WriteFile(cfgPath, []byte(seed), 0644); err != nil {
+		t.Fatal(err)
+	}
+	deleter := &recordingTokenDeleter{}
+	return NewLifecycleManager(newOAuthTestManager(deleter), cfgPath, 5, testLogger()), deleter
+}
+
+func TestRemoveTool_DisabledOAuthTool_DeletesStoredToken(t *testing.T) {
+	lm, deleter := newOAuthLifecycleMgr(t)
+	lm.toolMgr.RegisterDisabled("fastmail", config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+	}, "disabled by user", false)
+
+	if err := lm.RemoveTool(context.Background(), "fastmail"); err != nil {
+		t.Fatalf("RemoveTool: %v", err)
+	}
+
+	if !slices.Contains(deleter.deleted, "fastmail") {
+		t.Errorf("store deletions = %v, want fastmail", deleter.deleted)
+	}
+	if _, ok := lm.toolMgr.ServerInfo("fastmail"); ok {
+		t.Error("server still registered after RemoveTool")
+	}
+}
+
+func TestAddTool_PurgesOrphanedTokenBeforeRegister(t *testing.T) {
+	// A token row left behind by a deleted tool must not be adopted by a new
+	// tool created under the same name.
+	lm, deleter := newOAuthLifecycleMgr(t)
+
+	err := lm.AddTool(context.Background(), "fastmail", config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+	})
+	if err != nil {
+		t.Fatalf("AddTool: %v", err)
+	}
+
+	if !slices.Contains(deleter.deleted, "fastmail") {
+		t.Errorf("store deletions = %v, want fastmail purged before register", deleter.deleted)
+	}
+}
+
+func TestUpdateTool_OAuthIdentityChanged_DeletesToken(t *testing.T) {
+	lm, deleter := newOAuthLifecycleMgr(t)
+	lm.toolMgr.RegisterDisabled("fastmail", config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+	}, "disabled by user", false)
+
+	err := lm.UpdateTool(context.Background(), "fastmail", config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://other.example.com/mcp", // different server
+		Auth:      "oauth",
+	})
+	if err != nil {
+		t.Fatalf("UpdateTool: %v", err)
+	}
+
+	if !slices.Contains(deleter.deleted, "fastmail") {
+		t.Errorf("store deletions = %v, want fastmail (identity changed)", deleter.deleted)
+	}
+}
+
+func TestUpdateTool_OAuthIdentityUnchanged_KeepsToken(t *testing.T) {
+	lm, deleter := newOAuthLifecycleMgr(t)
+	cfg := config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+	}
+	lm.toolMgr.RegisterDisabled("fastmail", cfg, "disabled by user", false)
+
+	updated := cfg
+	updated.DisabledTools = []string{"noisy_tool"} // non-identity change
+	if err := lm.UpdateTool(context.Background(), "fastmail", updated); err != nil {
+		t.Fatalf("UpdateTool: %v", err)
+	}
+
+	if len(deleter.deleted) != 0 {
+		t.Errorf("store deletions = %v, want none (identity unchanged)", deleter.deleted)
+	}
+}
+
+func TestRemovePlugin_DeletesOrphanedToken(t *testing.T) {
+	lm, deleter := newOAuthLifecycleMgr(t)
+	lm.TrackPlugin("fastmail", config.PluginConfig{Type: "subprocess", Command: "/usr/bin/test"})
+
+	if err := lm.RemovePlugin(context.Background(), "fastmail"); err != nil {
+		t.Fatalf("RemovePlugin: %v", err)
+	}
+
+	if !slices.Contains(deleter.deleted, "fastmail") {
+		t.Errorf("store deletions = %v, want fastmail", deleter.deleted)
+	}
+}
+
+func TestOAuthIdentityChanged(t *testing.T) {
+	base := config.ToolConfig{
+		Transport: "sse",
+		URL:       "https://mcp.example.com/mcp",
+		Auth:      "oauth",
+		ClientID:  "id-1",
+		Scopes:    []string{"read"},
+	}
+
+	if oauthIdentityChanged(base, base) {
+		t.Error("identical configs reported as changed")
+	}
+
+	neither := config.ToolConfig{Transport: "stdio", Command: "/usr/bin/tool"}
+	if oauthIdentityChanged(neither, neither) {
+		t.Error("non-OAuth configs reported as changed")
+	}
+
+	mutations := map[string]func(c *config.ToolConfig){
+		"auth off":      func(c *config.ToolConfig) { c.Auth = "" },
+		"client id":     func(c *config.ToolConfig) { c.ClientID = "id-2" },
+		"client secret": func(c *config.ToolConfig) { c.ClientSecret = "hunter2" },
+		"url":           func(c *config.ToolConfig) { c.URL = "https://other.example.com/mcp" },
+		"scopes":        func(c *config.ToolConfig) { c.Scopes = []string{"read", "write"} },
+	}
+	for label, mutate := range mutations {
+		changed := base
+		mutate(&changed)
+		if !oauthIdentityChanged(base, changed) {
+			t.Errorf("%s: change not detected", label)
+		}
+	}
+
+	// Transition into OAuth purges rows orphaned by pre-cleanup versions.
+	if !oauthIdentityChanged(neither, base) {
+		t.Error("transition into OAuth not detected")
+	}
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2323,9 +2323,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -3104,9 +3104,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes #284.

## What changed

Deleting an OAuth MCP tool that was **disabled, config-errored, or pending** at delete time left its row in `oauth_tokens`: `Manager.CleanupOAuthToken` only cleared through the live `oauthHandler`, which exists solely on connected sessions. A tool later created with the same name silently adopted the stale token — skipping auth even when `client_id`/`token_url`/`scopes` differed. `UpdateTool` and `RemovePlugin` never called cleanup at all.

This PR resolves the ownership question the issue raised by giving the `Manager` store-level deletion: a new `TokenDeleter` interface on `OAuthSupport`, wired from `*oauth.TokenStore` in `cmd/denkeeper/oauth_init.go`. It's the same handler-first/store-fallback pattern the REST revoke endpoint (`handleToolOAuthRevoke`) already uses.

- **`CleanupOAuthToken`** (`internal/tool/manager.go`): clears via the live handler when present (also drops in-memory token state); otherwise — no handler, handler error, or no registration at all — deletes the row directly from the store.
- **`RemoveTool`**: now effective in every tool state (previously a no-op for disabled/config-error/pending tools).
- **`UpdateTool`** (`internal/tool/lifecycle.go`): discards the token when the OAuth identity changes (auth mode, `client_id`/`client_secret`, scopes, URL — new `oauthIdentityChanged` helper); unrelated edits keep the token so users aren't forced to re-auth.
- **`RemovePlugin`**: clears by name (plugins never use OAuth, so any row under a plugin's name is an orphan).
- **`AddTool`**: purges any leftover row before registering, so a new tool always starts unauthenticated. This also lazily cleans rows orphaned by older versions on name reuse.

## Deliberate non-changes

- `DisableTool`/`EnableTool` keep the token: disabling is temporary and re-enabling shouldn't force re-authorization.
- Tokens stay keyed by tool name. Re-keying by OAuth identity was considered but is unreliable for DCR flows, where the effective `client_id` isn't known until after the token exchange; airtight lifecycle cleanup plus the `AddTool` purge closes the adoption hole without a schema change.

## Testing

11 new tests in `internal/tool/oauth_cleanup_test.go`, including the issue's exact repro (disabled OAuth tool → `RemoveTool` → row deleted), store fallback for unregistered names and handler errors, `AddTool` purge, `UpdateTool` identity changed vs. unchanged, `RemovePlugin`, and the `oauthIdentityChanged` field matrix. The lifecycle tests exercise real `RegisterServer` calls with no network by riding the existing tokenless pending-auth short-circuit. `just check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)