### PR TITLE
feat(audit): multi-select Type and Status filters in the Audit Log

### DIFF
--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -14,9 +14,9 @@ import (
 // @Tags audit
 // @Produce json
 // @Security BearerAuth
-// @Param category query string false "Filter by event category (e.g. tool_call, skill, channel, approval)"
+// @Param category query string false "Filter by event category (e.g. tool_call, skill, channel, approval). Comma-separated or repeated for a union of several categories."
 // @Param agent query string false "Filter by agent name"
-// @Param status query string false "Filter by status (ok, error, pending, denied)"
+// @Param status query string false "Filter by status (ok, error, pending, denied). Comma-separated or repeated for a union of several statuses."
 // @Param source query string false "Filter by event source"
 // @Param search query string false "Free-text search across event fields"
 // @Param since query string false "Start of time range (RFC3339 format)"
@@ -36,11 +36,11 @@ func (s *Server) handleListAudit(w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 	opts := audit.ListOpts{
-		Category: q.Get("category"),
-		Agent:    q.Get("agent"),
-		Status:   q.Get("status"),
-		Source:   q.Get("source"),
-		Search:   q.Get("search"),
+		Categories: audit.ParseFilterList(q["category"]...),
+		Agent:      q.Get("agent"),
+		Statuses:   audit.ParseFilterList(q["status"]...),
+		Source:     q.Get("source"),
+		Search:     q.Get("search"),
 	}
 
 	if v := q.Get("since"); v != "" {

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -753,7 +753,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Filter by event category (e.g. tool_call, skill, channel, approval)",
+                        "description": "Filter by event category (e.g. tool_call, skill, channel, approval). Comma-separated or repeated for a union of several categories.",
                         "name": "category",
                         "in": "query"
                     },
@@ -765,7 +765,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filter by status (ok, error, pending, denied)",
+                        "description": "Filter by status (ok, error, pending, denied). Comma-separated or repeated for a union of several statuses.",
                         "name": "status",
                         "in": "query"
                     },

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -3,8 +3,34 @@ package audit
 
 import (
 	"context"
+	"strings"
 	"time"
 )
+
+// ParseFilterList normalizes multi-valued filter input into the union form
+// ListOpts.Categories / ListOpts.Statuses expect. Each input may itself be
+// comma-separated, so both `?category=llm,tool_call` and the repeated
+// `?category=llm&category=tool_call` spelling arrive here as the same set.
+// Blanks are dropped and duplicates collapsed, so a lone "" (the dashboard's
+// "All" chip) yields nil — i.e. no filter.
+func ParseFilterList(values ...string) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if _, dup := seen[part]; dup {
+				continue
+			}
+			seen[part] = struct{}{}
+			out = append(out, part)
+		}
+	}
+	return out
+}
 
 // Event categories.
 const (
@@ -45,16 +71,19 @@ type Event struct {
 }
 
 // ListOpts controls filtering and pagination for audit event queries.
+//
+// Categories and Statuses are unions: an event matches when it carries any one
+// of the listed values. Empty (or nil) means "no filter on this field".
 type ListOpts struct {
-	Category string
-	Agent    string
-	Status   string
-	Source   string
-	Search   string
-	Since    *time.Time
-	Until    *time.Time
-	Limit    int
-	Offset   int
+	Categories []string
+	Agent      string
+	Statuses   []string
+	Source     string
+	Search     string
+	Since      *time.Time
+	Until      *time.Time
+	Limit      int
+	Offset     int
 }
 
 // Stats holds aggregate counts for the audit log dashboard.

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,44 @@
+package audit
+
+import "testing"
+
+func TestParseFilterList_SplitsCommas(t *testing.T) {
+	got := ParseFilterList("tool_call,llm,approval")
+	want := []string{"tool_call", "llm", "approval"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d values, got %v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("value %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestParseFilterList_MergesRepeatedParams(t *testing.T) {
+	got := ParseFilterList("llm", "tool_call,llm")
+	if len(got) != 2 {
+		t.Fatalf("expected duplicates collapsed to 2 values, got %v", got)
+	}
+	if got[0] != "llm" || got[1] != "tool_call" {
+		t.Errorf("expected first-seen order [llm tool_call], got %v", got)
+	}
+}
+
+func TestParseFilterList_BlanksYieldNoFilter(t *testing.T) {
+	for _, in := range []string{"", " ", ",", " , "} {
+		if got := ParseFilterList(in); got != nil {
+			t.Errorf("ParseFilterList(%q): expected nil, got %v", in, got)
+		}
+	}
+	if got := ParseFilterList(); got != nil {
+		t.Errorf("ParseFilterList(): expected nil, got %v", got)
+	}
+}
+
+func TestParseFilterList_TrimsWhitespace(t *testing.T) {
+	got := ParseFilterList(" tool_call , llm ")
+	if len(got) != 2 || got[0] != "tool_call" || got[1] != "llm" {
+		t.Errorf("expected [tool_call llm], got %v", got)
+	}
+}

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -144,22 +144,37 @@ func (s *SQLiteStore) InsertBatch(ctx context.Context, events []Event) error {
 	return nil
 }
 
+// inClause renders a set-membership condition for col, or ("", nil) when vals
+// is empty so the caller can drop the filter entirely. The placeholders are
+// generated from len(vals) — the values themselves are always bound, never
+// interpolated.
+func inClause(col string, vals []string) (string, []any) {
+	if len(vals) == 0 {
+		return "", nil
+	}
+	args := make([]any, len(vals))
+	for i, v := range vals {
+		args[i] = v
+	}
+	return col + " IN (?" + strings.Repeat(",?", len(vals)-1) + ")", args
+}
+
 // buildWhereClause constructs WHERE conditions from ListOpts.
 func buildWhereClause(opts ListOpts) (string, []any) {
 	var where []string
 	var args []any
 
-	if opts.Category != "" {
-		where = append(where, "category = ?")
-		args = append(args, opts.Category)
+	if cond, vals := inClause("category", opts.Categories); cond != "" {
+		where = append(where, cond)
+		args = append(args, vals...)
 	}
 	if opts.Agent != "" {
 		where = append(where, "agent = ?")
 		args = append(args, opts.Agent)
 	}
-	if opts.Status != "" {
-		where = append(where, "status = ?")
-		args = append(args, opts.Status)
+	if cond, vals := inClause("status", opts.Statuses); cond != "" {
+		where = append(where, cond)
+		args = append(args, vals...)
 	}
 	if opts.Source != "" {
 		where = append(where, "source = ?")

--- a/internal/audit/store_test.go
+++ b/internal/audit/store_test.go
@@ -94,7 +94,7 @@ func TestListFilterByCategory(t *testing.T) {
 	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryLLM, Action: "complete", Summary: "llm", Status: StatusOK})
 	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "tool2", Status: StatusError})
 
-	events, total, err := store.List(ctx, ListOpts{Category: CategoryToolCall})
+	events, total, err := store.List(ctx, ListOpts{Categories: []string{CategoryToolCall}})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestListFilterByStatus(t *testing.T) {
 	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "ok", Status: StatusOK})
 	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "err", Status: StatusError})
 
-	events, total, err := store.List(ctx, ListOpts{Status: StatusError})
+	events, total, err := store.List(ctx, ListOpts{Statuses: []string{StatusError}})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -128,6 +128,82 @@ func TestListFilterByStatus(t *testing.T) {
 	}
 	if events[0].Summary != "err" {
 		t.Errorf("unexpected summary: %q", events[0].Summary)
+	}
+}
+
+func TestListFilterByMultipleCategories(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "tool", Status: StatusOK})
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryLLM, Action: "complete", Summary: "llm", Status: StatusOK})
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryApproval, Action: "approve", Summary: "approval", Status: StatusOK})
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategorySkill, Action: "match", Summary: "skill", Status: StatusOK})
+
+	events, total, err := store.List(ctx, ListOpts{Categories: []string{CategoryToolCall, CategoryLLM, CategoryApproval}})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("expected total=3, got %d", total)
+	}
+	for _, ev := range events {
+		if ev.Category == CategorySkill {
+			t.Errorf("skill event leaked into a tool_call/llm/approval filter")
+		}
+	}
+}
+
+func TestListFilterByMultipleStatuses(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "ok", Status: StatusOK})
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "err", Status: StatusError})
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "denied", Status: StatusDenied})
+
+	_, total, err := store.List(ctx, ListOpts{Statuses: []string{StatusError, StatusDenied}})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total=2, got %d", total)
+	}
+}
+
+// An empty slice must behave like the "All" chip: no condition at all, not an
+// IN () that matches nothing.
+func TestListFilterEmptySlicesMatchEverything(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryToolCall, Action: "execute", Summary: "tool", Status: StatusOK})
+	_ = store.Insert(ctx, Event{Timestamp: now, Category: CategoryLLM, Action: "complete", Summary: "llm", Status: StatusError})
+
+	_, total, err := store.List(ctx, ListOpts{Categories: []string{}, Statuses: []string{}})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total=2, got %d", total)
 	}
 }
 

--- a/internal/integration/approval_test.go
+++ b/internal/integration/approval_test.go
@@ -180,7 +180,7 @@ func TestApproval_ResolveViaAPI_DoesNotNotifyAdapter(t *testing.T) {
 	// Audit log must still record both resolutions so operators have a record
 	// of the API-driven decision even though no adapter message was emitted.
 	h.FlushAudit(t)
-	events, _, err := h.AuditStore.List(context.Background(), audit.ListOpts{Category: audit.CategoryApproval})
+	events, _, err := h.AuditStore.List(context.Background(), audit.ListOpts{Categories: []string{audit.CategoryApproval}})
 	if err != nil {
 		t.Fatalf("listing audit events: %v", err)
 	}

--- a/internal/integration/audit_test.go
+++ b/internal/integration/audit_test.go
@@ -113,6 +113,82 @@ func TestAudit_FilterByStatus(t *testing.T) {
 	}
 }
 
+// The dashboard's multi-select Type/Status chips send a comma-separated list;
+// repeating the param is accepted too, so a hand-built URL works either way.
+func TestAudit_FilterByMultipleCategories(t *testing.T) {
+	h := NewHarness(t, nil)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryToolCall, Action: "execute", Summary: "tool", Status: audit.StatusOK})
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryLLM, Action: "complete", Summary: "llm", Status: audit.StatusOK})
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryApproval, Action: "approve", Summary: "approval", Status: audit.StatusOK})
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategorySkill, Action: "match", Summary: "skill", Status: audit.StatusOK})
+
+	for _, query := range []string{
+		"/api/v1/audit?category=tool_call,llm,approval",
+		"/api/v1/audit?category=tool_call&category=llm,approval",
+	} {
+		rec := h.Do(h.AuthedRequest(http.MethodGet, query, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d", query, rec.Code)
+		}
+
+		var resp audit.ListResult
+		DecodeJSON(t, rec, &resp)
+		if resp.Total != 3 {
+			t.Errorf("%s: expected total=3, got %d", query, resp.Total)
+		}
+		for _, ev := range resp.Events {
+			if ev.Category == audit.CategorySkill {
+				t.Errorf("%s: skill event leaked through the category union", query)
+			}
+		}
+	}
+}
+
+func TestAudit_FilterByMultipleStatuses(t *testing.T) {
+	h := NewHarness(t, nil)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryToolCall, Action: "execute", Summary: "ok", Status: audit.StatusOK})
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryToolCall, Action: "execute", Summary: "err", Status: audit.StatusError})
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryToolCall, Action: "execute", Summary: "denied", Status: audit.StatusDenied})
+
+	rec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/audit?status=error,denied", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+
+	var resp audit.ListResult
+	DecodeJSON(t, rec, &resp)
+	if resp.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Total)
+	}
+}
+
+// An empty filter param is the "All" chip, not a filter that matches nothing.
+func TestAudit_EmptyFilterParamsMatchEverything(t *testing.T) {
+	h := NewHarness(t, nil)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryToolCall, Action: "execute", Summary: "tool", Status: audit.StatusOK})
+	_ = h.AuditStore.Insert(ctx, audit.Event{Timestamp: now, Category: audit.CategoryLLM, Action: "complete", Summary: "llm", Status: audit.StatusError})
+
+	rec := h.Do(h.AuthedRequest(http.MethodGet, "/api/v1/audit?category=&status=", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+
+	var resp audit.ListResult
+	DecodeJSON(t, rec, &resp)
+	if resp.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Total)
+	}
+}
+
 func TestAudit_Pagination(t *testing.T) {
 	h := NewHarness(t, nil)
 	ctx := context.Background()

--- a/internal/integration/schedule_api_test.go
+++ b/internal/integration/schedule_api_test.go
@@ -327,7 +327,7 @@ func TestScheduleAPI_BroadcastAuditOnPartialFailure(t *testing.T) {
 	h.FlushAudit(t)
 
 	events, _, err := h.AuditStore.List(context.Background(), audit.ListOpts{
-		Category: audit.CategorySchedule,
+		Categories: []string{audit.CategorySchedule},
 	})
 	if err != nil {
 		t.Fatalf("listing audit events: %v", err)

--- a/internal/mcpserver/tools_audit.go
+++ b/internal/mcpserver/tools_audit.go
@@ -9,9 +9,9 @@ import (
 )
 
 type auditEventsInput struct {
-	Category string `json:"category,omitempty" jsonschema:"Filter by category (tool_call, skill, channel, approval, schedule, llm, config, session, mcp, safety, supervisor)"`
+	Category string `json:"category,omitempty" jsonschema:"Filter by category (tool_call, skill, channel, approval, schedule, llm, config, session, mcp, safety, supervisor); comma-separated for several"`
 	Agent    string `json:"agent,omitempty" jsonschema:"Filter by agent name"`
-	Status   string `json:"status,omitempty" jsonschema:"Filter by status (ok, error, pending, denied)"`
+	Status   string `json:"status,omitempty" jsonschema:"Filter by status (ok, error, pending, denied); comma-separated for several"`
 	Source   string `json:"source,omitempty" jsonschema:"Filter by event source"`
 	Search   string `json:"search,omitempty" jsonschema:"Free-text search across event summaries"`
 	Since    string `json:"since,omitempty" jsonschema:"Start of time range (RFC 3339)"`
@@ -28,8 +28,9 @@ func (s *Server) registerAuditTools() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
 		Name: "audit_events",
 		Description: "List audit log events with optional filtering by category, agent, status, " +
-			"source, free-text search, and time range. Supports pagination (default limit 50, max 200). " +
-			"Requires 'audit:read' scope.",
+			"source, free-text search, and time range. 'category' and 'status' accept a " +
+			"comma-separated list and match any of the given values. " +
+			"Supports pagination (default limit 50, max 200). Requires 'audit:read' scope.",
 	}, s.handleAuditEvents)
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
@@ -49,13 +50,13 @@ func (s *Server) handleAuditEvents(ctx context.Context, _ *mcp.CallToolRequest, 
 	}
 
 	opts := audit.ListOpts{
-		Category: input.Category,
-		Agent:    input.Agent,
-		Status:   input.Status,
-		Source:   input.Source,
-		Search:   input.Search,
-		Limit:    input.Limit,
-		Offset:   input.Offset,
+		Categories: audit.ParseFilterList(input.Category),
+		Agent:      input.Agent,
+		Statuses:   audit.ParseFilterList(input.Status),
+		Source:     input.Source,
+		Search:     input.Search,
+		Limit:      input.Limit,
+		Offset:     input.Offset,
 	}
 	if input.Since != "" {
 		t, err := time.Parse(time.RFC3339, input.Since)

--- a/internal/mcpserver/tools_audit_test.go
+++ b/internal/mcpserver/tools_audit_test.go
@@ -63,6 +63,31 @@ func TestAuditEvents_ListsAndFilters(t *testing.T) {
 	}
 }
 
+func TestAuditEvents_CommaSeparatedFilters(t *testing.T) {
+	s := auditServer(t,
+		audit.Event{Timestamp: time.Now().UTC(), Category: audit.CategoryToolCall, Agent: "a", Status: audit.StatusOK, Summary: "ran tool"},
+		audit.Event{Timestamp: time.Now().UTC(), Category: audit.CategorySkill, Agent: "b", Status: audit.StatusError, Summary: "skill failed"},
+		audit.Event{Timestamp: time.Now().UTC(), Category: audit.CategoryLLM, Agent: "c", Status: audit.StatusOK, Summary: "completed"},
+		audit.Event{Timestamp: time.Now().UTC(), Category: audit.CategoryConfig, Agent: "d", Status: audit.StatusOK, Summary: "config changed"},
+	)
+
+	res, _, _ := s.handleAuditEvents(auditReadCtx(), nil, auditEventsInput{
+		Category: audit.CategoryToolCall + "," + audit.CategoryLLM,
+	})
+	var filtered audit.ListResult
+	if err := json.Unmarshal([]byte(toolResultText(res)), &filtered); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if filtered.Total != 2 {
+		t.Fatalf("expected 2 events for a two-category filter, got %+v", filtered)
+	}
+	for _, e := range filtered.Events {
+		if e.Category != audit.CategoryToolCall && e.Category != audit.CategoryLLM {
+			t.Errorf("unexpected category %q in the union", e.Category)
+		}
+	}
+}
+
 func TestAuditEvents_RequiresScope(t *testing.T) {
 	s := auditServer(t)
 	res, _, _ := s.handleAuditEvents(context.Background(), nil, auditEventsInput{})

--- a/web/src/__tests__/pages/AuditLog.test.js
+++ b/web/src/__tests__/pages/AuditLog.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/svelte'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/svelte'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../test/server.js'
 import { token, authMode } from '../../store.js'
@@ -164,38 +164,126 @@ describe('AuditLog page', () => {
     await waitFor(() => {
       expect(screen.getByText('Audit log')).toBeInTheDocument()
     })
-    const toolsChip = screen.getByRole('radio', { name: 'Tools' })
+    const toolsChip = screen.getByRole('button', { name: 'Tools' })
     expect(toolsChip).toBeInTheDocument()
     await fireEvent.click(toolsChip)
-    expect(toolsChip.getAttribute('aria-checked')).toBe('true')
+    expect(toolsChip.getAttribute('aria-pressed')).toBe('true')
   })
 
-  test('each chip bar is a single tab stop with arrow-key navigation', async () => {
+  test('Type and Status chips select several values at once', async () => {
+    let lastUrl = ''
+    server.use(
+      http.get('/api/v1/audit', ({ request }) => {
+        lastUrl = request.url
+        return HttpResponse.json({ events: [], total: 0 })
+      }),
+    )
+    render(AuditLog)
+    await waitFor(() => expect(lastUrl).not.toBe(''))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'LLM' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'Approvals' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'Error' }))
+
+    await waitFor(() => {
+      const params = new URL(lastUrl).searchParams
+      expect(params.get('category')).toBe('tool_call,llm,approval')
+      expect(params.get('status')).toBe('error')
+    })
+    expect(screen.getByRole('button', { name: 'LLM' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('deselecting a Type chip narrows the union back down', async () => {
+    let lastUrl = ''
+    server.use(
+      http.get('/api/v1/audit', ({ request }) => {
+        lastUrl = request.url
+        return HttpResponse.json({ events: [], total: 0 })
+      }),
+    )
+    render(AuditLog)
+    await waitFor(() => expect(lastUrl).not.toBe(''))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'LLM' }))
+    await waitFor(() => {
+      expect(new URL(lastUrl).searchParams.get('category')).toBe('tool_call,llm')
+    })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    await waitFor(() => {
+      expect(new URL(lastUrl).searchParams.get('category')).toBe('llm')
+    })
+  })
+
+  test('the All chip clears a multi-selection and sends no filter', async () => {
+    let lastUrl = ''
+    server.use(
+      http.get('/api/v1/audit', ({ request }) => {
+        lastUrl = request.url
+        return HttpResponse.json({ events: [], total: 0 })
+      }),
+    )
+    render(AuditLog)
+    await waitFor(() => expect(lastUrl).not.toBe(''))
+
+    const typeBar = screen.getByRole('toolbar', { name: 'Category filter' })
+    await fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'LLM' }))
+    await waitFor(() => {
+      expect(new URL(lastUrl).searchParams.get('category')).toBe('tool_call,llm')
+    })
+
+    // "All" is the clear-all chip; an empty selection must drop the param
+    // rather than send `category=`, which would match nothing server-side.
+    await fireEvent.click(within(typeBar).getByRole('button', { name: 'All' }))
+    await waitFor(() => {
+      expect(new URL(lastUrl).searchParams.has('category')).toBe(false)
+    })
+    expect(within(typeBar).getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('the range bar is a single tab stop with arrow-key selection', async () => {
     render(AuditLog)
     await waitFor(() => {
       expect(screen.getByText('Audit log')).toBeInTheDocument()
     })
 
-    const group = screen.getByRole('radiogroup', { name: 'Category filter' })
+    const group = screen.getByRole('radiogroup', { name: 'Time range' })
     const chips = [...group.querySelectorAll('[role="radio"]')]
-    // "All" is selected on load, so it owns the group's single tab stop.
-    expect(chips[0]).toHaveAttribute('tabindex', '0')
-    expect(chips.slice(1).every(c => c.getAttribute('tabindex') === '-1')).toBe(true)
-
-    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
-    await waitFor(() => {
-      expect(chips[1]).toHaveAttribute('aria-checked', 'true')
-    })
+    // "24h" is selected on load, so it owns the group's single tab stop.
     expect(chips[1]).toHaveAttribute('tabindex', '0')
-    expect(chips[0]).toHaveAttribute('tabindex', '-1')
+    expect(chips.filter((_, i) => i !== 1).every(c => c.getAttribute('tabindex') === '-1')).toBe(true)
 
-    await fireEvent.keyDown(chips[1], { key: 'Home' })
+    await fireEvent.keyDown(chips[1], { key: 'ArrowRight' })
+    await waitFor(() => {
+      expect(chips[2]).toHaveAttribute('aria-checked', 'true')
+    })
+    expect(chips[2]).toHaveAttribute('tabindex', '0')
+    expect(chips[1]).toHaveAttribute('tabindex', '-1')
+
+    await fireEvent.keyDown(chips[2], { key: 'Home' })
     await waitFor(() => {
       expect(chips[0]).toHaveAttribute('aria-checked', 'true')
     })
   })
 
-  test('arrow-keying across chips coalesces into a single refetch', async () => {
+  test('arrows move focus across Type chips without selecting', async () => {
+    render(AuditLog)
+    await waitFor(() => {
+      expect(screen.getByText('Audit log')).toBeInTheDocument()
+    })
+
+    const group = screen.getByRole('toolbar', { name: 'Category filter' })
+    const chips = [...group.querySelectorAll('.chip')]
+    chips[0].focus()
+    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(chips[1])
+    expect(chips[1]).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('rapid chip toggling coalesces into a single refetch', async () => {
     let calls = 0
     server.use(
       http.get('/api/v1/audit', () => {
@@ -206,25 +294,25 @@ describe('AuditLog page', () => {
     render(AuditLog)
     await waitFor(() => expect(calls).toBe(1))
 
-    const group = screen.getByRole('radiogroup', { name: 'Category filter' })
-    const chips = [...group.querySelectorAll('[role="radio"]')]
-    await fireEvent.keyDown(chips[0], { key: 'ArrowRight' })
-    await fireEvent.keyDown(chips[1], { key: 'ArrowRight' })
-    await fireEvent.keyDown(chips[2], { key: 'ArrowRight' })
+    const group = screen.getByRole('toolbar', { name: 'Category filter' })
+    const chips = [...group.querySelectorAll('.chip')]
+    await fireEvent.click(chips[1])
+    await fireEvent.click(chips[2])
+    await fireEvent.click(chips[3])
 
-    // Selection follows focus, so all three chips changed the filter; the
-    // page must not fire one request per keypress.
-    expect(chips[3]).toHaveAttribute('aria-checked', 'true')
+    // Three filter changes in quick succession; the page must not fire one
+    // request per click.
+    expect(chips[3]).toHaveAttribute('aria-pressed', 'true')
     await waitFor(() => expect(calls).toBeGreaterThan(1))
     expect(calls).toBeLessThanOrEqual(2)
   })
 
-  test('status and range chip bars are labelled radiogroups', async () => {
+  test('the status bar is a labelled toolbar and the range bar a radiogroup', async () => {
     render(AuditLog)
     await waitFor(() => {
       expect(screen.getByText('Audit log')).toBeInTheDocument()
     })
-    expect(screen.getByRole('radiogroup', { name: 'Status filter' })).toBeInTheDocument()
+    expect(screen.getByRole('toolbar', { name: 'Status filter' })).toBeInTheDocument()
     expect(screen.getByRole('radiogroup', { name: 'Time range' })).toBeInTheDocument()
   })
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -370,8 +370,15 @@ export const api = {
   sessionCheck: () => fetch('/auth/session').then(r => r.json()),
 
   // Audit Log
+  // Array values (category, status) go out comma-separated, which the API reads
+  // as a union. An empty array is truthy, so it has to be dropped explicitly or
+  // it would serialize as a `category=` that matches nothing.
   auditEvents: (params = {}) => {
-    const filtered = Object.fromEntries(Object.entries(params).filter(([, v]) => v))
+    const filtered = Object.fromEntries(
+      Object.entries(params)
+        .map(([k, v]) => [k, Array.isArray(v) ? v.join(',') : v])
+        .filter(([, v]) => v),
+    )
     return apiFetch(`/api/v1/audit?${new URLSearchParams(filtered)}`)
   },
   auditStats: (since) => apiFetch(`/api/v1/audit/stats${since ? `?since=${encodeURIComponent(since)}` : ''}`),

--- a/web/src/components/FilterChips.svelte
+++ b/web/src/components/FilterChips.svelte
@@ -1,12 +1,25 @@
 <script>
   /**
-   * Accessible filter chip bar.
+   * Accessible filter chip bar, single- or multi-select.
    *
-   * Renders an ARIA radiogroup and implements the keyboard contract that role
-   * advertises: the whole group is a single tab stop (roving tabindex) and
-   * Arrow / Home / End move the selection between chips. Styling lives in
-   * shared.css (.filter-chips / .chip / .chip-dot) so every chip bar in the
-   * dashboard looks and behaves the same.
+   * Single select (default) renders an ARIA radiogroup and implements the
+   * keyboard contract that role advertises: the whole group is a single tab
+   * stop (roving tabindex) and Arrow / Home / End move the selection.
+   *
+   * With `multiple`, `value` is an array and the bar becomes a toolbar of
+   * aria-pressed toggle buttons — the role ARIA pairs with roving tabindex and
+   * with toggles, so the single-tab-stop contract stays conformant. Arrows move
+   * focus *without* selecting; Enter/Space toggle natively (these are real
+   * <button>s, so the browser fires click — handleKeydown deliberately doesn't
+   * intercept them). `onselect` still fires once per interaction, but carries
+   * the next array.
+   *
+   * The `''` item is the clear-all chip ("All"): choosing it emits `[]`, and it
+   * renders active whenever nothing is selected — so a caller's item list is
+   * identical in both modes.
+   *
+   * Styling lives in shared.css (.filter-chips / .chip / .chip-dot /
+   * .chip-mark) so every chip bar in the dashboard looks and behaves the same.
    *
    * items: [{ value, label, dot?, testid? }]
    */
@@ -15,23 +28,60 @@
     value = '',
     label = '',
     size = '',
+    multiple = false,
     testid = undefined,
     onselect = () => {},
   } = $props()
 
   let buttons = $state([])
 
-  // The chip that owns the group's tab stop: the selected one, or the first
-  // chip when nothing matches the current value.
+  // Multi-select tolerates a stale scalar `value` (e.g. a caller mid-migration)
+  // rather than throwing on `.includes`.
+  let selected = $derived(
+    multiple ? (Array.isArray(value) ? value : (value ? [value] : [])) : [],
+  )
+
+  function isActive(itemValue) {
+    if (!multiple) return value === itemValue
+    if (itemValue === '') return selected.length === 0
+    return selected.includes(itemValue)
+  }
+
+  // The chip that owns the group's tab stop: the first selected one, or the
+  // first chip when nothing matches. In multi-select, arrows move focus without
+  // selecting, so the tab stop has to follow the last-focused chip instead —
+  // otherwise tabbing away and back would snap focus back to the selection.
+  let focusedIndex = $state(null)
   let activeIndex = $derived.by(() => {
-    const i = items.findIndex((it) => it.value === value)
+    if (multiple && focusedIndex !== null && focusedIndex < items.length) return focusedIndex
+    const i = items.findIndex((it) => isActive(it.value))
     return i >= 0 ? i : 0
   })
+
+  function choose(itemValue) {
+    if (!multiple) {
+      onselect(itemValue)
+      return
+    }
+    // The clear-all chip resets rather than joining the set.
+    if (itemValue === '') {
+      onselect([])
+      return
+    }
+    onselect(
+      selected.includes(itemValue)
+        ? selected.filter((v) => v !== itemValue)
+        : [...selected, itemValue],
+    )
+  }
 
   function move(index) {
     const item = items[index]
     if (!item) return
-    onselect(item.value)
+    // Toggles are pressed deliberately, so arrows only move focus; radios
+    // select on arrow, which is the pattern that role prescribes.
+    if (multiple) focusedIndex = index
+    else onselect(item.value)
     buttons[index]?.focus()
   }
 
@@ -63,13 +113,14 @@
   }
 </script>
 
-<!-- The group is deliberately not focusable: the radios carry the roving
-     tabindex, and the keydown handler sees their events by bubbling. -->
+<!-- The container is deliberately not focusable: the chips carry the roving
+     tabindex, and the keydown handler sees their events by bubbling. (The
+     a11y suppression is for the radiogroup case; toolbar is fine unfocused.) -->
 <!-- svelte-ignore a11y_interactive_supports_focus -->
 <div
   class="filter-chips"
   class:filter-chips-sm={size === 'sm'}
-  role="radiogroup"
+  role={multiple ? 'toolbar' : 'radiogroup'}
   aria-label={label}
   data-testid={testid}
   onkeydown={handleKeydown}
@@ -77,13 +128,14 @@
   {#each items as item, i (item.value)}
     <button
       class="chip"
-      class:active={value === item.value}
-      role="radio"
-      aria-checked={value === item.value}
+      class:active={isActive(item.value)}
+      role={multiple ? undefined : 'radio'}
+      aria-checked={multiple ? undefined : isActive(item.value)}
+      aria-pressed={multiple ? isActive(item.value) : undefined}
       tabindex={i === activeIndex ? 0 : -1}
       data-testid={item.testid}
       bind:this={buttons[i]}
-      onclick={() => onselect(item.value)}
-    >{#if item.dot}<span class="chip-dot" style="background: {item.dot}"></span>{/if}{item.label}</button>
+      onclick={() => choose(item.value)}
+    >{#if multiple}<span class="chip-mark"></span>{:else if item.dot}<span class="chip-dot" style="background: {item.dot}"></span>{/if}{item.label}</button>
   {/each}
 </div>

--- a/web/src/components/__tests__/FilterChips.test.js
+++ b/web/src/components/__tests__/FilterChips.test.js
@@ -130,3 +130,85 @@ describe('FilterChips', () => {
     expect(onselect).not.toHaveBeenCalled()
   })
 })
+
+describe('FilterChips (multiple)', () => {
+  function setupMulti(props = {}) {
+    return setup({ multiple: true, value: [], ...props })
+  }
+  const chipsOf = (container) => [...container.querySelectorAll('.chip')]
+
+  test('renders a labelled toolbar of toggle buttons instead of radios', () => {
+    const { container } = setupMulti()
+    const bar = container.querySelector('[role="toolbar"]')
+    expect(bar).toHaveAttribute('aria-label', 'Test filter')
+    expect(chipsOf(container)).toHaveLength(3)
+    expect(container.querySelectorAll('[role="radio"]')).toHaveLength(0)
+    expect(container.querySelectorAll('[aria-checked]')).toHaveLength(0)
+  })
+
+  test('marks every selected chip', () => {
+    const { container } = setupMulti({ value: ['a', 'b'] })
+    const chips = chipsOf(container)
+    expect(chips.map(c => c.getAttribute('aria-pressed'))).toEqual(['false', 'true', 'true'])
+    expect(chips[1]).toHaveClass('active')
+    expect(chips[2]).toHaveClass('active')
+  })
+
+  test('the All chip is active while nothing is selected', () => {
+    const { container } = setupMulti()
+    expect(chipsOf(container)[0]).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('every chip carries a state marker so the bar reads as multi-select', () => {
+    const { container } = setupMulti({ value: ['a'] })
+    expect(container.querySelectorAll('.chip-mark')).toHaveLength(3)
+    // The colour dot is a single-select affordance and must not double up.
+    expect(container.querySelectorAll('.chip-dot')).toHaveLength(0)
+  })
+
+  test('clicking an unselected chip adds it to the selection', async () => {
+    const { container, onselect } = setupMulti({ value: ['a'] })
+    await fireEvent.click(chipsOf(container)[2])
+    expect(onselect).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  test('clicking a selected chip removes it', async () => {
+    const { container, onselect } = setupMulti({ value: ['a', 'b'] })
+    await fireEvent.click(chipsOf(container)[1])
+    expect(onselect).toHaveBeenCalledWith(['b'])
+  })
+
+  test('the All chip clears the whole selection', async () => {
+    const { container, onselect } = setupMulti({ value: ['a', 'b'] })
+    await fireEvent.click(chipsOf(container)[0])
+    expect(onselect).toHaveBeenCalledWith([])
+  })
+
+  test('arrows move focus without changing the selection', async () => {
+    const { container, onselect } = setupMulti({ value: ['a'] })
+    const chips = chipsOf(container)
+    chips[1].focus()
+    await fireEvent.keyDown(chips[1], { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(chips[2])
+    expect(onselect).not.toHaveBeenCalled()
+  })
+
+  test('roving tabindex anchors on the first selected chip', () => {
+    const { container } = setupMulti({ value: ['b'] })
+    expect(chipsOf(container).map(c => c.getAttribute('tabindex'))).toEqual(['-1', '-1', '0'])
+  })
+
+  test('the tab stop follows the last-focused chip, not the selection', async () => {
+    const { container } = setupMulti({ value: ['a'] })
+    const chips = chipsOf(container)
+    expect(chips[1]).toHaveAttribute('tabindex', '0')
+    await fireEvent.keyDown(chips[1], { key: 'End' })
+    expect(chips[2]).toHaveAttribute('tabindex', '0')
+    expect(chips[1]).toHaveAttribute('tabindex', '-1')
+  })
+
+  test('tolerates a scalar value from a single-select caller', () => {
+    const { container } = setupMulti({ value: 'a' })
+    expect(chipsOf(container)[1]).toHaveAttribute('aria-pressed', 'true')
+  })
+})

--- a/web/src/pages/AuditLog.svelte
+++ b/web/src/pages/AuditLog.svelte
@@ -14,8 +14,9 @@
   let offset = $state(0)
   const limit = 50
 
-  let category = $state('')
-  let status = $state('')
+  // Type and Status are unions (multi-select chips); an empty array is "All".
+  let categories = $state([])
+  let statuses = $state([])
   let timeRange = $state('24h')
   let search = $state('')
   let view = $state('timeline')
@@ -25,7 +26,7 @@
   let expandedRowId = $state(null)
   let expandedSessions = $state(new Set())
 
-  const categories = [
+  const categoryItems = [
     { value: '', label: 'All' },
     { value: 'tool_call', label: 'Tools' },
     { value: 'llm', label: 'LLM' },
@@ -36,7 +37,7 @@
     { value: 'skill', label: 'Skills' },
     { value: 'supervisor', label: 'Supervisor' },
   ]
-  const statuses = [
+  const statusItems = [
     { value: '', label: 'All' },
     { value: 'ok', label: 'OK' },
     { value: 'error', label: 'Error' },
@@ -68,7 +69,7 @@
       error = ''
       if (!append) refreshing = true
       const since = sinceFromRange(timeRange)
-      const res = await api.auditEvents({ category, status, search, since, limit: String(limit), offset: String(append ? offset : 0) })
+      const res = await api.auditEvents({ category: categories, status: statuses, search, since, limit: String(limit), offset: String(append ? offset : 0) })
       if (seq !== loadSeq) return
       if (append) { events = [...events, ...res.events] }
       else { events = res.events; offset = 0 }
@@ -86,12 +87,13 @@
   function refresh() { load(); loadStats() }
   function loadMore() { offset += limit; load(true) }
 
-  // Chips select on arrow-key focus, so a keyboard user sweeping the bar would
-  // fire one request per chip. Coalesce them the way the search box does.
+  // Range chips select on arrow-key focus, so a keyboard user sweeping the bar
+  // would fire one request per chip; toggling several Type chips is the same
+  // shape. Coalesce them the way the search box does.
   let filterTimeout
   function setFilter(key, value) {
-    if (key === 'category') category = value
-    else if (key === 'status') status = value
+    if (key === 'categories') categories = value
+    else if (key === 'statuses') statuses = value
     else if (key === 'timeRange') timeRange = value
     refreshing = true
     clearTimeout(filterTimeout)
@@ -258,11 +260,11 @@
   <!-- Filters -->
   <div class="filters">
     <span class="filter-label">Type</span>
-    <FilterChips items={categories} value={category} label="Category filter" size="sm"
-      onselect={(v) => setFilter('category', v)} />
+    <FilterChips items={categoryItems} value={categories} label="Category filter" size="sm" multiple
+      onselect={(v) => setFilter('categories', v)} />
     <span class="filter-label">Status</span>
-    <FilterChips items={statuses} value={status} label="Status filter" size="sm"
-      onselect={(v) => setFilter('status', v)} />
+    <FilterChips items={statusItems} value={statuses} label="Status filter" size="sm" multiple
+      onselect={(v) => setFilter('statuses', v)} />
     <span class="filter-label">Range</span>
     <FilterChips items={timeRanges} value={timeRange} label="Time range" size="sm"
       onselect={(v) => setFilter('timeRange', v)} />

--- a/web/src/shared.css
+++ b/web/src/shared.css
@@ -325,6 +325,23 @@
   flex-shrink: 0;
 }
 
+/* State marker on multi-select chips. Without it a bar that accepts several
+   values looks identical to a single-select one, so "you may pick more than
+   one" is only discoverable after risking a second click. Same geometry as
+   .chip-dot; currentColor keeps it correct on both chip backgrounds. */
+.chip-mark {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  border: 1px solid currentColor;
+  opacity: 0.5;
+}
+.chip.active .chip-mark {
+  background: currentColor;
+  opacity: 1;
+}
+
 /* ---------- Utilities ---------------------------------------------------- */
 
 .muted { color: var(--text-muted); }


### PR DESCRIPTION
## Why

Picking **Tools** in the Audit Log hid LLM and Approval events, so the common investigation question — *show me tool calls **and** LLM rounds **and** approvals for this session* — took three passes.

Type and Status now accept a union. **Range stays single-select**, since a time window genuinely is exclusive.

## What changed

The multi-value filter had to survive the whole path — chip → page state → query string → `ListOpts` → SQL.

**Store** — `ListOpts.Category/Status` become `Categories/Statuses []string`, rendered as `col IN (?,?)` by a new `inClause` helper. An empty slice drops the condition entirely, so "All" behaves exactly as before.

**Wire format** — a shared `audit.ParseFilterList` accepts both `?category=a,b` and the repeated `?category=a&category=b` spelling, trimming blanks and collapsing duplicates. The REST handler and the `audit_events` MCP tool both parse through it, so an agent can pass `"llm,tool_call"` too. Single values are unchanged, so existing callers and bookmarked URLs keep working. Swagger annotations updated and `swagger.json` regenerated.

**FilterChips** — new `multiple` prop. Multi mode renders a `role="toolbar"` of `aria-pressed` toggle buttons rather than checkboxes: toolbar is the role ARIA pairs with roving tabindex, so the bar keeps its existing single-tab-stop keyboard contract instead of inventing a non-conformant one. Arrows move focus (following last-focused, not the selection); Space/Enter toggle natively. **Single-select mode is behaviourally untouched** — all 17 original `FilterChips` tests pass unmodified, which is the regression net for the mode split.

**Affordance** — multi-select chips carry a `.chip-mark` state marker reusing `.chip-dot` geometry (`currentColor`, so it reads correctly on both chip backgrounds). Without it a bar accepting several values looked identical to the adjacent single-select Range bar, so "you may pick more than one" was only discoverable after risking a second click.

## Review notes

- `ListOpts` field rename touches three construction sites plus tests; a plural rename beat carrying both a scalar and a slice for the same filter.
- `api.auditEvents` needed an explicit empty-array drop — an empty array is truthy, so it would otherwise have serialized as `category=`, which matches nothing server-side.
- `Stats` is deliberately untouched: it takes only `since` and is filter-independent by design, so the stats card and sparkline keep showing the whole window.
- The `''` "All" chip is the clear-all: choosing it emits `[]`, and it renders active whenever nothing is selected — so a caller's item list is identical in both modes.

## Testing

`just check` (fmt-check + vet + lint + test + test-ui + openapi-check) and the tagged integration suite both pass.

New coverage: store unions and the empty-slice-means-all invariant, `ParseFilterList` edge cases (blanks, whitespace, dedup, repeated-param merge), integration cases for both query spellings, one MCP case, and **the first query-string assertions on the Audit Log page** — the wire format previously had no regression net.

Chip rendering verified visually in both modes: multi bars show the marker, Range does not.

## Not included

The empty state still just says "No audit events found." It's now easier to build a contradictory filter set (Status=denied + Type=llm), so an empty state naming the active filters with a "Clear filters" action would be worth a follow-up — left out as scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)