### PR TITLE
fix(web): make the Audit Log tool:/agent: search hints actually filter

### DIFF
--- a/web/src/__tests__/auditSearch.test.js
+++ b/web/src/__tests__/auditSearch.test.js
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'vitest'
+import { parseAuditSearch } from '../auditSearch.js'
+
+describe('parseAuditSearch', () => {
+  test('plain text passes through as the search term', () => {
+    expect(parseAuditSearch('database error')).toEqual({
+      agent: '', search: 'database error',
+    })
+  })
+
+  test('empty input yields no filters', () => {
+    expect(parseAuditSearch('')).toEqual({ agent: '', search: '' })
+    expect(parseAuditSearch(undefined)).toEqual({ agent: '', search: '' })
+  })
+
+  test('agent: maps to the exact-match agent filter and leaves the search empty', () => {
+    expect(parseAuditSearch('agent:planner')).toEqual({ agent: 'planner', search: '' })
+  })
+
+  test('tool: folds into the search term', () => {
+    expect(parseAuditSearch('tool:web_search')).toEqual({ agent: '', search: 'web_search' })
+  })
+
+  test('tokens combine with each other and with free text', () => {
+    expect(parseAuditSearch('agent:planner tool:web_search timeout')).toEqual({
+      agent: 'planner', search: 'web_search timeout',
+    })
+  })
+
+  // The server takes one ?search=, applied as a single summary LIKE, so
+  // repeated tool: tokens are a phrase match — not two independent filters.
+  test('repeated tool: tokens join into one phrase', () => {
+    expect(parseAuditSearch('tool:a tool:b').search).toBe('a b')
+  })
+
+  test('prefixes are case-insensitive', () => {
+    expect(parseAuditSearch('Agent:planner').agent).toBe('planner')
+    expect(parseAuditSearch('TOOL:kv_get').search).toBe('kv_get')
+  })
+
+  test('the last agent: wins, since the API takes one agent', () => {
+    expect(parseAuditSearch('agent:planner agent:default').agent).toBe('default')
+  })
+
+  test('quoted values survive whitespace', () => {
+    expect(parseAuditSearch('agent:"my agent"').agent).toBe('my agent')
+    expect(parseAuditSearch('"exact phrase"').search).toBe('exact phrase')
+  })
+
+  test('unknown prefixes stay literal search text', () => {
+    expect(parseAuditSearch('chan:general').search).toBe('chan:general')
+    expect(parseAuditSearch('https://example.com').search).toBe('https://example.com')
+  })
+
+  test('a bare prefix mid-typing is neither a filter nor literal text', () => {
+    expect(parseAuditSearch('agent:')).toEqual({ agent: '', search: '' })
+  })
+})

--- a/web/src/__tests__/pages/AuditLog.test.js
+++ b/web/src/__tests__/pages/AuditLog.test.js
@@ -159,6 +159,122 @@ describe('AuditLog page', () => {
     expect(screen.getByPlaceholderText('Search events')).toBeInTheDocument()
   })
 
