### PR TITLE
fix(openrouter): follow frontend API move to /api/frontend/v1

### DIFF
--- a/internal/llm/openrouter/frontend_test.go
+++ b/internal/llm/openrouter/frontend_test.go
@@ -1,0 +1,204 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// frontendFindResponse mirrors the shape fetchFrontendData decodes.
+type frontendFindResponse struct {
+	Data struct {
+		Models    []frontendModel           `json:"models"`
+		Analytics map[string]analyticsEntry `json:"analytics"`
+	} `json:"data"`
+}
+
+// newFrontendStub serves a /models/find payload and records the paths it saw.
+func newFrontendStub(t *testing.T, status int, body *frontendFindResponse) (*httptest.Server, *[]string) {
+	t.Helper()
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			// OpenRouter serves an HTML app shell on a missing API path.
+			_, _ = w.Write([]byte("<!DOCTYPE html><html></html>"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(server.Close)
+	return server, &paths
+}
+
+// TestFrontendBaseURL_IsVersioned pins the versioned namespace. OpenRouter
+// moved /api/frontend → /api/frontend/v1 without announcement, which silently
+// zeroed every model's weekly_tokens and flattened popularity sorting.
+func TestFrontendBaseURL_IsVersioned(t *testing.T) {
+	if !strings.HasPrefix(frontendBaseURL, "https://openrouter.ai/api/frontend/") {
+		t.Fatalf("frontendBaseURL = %q, want an openrouter.ai/api/frontend/* URL", frontendBaseURL)
+	}
+	if !strings.HasSuffix(frontendBaseURL, "/v1") {
+		t.Errorf("frontendBaseURL = %q, want the versioned /v1 namespace; the unversioned path 404s", frontendBaseURL)
+	}
+}
+
+func TestFetchFrontendData_MapsAnalyticsByPermaslug(t *testing.T) {
+	var body frontendFindResponse
+	body.Data.Models = []frontendModel{
+		{Slug: "vendor/model-a", Permaslug: "vendor/model-a-20260101"},
+	}
+	body.Data.Analytics = map[string]analyticsEntry{
+		"vendor/model-a-20260101": {
+			ModelPermaslug:    "vendor/model-a-20260101",
+			Variant:           "standard",
+			TotalPromptTokens: 100, TotalCompletionTokens: 25,
+		},
+	}
+	server, paths := newFrontendStub(t, http.StatusOK, &body)
+
+	c := New("test-key")
+	c.frontendURL = server.URL
+
+	permaslugs, analytics := c.fetchFrontendData(context.Background())
+
+	if got := (*paths); len(got) != 1 || got[0] != "/models/find" {
+		t.Errorf("requested paths = %v, want [/models/find]", got)
+	}
+	if got := permaslugs["vendor/model-a"]; got != "vendor/model-a-20260101" {
+		t.Errorf("permaslug = %q, want vendor/model-a-20260101", got)
+	}
+	a, ok := analytics["vendor/model-a-20260101"]
+	if !ok {
+		t.Fatal("analytics missing entry for permaslug")
+	}
+	if total := a.TotalPromptTokens + a.TotalCompletionTokens; total != 125 {
+		t.Errorf("weekly tokens = %d, want 125", total)
+	}
+}
+
+// Variant IDs such as "model:free" come back from /api/v1/models but analytics
+// is keyed by the base permaslug, so variant forms must be pre-registered.
+func TestFetchFrontendData_RegistersVariantSlugs(t *testing.T) {
+	var body frontendFindResponse
+	body.Data.Models = []frontendModel{
+		{Slug: "vendor/model-a", Permaslug: "vendor/model-a-20260101"},
+	}
+	body.Data.Analytics = map[string]analyticsEntry{
+		"vendor/model-a-20260101": {Variant: "free", TotalPromptTokens: 10},
+		"vendor/model-b-20260101": {Variant: "standard", TotalPromptTokens: 5},
+	}
+	server, _ := newFrontendStub(t, http.StatusOK, &body)
+
+	c := New("test-key")
+	c.frontendURL = server.URL
+
+	permaslugs, _ := c.fetchFrontendData(context.Background())
+
+	if got := permaslugs["vendor/model-a:free"]; got != "vendor/model-a-20260101" {
+		t.Errorf("variant slug mapped to %q, want vendor/model-a-20260101", got)
+	}
+	// "standard" is the default variant and must not produce a ":standard" key.
+	if _, ok := permaslugs["vendor/model-a:standard"]; ok {
+		t.Error("standard variant should not be registered as a suffixed slug")
+	}
+}
+
+// A moved or removed endpoint must degrade gracefully — nil maps, no panic —
+// so model listing keeps working without popularity data.
+func TestFetchFrontendData_NotFoundReturnsEmpty(t *testing.T) {
+	server, _ := newFrontendStub(t, http.StatusNotFound, nil)
+
+	c := New("test-key")
+	c.frontendURL = server.URL
+
+	permaslugs, analytics := c.fetchFrontendData(context.Background())
+
+	if len(permaslugs) != 0 || len(analytics) != 0 {
+		t.Errorf("got permaslugs=%d analytics=%d, want both empty on 404", len(permaslugs), len(analytics))
+	}
+}
+
+// The frontend API is best-effort: when it is unreachable, model details must
+// still be returned, just without weekly token counts.
+func TestListModelDetails_SurvivesFrontendFailure(t *testing.T) {
+	models := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"vendor/model-a","name":"Model A",
+			"pricing":{"prompt":"0.000001","completion":"0.000002"},
+			"supported_parameters":["tools"]}]}`))
+	}))
+	defer models.Close()
+
+	frontend, _ := newFrontendStub(t, http.StatusNotFound, nil)
+
+	c := New("test-key")
+	c.baseURL = models.URL
+	c.frontendURL = frontend.URL
+
+	got, err := c.ListModelDetails(context.Background())
+	if err != nil {
+		t.Fatalf("ListModelDetails returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d models, want 1", len(got))
+	}
+	if got[0].ID != "vendor/model-a" || !got[0].SupportsTools {
+		t.Errorf("unexpected model: %+v", got[0])
+	}
+	if got[0].WeeklyTokens != 0 {
+		t.Errorf("WeeklyTokens = %d, want 0 when analytics unavailable", got[0].WeeklyTokens)
+	}
+}
+
+// End-to-end through ListModelDetails: analytics resolved via the permaslug
+// indirection must land on ModelInfo.WeeklyTokens, which drives the sort.
+func TestListModelDetails_PopulatesWeeklyTokens(t *testing.T) {
+	models := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"vendor/model-a","name":"Model A",
+			"pricing":{"prompt":"0.000001","completion":"0.000002"},
+			"supported_parameters":["tools"]}]}`))
+	}))
+	defer models.Close()
+
+	var body frontendFindResponse
+	body.Data.Models = []frontendModel{
+		{Slug: "vendor/model-a", Permaslug: "vendor/model-a-20260101"},
+	}
+	// Analytics is re-keyed by the model_permaslug *field*, not the JSON map
+	// key, and summed across variants — so both variants below aggregate.
+	body.Data.Analytics = map[string]analyticsEntry{
+		"vendor/model-a-20260101:standard": {
+			ModelPermaslug:    "vendor/model-a-20260101",
+			Variant:           "standard",
+			TotalPromptTokens: 900, TotalCompletionTokens: 50,
+		},
+		"vendor/model-a-20260101:free": {
+			ModelPermaslug:        "vendor/model-a-20260101",
+			Variant:               "free",
+			TotalCompletionTokens: 50,
+		},
+	}
+	frontend, _ := newFrontendStub(t, http.StatusOK, &body)
+
+	c := New("test-key")
+	c.baseURL = models.URL
+	c.frontendURL = frontend.URL
+
+	got, err := c.ListModelDetails(context.Background())
+	if err != nil {
+		t.Fatalf("ListModelDetails returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d models, want 1", len(got))
+	}
+	if got[0].WeeklyTokens != 1000 {
+		t.Errorf("WeeklyTokens = %d, want 1000", got[0].WeeklyTokens)
+	}
+}

