### PR TITLE
fix(audit): show the in-flight state on Audit Log refetches

### DIFF
--- a/web/src/__tests__/pages/AuditLog.test.js
+++ b/web/src/__tests__/pages/AuditLog.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from 'vitest'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/svelte'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../test/server.js'
@@ -332,5 +332,123 @@ describe('AuditLog page', () => {
       expect(screen.getByText('Audit log')).toBeInTheDocument()
     })
     expect(screen.queryByText('Load older events')).not.toBeInTheDocument()
+  })
+})
+
+describe('AuditLog in-flight state', () => {
+  // `.results` is the only element carrying aria-busy, and role="status" is
+  // unique to the search-card marker, so both are safe page-wide handles.
+  const results = (container) => container.querySelector('.results')
+  const settled = (container) =>
+    waitFor(() => expect(results(container)).toHaveAttribute('aria-busy', 'false'))
+
+  test('marks the search card in-flight while a filter refetch is pending', async () => {
+    const { container } = render(AuditLog)
+    await settled(container)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Tools' }))
+    expect(screen.getByRole('status')).toHaveTextContent('Searching')
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
+  })
+
+  test('dims the current results while a refetch is pending, then restores', async () => {
+    const { container } = render(AuditLog)
+    await settled(container)
+    expect(results(container)).not.toHaveClass('is-refreshing')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Error' }))
+    expect(results(container)).toHaveAttribute('aria-busy', 'true')
+    expect(results(container)).toHaveClass('is-refreshing')
+
+    await settled(container)
+    expect(results(container)).not.toHaveClass('is-refreshing')
+  })
+
+  test('marks in-flight from the keystroke, before the debounce fires a request', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/v1/audit', () => {
+        calls++
+        return HttpResponse.json({ events: auditEvents, total: auditEvents.length })
+      }),
+    )
+    const { container } = render(AuditLog)
+    await settled(container)
+    const before = calls
+
+    await fireEvent.input(screen.getByPlaceholderText('Search events'), { target: { value: 'tool:web' } })
+
+    // The 300ms debounce has not elapsed, so nothing has gone out yet — but the
+    // user is already waiting, so the page must already read as busy.
+    expect(calls).toBe(before)
+    expect(screen.getByRole('status')).toHaveTextContent('Searching')
+    expect(results(container)).toHaveAttribute('aria-busy', 'true')
+
+    await waitFor(() => expect(calls).toBe(before + 1))
+    await settled(container)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  test('a search that will match nothing reads as in-flight before it reads as empty', async () => {
+    server.use(
+      http.get('/api/v1/audit', ({ request }) => {
+        const search = new URL(request.url).searchParams.get('search') || ''
+        // `agent:`-style queries are matched against summary text, so a name
+        // that appears in no summary is a perfectly valid query that simply
+        // returns zero rows — the case that used to be indistinguishable from
+        // a load still in flight.
+        if (search.startsWith('agent:')) return HttpResponse.json({ events: [], total: 0 })
+        return HttpResponse.json({ events: auditEvents, total: auditEvents.length })
+      }),
+    )
+    const { container } = render(AuditLog)
+    await settled(container)
+    expect(screen.queryByText('No audit events found.')).not.toBeInTheDocument()
+
+    await fireEvent.input(screen.getByPlaceholderText('Search events'), { target: { value: 'agent:plannr' } })
+    // This window used to be indistinguishable from a settled empty result.
+    expect(screen.getByRole('status')).toHaveTextContent('Searching')
+
+    await waitFor(() => {
+      expect(screen.getByText('No audit events found.')).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(results(container)).not.toHaveClass('is-refreshing')
+  })
+
+  test('the in-flight marker is absent while a response is still outstanding on Follow polls', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      let calls = 0
+      let releasePoll
+      server.use(
+        http.get('/api/v1/audit', async () => {
+          calls++
+          // Hold every poll open so the assertions below run mid-request.
+          if (calls > 1) await new Promise((r) => { releasePoll = r })
+          return HttpResponse.json({ events: auditEvents, total: auditEvents.length })
+        }),
+      )
+      const { container } = render(AuditLog)
+      await settled(container)
+
+      await fireEvent.click(screen.getByText('Follow'))
+      await vi.advanceTimersByTimeAsync(5000)
+
+      // Follow refreshes in the background: the user did not ask for it, so it
+      // must not dim their list or claim a search is running.
+      expect(calls).toBe(2)
+      expect(results(container)).toHaveAttribute('aria-busy', 'false')
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+
+      releasePoll?.()
+      await fireEvent.click(screen.getByText('Follow'))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/web/src/pages/AuditLog.svelte
+++ b/web/src/pages/AuditLog.svelte
@@ -63,11 +63,13 @@
   // otherwise repaint the list with a filter the user has already left.
   let loadSeq = 0
 
-  async function load(append = false) {
+  // `quiet` suppresses the in-flight marker for background work (the Follow
+  // poll): dimming the list every 5s unprompted is worse than showing nothing.
+  async function load(append = false, quiet = false) {
     const seq = ++loadSeq
     try {
       error = ''
-      if (!append) refreshing = true
+      if (!append && !quiet) refreshing = true
       const since = sinceFromRange(timeRange)
       const res = await api.auditEvents({ category: categories, status: statuses, search, since, limit: String(limit), offset: String(append ? offset : 0) })
       if (seq !== loadSeq) return
@@ -84,7 +86,7 @@
     try { stats = await api.auditStats(sinceFromRange(timeRange)) } catch { /* non-critical */ }
   }
 
-  function refresh() { load(); loadStats() }
+  function refresh(quiet = false) { load(false, quiet); loadStats() }
   function loadMore() { offset += limit; load(true) }
 
   // Range chips select on arrow-key focus, so a keyboard user sweeping the bar
@@ -101,12 +103,16 @@
   }
   function toggleFollow() {
     follow = !follow
-    if (follow) refreshTimer = setInterval(refresh, 5000)
+    if (follow) refreshTimer = setInterval(() => refresh(true), 5000)
     else clearInterval(refreshTimer)
   }
 
   let searchTimeout
   function onSearchInput(e) {
+    // Marked on the keystroke rather than when the request finally goes out:
+    // the debounce is part of the wait the user is sitting through, and a
+    // query that will return nothing must not read as "no results" meanwhile.
+    refreshing = true
     clearTimeout(searchTimeout)
     searchTimeout = setTimeout(() => { search = e.target.value; refresh() }, 300)
   }
@@ -277,43 +283,48 @@
     <span class="search-hint">try</span>
     <code class="search-example">tool:name</code>
     <code class="search-example">agent:planner</code>
+    {#if refreshing}
+      <span class="search-status" role="status">Searching{'\u2026'}</span>
+    {/if}
   </div>
 
   <!-- Event list -->
-  {#if loading}
-    <p class="empty">Loading...</p>
-  {:else if groupedItems.length === 0}
-    <p class="empty">No audit events found.</p>
-  {:else if view === 'timeline'}
-    <div class="timeline">
-      {#each groupedItems as item}
-        {#if item.type === 'session'}
-          <AuditSession session={item} expandedId={expandedRowId} onToggleRow={toggleRow} onToggleSession={toggleSession} />
-        {:else}
-          <div class="standalone-card" class:error-border={item.event.status === 'error'}>
-            <AuditRow event={item.event} expanded={expandedRowId === item.event.id} ontoggle={() => toggleRow(item.event.id)} standalone={true} />
-          </div>
-        {/if}
-      {/each}
-    </div>
-  {:else}
-    <table class="table">
-      <thead><tr><th>Time</th><th>Type</th><th>Summary</th><th>Status</th><th>Duration</th><th>Agent</th></tr></thead>
-      <tbody>
-        {#each events as event (event.id)}
-          {@const isErr = event.status === 'error'}
-          <tr class="row-clickable" class:row-expanded={expandedRowId === event.id} class:error-table-row={isErr} role="button" tabindex="0" aria-expanded={expandedRowId === event.id} onclick={() => toggleRow(event.id)} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleRow(event.id) }}}>
-            <td class="date">{new Date(event.timestamp).toLocaleString()}</td>
-            <td><span class="cat-badge-sm">{event.category}</span></td>
-            <td class="summary-cell">{event.summary || event.action}{#if isErr} <span class="pill-failed-sm">FAILED</span>{/if}</td>
-            <td><span class="status-text" class:status-err={isErr}>{event.status}</span></td>
-            <td class="mono" class:dur-err={isErr}>{event.duration_ms > 0 ? `${event.duration_ms}ms` : '\u2014'}</td>
-            <td class="muted">{event.agent || '\u2014'}</td>
-          </tr>
+  <div class="results" class:is-refreshing={refreshing} aria-busy={refreshing}>
+    {#if loading}
+      <p class="empty">Loading...</p>
+    {:else if groupedItems.length === 0}
+      <p class="empty">No audit events found.</p>
+    {:else if view === 'timeline'}
+      <div class="timeline">
+        {#each groupedItems as item}
+          {#if item.type === 'session'}
+            <AuditSession session={item} expandedId={expandedRowId} onToggleRow={toggleRow} onToggleSession={toggleSession} />
+          {:else}
+            <div class="standalone-card" class:error-border={item.event.status === 'error'}>
+              <AuditRow event={item.event} expanded={expandedRowId === item.event.id} ontoggle={() => toggleRow(item.event.id)} standalone={true} />
+            </div>
+          {/if}
         {/each}
-      </tbody>
-    </table>
-  {/if}
+      </div>
+    {:else}
+      <table class="table">
+        <thead><tr><th>Time</th><th>Type</th><th>Summary</th><th>Status</th><th>Duration</th><th>Agent</th></tr></thead>
+        <tbody>
+          {#each events as event (event.id)}
+            {@const isErr = event.status === 'error'}
+            <tr class="row-clickable" class:row-expanded={expandedRowId === event.id} class:error-table-row={isErr} role="button" tabindex="0" aria-expanded={expandedRowId === event.id} onclick={() => toggleRow(event.id)} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleRow(event.id) }}}>
+              <td class="date">{new Date(event.timestamp).toLocaleString()}</td>
+              <td><span class="cat-badge-sm">{event.category}</span></td>
+              <td class="summary-cell">{event.summary || event.action}{#if isErr} <span class="pill-failed-sm">FAILED</span>{/if}</td>
+              <td><span class="status-text" class:status-err={isErr}>{event.status}</span></td>
+              <td class="mono" class:dur-err={isErr}>{event.duration_ms > 0 ? `${event.duration_ms}ms` : '\u2014'}</td>
+              <td class="muted">{event.agent || '\u2014'}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </div>
 
   {#if events.length < total}
     <div class="load-more"><button class="btn-load-more" onclick={loadMore}>Load older events</button></div>
@@ -382,6 +393,14 @@
     background: rgba(44,24,16,0.06); padding: 1px 6px;
     border-radius: 3px; font-size: 11px; color: #5F4A35;
   }
+
+  /* In-flight marker. Every keystroke-debounce and filter chip refetches, so a
+     full-page "Loading..." swap would flicker; instead the current results dim
+     and the search card names the state. Without it a query that will return
+     nothing is indistinguishable from one still in flight. */
+  .search-status { color: var(--text-muted); font-size: 11px; white-space: nowrap; }
+  .results { transition: opacity 0.12s ease; }
+  .results.is-refreshing { opacity: 0.5; }
 
   /* Timeline */
   .timeline { display: flex; flex-direction: column; gap: 6px; }


### PR DESCRIPTION
## What

`AuditLog.svelte` declared `let refreshing = $state(false)` and assigned it in three places, but never read it in the template. This wires it to a visible state.

## Why

During the 300ms search debounce plus the API round-trip that follows, a filter or query that will return nothing looked identical to one still loading — the list either kept showing the previous results or sat on the empty state with no signal that anything was happening.

The search card advertises `agent:planner` as an example query. Search is matched against summary text (`summary LIKE ?` in `internal/audit/store.go`), so that shape of query very often returns zero rows — precisely the case where "still loading" and "nothing matched" needed to look different.

## How

A full-page `Loading...` swap was the wrong instrument here: this path fires on every keystroke-debounce and every filter chip toggle, so swapping the body out would flicker badly. Two subtle treatments instead, both reusing patterns already in the dashboard:

- The list moves into a `.results` wrapper carrying `aria-busy` and a `0.5` opacity dim — the same value `shared.css` uses for disabled states. The 0.12s transition is already neutralised by the existing `prefers-reduced-motion` block.
- The search card gains a `Searching…` marker styled like the adjacent `.search-hint`, using `role="status"` to match the idiom in `Chat.svelte` and `ServerConfig.svelte`. Deliberately no new spinner — the only spinner in the codebase is for a full-panel session restore, the wrong scale for something that fires on a keystroke.

Two behaviour fixes fell out of making the flag visible:

- `onSearchInput` now sets `refreshing` on the keystroke rather than when the debounced request goes out. The debounce was the larger half of the blind window.
- Follow polling refreshes quietly via a new `quiet` argument on `load()`. The 5s poll was already setting `refreshing`; surfacing it unchanged would have pulsed the whole list every five seconds.

## Reviewer notes

- **Quiet loads still clear the flag** when they are the newest request (the existing `loadSeq` guard). Leaving it strictly untouched reads cleaner, but can strand the marker on if a background poll supersedes a user-initiated load. The trade is a brief blink if a poll lands inside a typing gap, in exchange for the flag always resolving.
- **First paint shows both** `Loading...` and `Searching…`. Accurate rather than wrong, and gating the marker on `!loading` would cost a derived state plus a weaker settle signal in the tests. Happy to suppress it if reviewers prefer.
- The template diff looks larger than it is — most of it is the existing `{#if}` chain re-indented one level inside the new wrapper.

## Testing

`just test-ui` — 779 passed across 43 files. `just lint-ui` clean. Five new cases in `web/src/__tests__/pages/AuditLog.test.js`: the marker appearing on a filter refetch and on the keystroke before any request goes out, the dim applying and lifting, Follow polls staying silent, and the motivating case — a query that will match nothing reading as in-flight before it reads as empty.