+  // The search box advertises `tool:`/`agent:` tokens, so they have to reach
+  // the API as the filters they name — `agent:` in particular is an exact
+  // match server-side and would never hit as a summary substring.
+  describe('token search syntax', () => {
+    // Returns the query params of the most recent /api/v1/audit request.
+    function captureAuditQuery() {
+      const seen = []
+      server.use(
+        http.get('/api/v1/audit', ({ request }) => {
+          seen.push(new URL(request.url).searchParams)
+          return HttpResponse.json({ events: auditEvents, total: auditEvents.length })
+        }),
+      )
+      return seen
+    }
+
+    async function typeSearch(text) {
+      const input = screen.getByPlaceholderText('Search events')
+      await fireEvent.input(input, { target: { value: text } })
+    }
+
+    test('agent: is sent as the exact-match agent filter, not as search text', async () => {
+      const seen = captureAuditQuery()
+      render(AuditLog)
+      await waitFor(() => expect(seen.length).toBe(1))
+
+      await typeSearch('agent:planner')
+      await waitFor(() => expect(seen.length).toBe(2))
+      expect(seen[1].get('agent')).toBe('planner')
+      expect(seen[1].get('search')).toBeNull()
+    })
+
+    test('tool: is sent as the search term', async () => {
+      const seen = captureAuditQuery()
+      render(AuditLog)
+      await waitFor(() => expect(seen.length).toBe(1))
+
+      await typeSearch('tool:web_search')
+      await waitFor(() => expect(seen.length).toBe(2))
+      expect(seen[1].get('search')).toBe('web_search')
+      expect(seen[1].get('agent')).toBeNull()
+    })
+
+    test('tokens combine with free text in one request', async () => {
+      const seen = captureAuditQuery()
+      render(AuditLog)
+      await waitFor(() => expect(seen.length).toBe(1))
+
+      await typeSearch('agent:planner tool:web_search timeout')
+      await waitFor(() => expect(seen.length).toBe(2))
+      expect(seen[1].get('agent')).toBe('planner')
+      expect(seen[1].get('search')).toBe('web_search timeout')
+    })
+
+    test('untokenized text still searches summaries', async () => {
+      const seen = captureAuditQuery()
+      render(AuditLog)
+      await waitFor(() => expect(seen.length).toBe(1))
+
+      await typeSearch('database error')
+      await waitFor(() => expect(seen.length).toBe(2))
+      expect(seen[1].get('search')).toBe('database error')
+      expect(seen[1].get('agent')).toBeNull()
+    })
+
+    // The chips describe the request, not the tokens: two tool: tokens are one
+    // phrase match on the wire and must not read as two independent filters.
+    test('active chips describe the query actually sent', async () => {
+      render(AuditLog)
+      await waitFor(() => {
+        expect(screen.getByText('agent:planner')).toBeInTheDocument()
+      })
+      expect(screen.getByText('try')).toBeInTheDocument()
+
+      await typeSearch('agent:default tool:kv_get tool:kv_list')
+
+      await waitFor(() => {
+        expect(screen.getByText('filtering')).toBeInTheDocument()
+      })
+      expect(screen.getByText('agent = default')).toBeInTheDocument()
+      expect(screen.getByText('summary contains "kv_get kv_list"')).toBeInTheDocument()
+      // The example chips are gone, so nothing claims a filter that isn't set.
+      expect(screen.queryByText('try')).not.toBeInTheDocument()
+      expect(screen.queryByText('tool:name')).not.toBeInTheDocument()
+    })
+
+    test('untokenized text is chipped too, so the summary match is visible', async () => {
+      render(AuditLog)
+      await waitFor(() => expect(screen.getByText('try')).toBeInTheDocument())
+
+      await typeSearch('database error')
+
+      await waitFor(() => {
+        expect(screen.getByText('summary contains "database error"')).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/^agent = /)).not.toBeInTheDocument()
+    })
+
+    // An exact-match agent filter that misses looks identical to an empty log
+    // unless the empty state says which filter produced it.
+    test('empty state names the filters that produced it', async () => {
+      server.use(
+        http.get('/api/v1/audit', () => HttpResponse.json({ events: [], total: 0 })),
+      )
+      render(AuditLog)
+      await waitFor(() => {
+        expect(screen.getByText('No audit events found.')).toBeInTheDocument()
+      })
+
+      await typeSearch('agent:typo tool:kv_get')
+      await waitFor(() => {
+        expect(screen.getByText('No audit events found for agent "typo" matching "kv_get".')).toBeInTheDocument()
+      })
+    })
+  })
+
   test('category filter chips are clickable', async () => {
     render(AuditLog)
     await waitFor(() => {

--- a/web/src/auditSearch.js
+++ b/web/src/auditSearch.js
@@ -1,0 +1,55 @@
+// Parses the audit search box into the API filters it actually maps to.
+//
+//   agent:<name>  -> the server's exact-match ?agent= filter
+//   tool:<name>   -> folded into the free-text ?search= term
+//
+// `tool:` is a search term rather than its own filter because audit_events has
+// no tool column: a tool call's summary IS the tool name, and approval,
+// supervisor and error summaries embed it, so a summary match is the widest
+// correct reading. Unprefixed words keep their old meaning and pass through
+// verbatim, joined by spaces — the server matches the joined string as one
+// LIKE phrase, so multi-word input stays a phrase search as it always was.
+//
+// Only `agent:` and `tool:` are prefixes; anything else with a colon in it
+// (`http://x`, `chan:general`) stays literal search text.
+
+const PREFIXED = /^(agent|tool):(.*)$/is
+
+// Splits on whitespace, treating a double-quoted run as one chunk so
+// `agent:"my agent"` and `"exact phrase"` survive intact.
+function chunk(input) {
+  const out = []
+  let cur = ''
+  let inQuotes = false
+  for (const ch of input) {
+    if (ch === '"') { inQuotes = !inQuotes; continue }
+    if (!inQuotes && /\s/.test(ch)) {
+      if (cur) out.push(cur)
+      cur = ''
+      continue
+    }
+    cur += ch
+  }
+  if (cur) out.push(cur)
+  return out
+}
+
+// Returns the two query params the box can drive: { agent, search }. The UI
+// renders its active-filter chips from these rather than from the tokens it
+// recognised, so what is displayed cannot drift from what is requested.
+export function parseAuditSearch(input) {
+  let agent = ''
+  const terms = []
+  for (const c of chunk(input || '')) {
+    const m = PREFIXED.exec(c)
+    if (!m) { terms.push(c); continue }
+    // A bare `agent:` is mid-typing, not a filter and not literal text.
+    if (!m[2]) continue
+    if (m[1].toLowerCase() === 'agent') {
+      agent = m[2] // one ?agent= on the wire, so the last one typed wins
+    } else {
+      terms.push(m[2])
+    }
+  }
+  return { agent, search: terms.join(' ') }
+}

--- a/web/src/pages/AuditLog.svelte
+++ b/web/src/pages/AuditLog.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount, onDestroy } from 'svelte'
   import { api } from '../api.js'
+  import { parseAuditSearch } from '../auditSearch.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
   import AuditSession from '../components/AuditSession.svelte'
   import AuditRow from '../components/AuditRow.svelte'
@@ -19,6 +20,7 @@
   let statuses = $state([])
   let timeRange = $state('24h')
   let search = $state('')
+  let agent = $state('')
   let view = $state('timeline')
   let follow = $state(false)
   let refreshTimer
@@ -69,7 +71,7 @@
       error = ''
       if (!append) refreshing = true
       const since = sinceFromRange(timeRange)
-      const res = await api.auditEvents({ category: categories, status: statuses, search, since, limit: String(limit), offset: String(append ? offset : 0) })
+      const res = await api.auditEvents({ category: categories, status: statuses, agent, search, since, limit: String(limit), offset: String(append ? offset : 0) })
       if (seq !== loadSeq) return
       if (append) { events = [...events, ...res.events] }
       else { events = res.events; offset = 0 }
@@ -105,10 +107,36 @@
     else clearInterval(refreshTimer)
   }
 
+  // `tool:`/`agent:` tokens are resolved here rather than sent verbatim: the
+  // API has an exact-match agent filter but no token syntax of its own.
   let searchTimeout
   function onSearchInput(e) {
+    const raw = e.target.value
     clearTimeout(searchTimeout)
-    searchTimeout = setTimeout(() => { search = e.target.value; refresh() }, 300)
+    searchTimeout = setTimeout(() => {
+      const parsed = parseAuditSearch(raw)
+      search = parsed.search
+      agent = parsed.agent
+      refresh()
+    }, 300)
+  }
+
+  // Chips describe the request that was sent, not the tokens that were typed:
+  // `tool:a tool:b` is one phrase match on the wire, so it reads as one chip,
+  // and untokenized text gets a chip too. The two filters read differently
+  // server-side — agent is exact, search is a summary substring — so they say
+  // so, which is the mapping the token syntax exists to expose.
+  let activeFilters = $derived([
+    ...(agent ? [`agent = ${agent}`] : []),
+    ...(search ? [`summary contains "${search}"`] : []),
+  ])
+
+  // Distinguishes "nothing happened yet" from "your filter matched nothing".
+  function filterSuffix() {
+    const parts = []
+    if (agent) parts.push(`for agent "${agent}"`)
+    if (search) parts.push(`matching "${search}"`)
+    return parts.length ? ` ${parts.join(' ')}` : ''
   }
 
   function toggleRow(id) { expandedRowId = expandedRowId === id ? null : id }
@@ -274,16 +302,29 @@
   <div class="search-card">
     <span class="search-icon">{'\u2315'}</span>
     <input type="text" class="search-input" placeholder="Search events" aria-label="Search audit events" oninput={onSearchInput} />
-    <span class="search-hint">try</span>
-    <code class="search-example">tool:name</code>
-    <code class="search-example">agent:planner</code>
+    <!-- Mounted even when empty: a live region inserted together with its
+         content is not reliably announced, and the first filter is the one
+         that matters. -->
+    <span class="search-filters" class:has-filters={activeFilters.length > 0} role="status">
+      {#if activeFilters.length > 0}
+        <span class="search-hint">filtering</span>
+        {#each activeFilters as f}
+          <code class="search-example is-active">{f}</code>
+        {/each}
+      {/if}
+    </span>
+    {#if activeFilters.length === 0}
+      <span class="search-hint is-hint">try</span>
+      <code class="search-example is-hint">tool:name</code>
+      <code class="search-example is-hint">agent:planner</code>
+    {/if}
   </div>
 
   <!-- Event list -->
   {#if loading}
     <p class="empty">Loading...</p>
   {:else if groupedItems.length === 0}
-    <p class="empty">No audit events found.</p>
+    <p class="empty">No audit events found{filterSuffix()}.</p>
   {:else if view === 'timeline'}
     <div class="timeline">
       {#each groupedItems as item}
@@ -373,7 +414,7 @@
   }
   .search-icon { color: var(--text-muted); font-size: 13px; }
   .search-input {
-    flex: 1; border: none; background: transparent;
+    flex: 1; min-width: 0; border: none; background: transparent;
     font-size: 12px; color: var(--text); outline: none;
   }
   .search-input::placeholder { color: var(--text-muted); }
@@ -382,6 +423,13 @@
     background: rgba(44,24,16,0.06); padding: 1px 6px;
     border-radius: 3px; font-size: 11px; color: #5F4A35;
   }
+  /* Live filters read as state, not as the muted examples they replace —
+     same accent tint the FAILED pill uses for its own state below. */
+  .search-example.is-active {
+    background: rgba(200,78,53,0.10); color: var(--accent);
+    max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .search-filters { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
 
   /* Timeline */
   .timeline { display: flex; flex-direction: column; gap: 6px; }
@@ -421,6 +469,10 @@
   @media (max-width: 768px) {
     .page-header { flex-direction: column; align-items: flex-start; gap: 8px; }
     .filters { grid-template-columns: 40px 1fr; }
-    .search-example { display: none; }
+    /* Examples are optional prompting; active filters must stay visible, and
+       wrap to their own line rather than crushing the input. */
+    .is-hint { display: none; }
+    .search-card { flex-wrap: wrap; }
+    .search-filters.has-filters { flex-basis: 100%; }
   }
 </style>


### PR DESCRIPTION
## The problem

The Audit Log search box advertised `tool:name` and `agent:planner` as example syntax, but nothing parsed either token — not on the client, not on the server. The raw input went straight to `?search=`, which `buildWhereClause` applies as `summary LIKE '%...%'`.

So typing `agent:planner` searched for that literal string *inside event summaries*, which essentially never matches. The hint was dead copy promising a feature that was never built.

## The fix

`agent:` now resolves to the exact-match `?agent=` filter the API already supported, and `tool:` folds into the search term.

`tool:` is deliberately **not** its own filter: `audit_events` has no tool column. A tool call's summary *is* the tool name (`engine.go` sets `Summary: tc.Function.Name`), and approval, supervisor and error summaries embed it, so a summary match is the widest correct reading — a server-side `tool:` filter could not do better without a schema change. The real win is composition: `agent:planner tool:web_search` was previously impossible to express.

Parsing lives in `web/src/auditSearch.js` so it is testable apart from the page. Unprefixed text keeps its exact old meaning, and unknown prefixes (`chan:general`, `https://...`) stay literal, since only `agent:` and `tool:` are claimed.

## Making the tokens real created a second problem

An exact-match filter that misses looks identical to an empty log. So the page now shows what it actually sent:

- **Chips are derived from the two values on the wire, not from the tokens recognised.** This matters: `tool:a tool:b` is one phrase match server-side, so it renders as one chip rather than two independent filters, and untokenized text gets a chip too. They read as `agent = planner` and `summary contains "..."` because the two filters genuinely differ — exact versus substring — and that mapping is the thing the token syntax exists to expose.
- **The empty state names the filters that produced it** (`No audit events found for agent "typo" matching "kv_get".`), following the `Approvals.svelte` idiom, so a mistyped agent reads as a miss rather than as an empty log.
- **Active chips take the accent tint** instead of the muted example styling — live state should not look like static prompting. Reuses the tint `.pill-failed-sm` already uses in this file.
- **The live region is mounted permanently.** A region inserted together with its content is not reliably announced, and the first filter is the one that matters.
- **On mobile the examples still hide, but active filters wrap to their own line** rather than vanishing or crushing the input.

## Reviewer notes

- **No server changes.** This uses the `agent` filter that `internal/api/audit.go` and `buildWhereClause` already implement. No OpenAPI change, so no regen needed.
- **Rebased on top of #289**, which landed in the same file. The one conflict was the `api.auditEvents({...})` call; resolved by keeping #289's `category: categories, status: statuses` arrays and adding `agent` alongside. #289's four new query-string assertions still pass unmodified.
- **While reviewing this I checked the LIKE path for injection and it is clean** — `buildWhereClause` only appends constant SQL fragments and binds every user value, and `LIMIT ? OFFSET ?` is bound with `limit` clamped. One unrelated nit worth knowing: `%` and `_` in the search term reach LIKE unescaped (no `ESCAPE` clause), so searching `50%` matches more broadly than intended. Not addressed here.
- **Known gap, not addressed:** `refreshing` in `AuditLog.svelte` is assigned in three places and never read, so during the 300ms debounce plus request a filter that will return nothing looks the same as one still loading. Pre-existing, tracked separately.

## Testing

- 13 parser cases in `web/src/__tests__/auditSearch.test.js` covering tokens, quoting, case-insensitivity, last-agent-wins, unknown prefixes and mid-typing.
- Page tests asserting the **actual outgoing query string** (via MSW request interception) rather than just parser output, plus the empty-state wording.
- `JUST_HOOK_FORCE=1 just hook` green across `fmt-check`, `vet`, `lint`, `lint-ui`, `test`, `test-ui`, `openapi-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