--- a/internal/llm/openrouter/openrouter.go
+++ b/internal/llm/openrouter/openrouter.go
@@ -60,6 +60,16 @@ type Client struct {
 
 	detailsMu    sync.Mutex
 	detailsCache *modelDetailsCache
+
+	frontendURL string // injectable frontend API base for tests; empty → frontendBaseURL
+}
+
+// frontendBase returns the frontend API base, honoring an injected override.
+func (c *Client) frontendBase() string {
+	if c.frontendURL != "" {
+		return c.frontendURL
+	}
+	return frontendBaseURL
 }
 
 // clock returns the current time, honoring an injected clock for tests.
@@ -561,7 +571,12 @@ func (c *Client) fetchModelDetails(ctx context.Context) ([]llm.ModelInfo, error)
 	return models, nil
 }
 
-const frontendBaseURL = "https://openrouter.ai/api/frontend"
+// frontendBaseURL is OpenRouter's unofficial frontend API, the only public
+// source of per-model usage analytics. It is versioned and unannounced: the
+// namespace moved from /api/frontend to /api/frontend/v1 in 2026, which
+// silently zeroed popularity sorting until noticed. If popularity bars go
+// flat, check this path against what openrouter.ai/rankings calls.
+const frontendBaseURL = "https://openrouter.ai/api/frontend/v1"
 
 const frontendTimeout = 10 * time.Second
 
@@ -571,7 +586,9 @@ func (c *Client) fetchFrontendData(ctx context.Context) (permaslugs map[string]s
 	ctx, cancel := context.WithTimeout(ctx, frontendTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, frontendBaseURL+"/models/find", nil)
+	findURL := c.frontendBase() + "/models/find"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, findURL, nil)
 	if err != nil {
 		slog.Debug("openrouter: failed to build frontend request", "error", err)
 		return nil, nil
@@ -585,7 +602,10 @@ func (c *Client) fetchFrontendData(ctx context.Context) (permaslugs map[string]s
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		slog.Debug("openrouter: frontend API returned non-200", "status", resp.StatusCode)
+		// Warn, not Debug: a moved/removed endpoint degrades popularity
+		// sorting to zeros, which looks like working-but-empty data.
+		slog.Warn("openrouter: frontend API returned non-200, popularity data unavailable",
+			"status", resp.StatusCode, "url", findURL)
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Problem

The OpenRouter model popularity listing stopped working. OpenRouter moved their unofficial frontend API from `/api/frontend` to `/api/frontend/v1` without announcement — the old path now returns a 404 HTML app shell.

That endpoint is the only public source of per-model usage analytics, so `fetchFrontendData` bailed out and every model came back with `weekly_tokens: 0`. Popularity sorting degraded to an alphabetical no-op and the popularity bars in `ModelSelector.svelte` rendered empty.

The breakage was invisible because `fetchFrontendData` is best-effort by design: on any failure it logged at `Debug` and returned nil maps, so the listing kept working — just with all-zero data.

## Changes

- **Point `frontendBaseURL` at the versioned namespace**, with a comment recording that this path is unversioned-and-unannounced upstream and how to re-derive it (whatever `openrouter.ai/rankings` calls).
- **Raise the non-200 log from `Debug` to `Warn`**, including status and URL, so the next silent move surfaces in logs rather than as quietly-flat bars.
- **Make the frontend base injectable** (`frontendURL`, empty → const default, following the existing `now` clock idiom) and **add tests for a path that previously had none**:
  - `TestFrontendBaseURL_IsVersioned` — pins the versioned namespace
  - `TestFetchFrontendData_MapsAnalyticsByPermaslug` — the slug → permaslug → analytics indirection
  - `TestFetchFrontendData_RegistersVariantSlugs` — `model:free` variant resolution; `standard` must not be suffixed
  - `TestFetchFrontendData_NotFoundReturnsEmpty` — graceful degradation on a moved endpoint
  - `TestListModelDetails_SurvivesFrontendFailure` / `_PopulatesWeeklyTokens` — end-to-end, with and without analytics

The response shape is unchanged (`data.models[].slug/permaslug` + `data.analytics`), so no parsing changes were needed.

## Verification

Ran the real `fetchFrontendData` against the live API: 3332 permaslug mappings, 443 analytics entries, and known models resolve to non-zero weekly totals — `google/gemini-2.5-flash` 540B, `anthropic/claude-sonnet-4.5` 84B, `openai/gpt-5` 18B. `just hook` passes clean (fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check).

## Notes

- The new tests cannot catch a future **URL move** — only a live-network test could, and that's a flaky CI dependency. They do pin the current namespace and lock in the graceful-degradation and Warn behavior. A `-tags=live` smoke test on a schedule would close the remaining gap if that's wanted.
- Takes effect on deploy; the 5-minute `modelDetailsTTL` cache means popularity data repopulates on the first fetch after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWuyCtVbCZMGhu4CKWneeV