### PR TITLE
fix(web): separate --accent from --danger in the light theme

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -131,8 +131,11 @@
     --border:      #e8dcc8;
     --text:        #3d2a1e;
     --text-muted:  #8a7a6a;
-    --accent:      #c84e35;
-    --accent-hover:#b5432c;
+    /* Accent is a terracotta held ~21° off --danger so "active" never reads as
+       "destructive"; --accent-rgb is the same colour for rgba() tints. */
+    --accent:      #b85a28;
+    --accent-rgb:  184, 90, 40;
+    --accent-hover:#a44e20;
     --danger:      #c43a3a;
     --success:     #3d8f62;
     --warn:        #c87e30;
@@ -146,8 +149,8 @@
     --sidebar-bg:           #FDF8F0;
     --sidebar-text:         #3d3d3a;
     --sidebar-section-label: rgba(0, 0, 0, 0.4);
-    --sidebar-border-accent: rgba(192, 68, 44, 0.15);
-    --sidebar-active-bg:    rgba(192, 68, 44, 0.08);
+    --sidebar-border-accent: rgba(var(--accent-rgb), 0.15);
+    --sidebar-active-bg:    rgba(var(--accent-rgb), 0.08);
     --sidebar-hover-bg:     rgba(0, 0, 0, 0.04);
     --sidebar-divider:      rgba(0, 0, 0, 0.08);
   }
@@ -159,6 +162,7 @@
     --text:        #e8ddd4;
     --text-muted:  #9a8a7a;
     --accent:      #e07a5a;
+    --accent-rgb:  224, 122, 90;
     --accent-hover:#eb9070;
     --danger:      #e05c6e;
     --success:     #4caf7d;
@@ -170,8 +174,8 @@
     --sidebar-bg:           #1E1C19;
     --sidebar-text:         #d4d0c8;
     --sidebar-section-label: rgba(255, 255, 255, 0.35);
-    --sidebar-border-accent: rgba(207, 100, 75, 0.25);
-    --sidebar-active-bg:    rgba(207, 100, 75, 0.15);
+    --sidebar-border-accent: rgba(var(--accent-rgb), 0.25);
+    --sidebar-active-bg:    rgba(var(--accent-rgb), 0.15);
     --sidebar-hover-bg:     rgba(255, 255, 255, 0.06);
     --sidebar-divider:      rgba(255, 255, 255, 0.08);
   }

--- a/web/src/__tests__/theme.test.js
+++ b/web/src/__tests__/theme.test.js
@@ -1,0 +1,100 @@
+import { describe, test, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// --accent and --danger answer different questions ("this is on" vs "this
+// destroys something"), so they must stay far enough apart to be told apart
+// across a screen, not just side by side. Light mode regressed to ΔE 11 once
+// (issue #304); this is the guard against drifting back together.
+const MIN_DELTA_E = 20
+
+// .btn-primary and .chip.active put white text on the accent fill.
+const MIN_CONTRAST = 4.5
+
+// jsdom rewrites import.meta.url to an http URL, so resolve from the vitest
+// root (web/) instead.
+const appSvelte = readFileSync(resolve('src/App.svelte'), 'utf8')
+
+function themeBlock(selector) {
+  const start = appSvelte.indexOf(`:global(${selector}) {`)
+  if (start === -1) throw new Error(`no :global(${selector}) block in App.svelte`)
+  return appSvelte.slice(start, appSvelte.indexOf('\n  }', start))
+}
+
+function token(block, name) {
+  const match = block.match(new RegExp(`--${name}:\\s*([^;]+);`))
+  if (!match) throw new Error(`token --${name} not found`)
+  return match[1].trim()
+}
+
+function rgb(hex) {
+  const n = parseInt(hex.replace('#', ''), 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+function linearize(c) {
+  const s = c / 255
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(hex) {
+  const [r, g, b] = rgb(hex).map(linearize)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrastOnWhite(hex) {
+  return 1.05 / (relativeLuminance(hex) + 0.05)
+}
+
+// CIE-Lab under D65.
+function lab(hex) {
+  const [r, g, b] = rgb(hex).map(linearize)
+  const x = (0.4124 * r + 0.3576 * g + 0.1805 * b) / 0.95047
+  const y = 0.2126 * r + 0.7152 * g + 0.0722 * b
+  const z = (0.0193 * r + 0.1192 * g + 0.9505 * b) / 1.08883
+  const f = (t) => (t > 216 / 24389 ? Math.cbrt(t) : (841 / 108) * t + 4 / 29)
+  const [fx, fy, fz] = [f(x), f(y), f(z)]
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)]
+}
+
+function deltaE(a, b) {
+  const [l1, a1, b1] = lab(a)
+  const [l2, a2, b2] = lab(b)
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2)
+}
+
+describe.each([
+  ['light', ':root'],
+  ['dark', ':root.dark'],
+])('%s theme palette', (_name, selector) => {
+  const block = themeBlock(selector)
+  const accent = token(block, 'accent')
+  const danger = token(block, 'danger')
+
+  test('--accent is distinguishable from --danger', () => {
+    expect(deltaE(accent, danger)).toBeGreaterThanOrEqual(MIN_DELTA_E)
+  })
+
+  test('--accent-hover is distinguishable from --danger', () => {
+    expect(deltaE(token(block, 'accent-hover'), danger)).toBeGreaterThanOrEqual(MIN_DELTA_E)
+  })
+
+  test('--accent-rgb is the same colour as --accent', () => {
+    const parsed = token(block, 'accent-rgb').split(',').map((n) => Number(n.trim()))
+    expect(parsed).toEqual(rgb(accent))
+  })
+})
+
+describe('light theme contrast', () => {
+  const block = themeBlock(':root')
+
+  // Only light mode uses white text on the accent fill; dark mode's accent is
+  // a light tint that carries dark text.
+  test('white text on --accent clears AA', () => {
+    expect(contrastOnWhite(token(block, 'accent'))).toBeGreaterThanOrEqual(MIN_CONTRAST)
+  })
+
+  test('white text on --accent-hover clears AA', () => {
+    expect(contrastOnWhite(token(block, 'accent-hover'))).toBeGreaterThanOrEqual(MIN_CONTRAST)
+  })
+})

--- a/web/src/components/AuditRow.svelte
+++ b/web/src/components/AuditRow.svelte
@@ -203,7 +203,7 @@
   .cat-schedule { color: var(--success); background: rgba(61,143,98,0.08); }
   .cat-config { color: #8b5cf6; background: rgba(139,92,246,0.08); }
   .cat-skill { color: #06b6d4; background: rgba(6,182,212,0.08); }
-  .cat-mcp { color: var(--accent); background: rgba(192,68,44,0.08); }
+  .cat-mcp { color: var(--accent); background: rgba(var(--accent-rgb), 0.08); }
   .cat-session { color: #10b981; background: rgba(16,185,129,0.08); }
   .cat-supervisor { color: #534AB7; background: rgba(127,119,221,0.12); }
 

--- a/web/src/components/DryRunPanel.svelte
+++ b/web/src/components/DryRunPanel.svelte
@@ -272,7 +272,7 @@
   }
   .menu-item:first-child { border-top: none; }
   .menu-item:hover { background: var(--hover-overlay); }
-  .menu-item[aria-selected="true"] { background: rgba(200, 78, 53, 0.08); }
+  .menu-item[aria-selected="true"] { background: rgba(var(--accent-rgb), 0.08); }
   .menu-model {
     flex: 1; min-width: 0; font-size: 12px; color: var(--text);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/web/src/pages/Agents.svelte
+++ b/web/src/pages/Agents.svelte
@@ -687,7 +687,7 @@
       <div class="stat-cards">
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div class="stat-card" class:expanded={expandedCard === 'model'} onclick={() => toggleCard('model')} role="button" tabindex="0" aria-expanded={expandedCard === 'model'}>
-          <div class="stat-icon" style="background: rgba(200, 78, 53, 0.12); color: var(--accent);">
+          <div class="stat-icon" style="background: rgba(var(--accent-rgb), 0.12); color: var(--accent);">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
           </div>
           <div class="stat-text">
@@ -1276,9 +1276,9 @@
     cursor: default;
   }
   .tool-pill:hover, .tool-pill.expanded { border-color: var(--accent); }
-  .tool-pill.expanded { background: rgba(200, 78, 53, 0.08); }
+  .tool-pill.expanded { background: rgba(var(--accent-rgb), 0.08); }
   .pill-count {
-    background: rgba(200, 78, 53, 0.15);
+    background: rgba(var(--accent-rgb), 0.15);
     color: var(--accent);
     font-size: 11px; font-weight: 600;
     padding: 1px 6px;

--- a/web/src/pages/Approvals.svelte
+++ b/web/src/pages/Approvals.svelte
@@ -225,7 +225,7 @@
     text-transform: capitalize;
   }
   .filter-btn:hover  { color: var(--text); border-color: var(--text-muted); }
-  .filter-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(200, 78, 53, 0.1); }
+  .filter-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(var(--accent-rgb), 0.1); }
   .id { font-family: monospace; color: var(--text-muted); white-space: nowrap; }
   .summary { max-width: 380px; }
   .payload-details {

--- a/web/src/pages/AuditLog.svelte
+++ b/web/src/pages/AuditLog.svelte
@@ -468,7 +468,7 @@
   /* Live filters read as state, not as the muted examples they replace —
      same accent tint the FAILED pill uses for its own state below. */
   .search-example.is-active {
-    background: rgba(200,78,53,0.10); color: var(--accent);
+    background: rgba(var(--accent-rgb), 0.10); color: var(--accent);
     max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .search-filters { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
@@ -498,7 +498,7 @@
   .row-clickable { cursor: pointer; }
   .row-clickable:hover { background: var(--hover-overlay); }
   .row-clickable:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
-  .row-expanded { background: rgba(200, 78, 53, 0.08); }
+  .row-expanded { background: rgba(var(--accent-rgb), 0.08); }
   .error-table-row { background: rgba(196, 58, 58, 0.04); }
   .date { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
   .mono { font-family: monospace; font-size: 12px; }

--- a/web/src/pages/Chat.svelte
+++ b/web/src/pages/Chat.svelte
@@ -633,7 +633,7 @@
     gap: 6px;
     padding: 12px;
     margin-top: 8px;
-    background: rgba(200, 78, 53, 0.06);
+    background: rgba(var(--accent-rgb), 0.06);
     border: 1px solid var(--accent);
     border-radius: var(--radius);
   }

--- a/web/src/pages/SetupWizard.svelte
+++ b/web/src/pages/SetupWizard.svelte
@@ -500,7 +500,7 @@ Remember you're a guest. You have access to someone's life — treat it with res
   .tier-option:last-child { border-bottom: none; }
   .tier-option:hover { background: var(--hover-overlay); }
   .tier-option.selected {
-    background: rgba(200, 78, 53, 0.06);
+    background: rgba(var(--accent-rgb), 0.06);
     border-left: 3px solid var(--accent);
     padding-left: 9px;
   }
@@ -536,7 +536,7 @@ Remember you're a guest. You have access to someone's life — treat it with res
     display: flex;
     flex-direction: column;
     gap: 10px;
-    background: rgba(200, 78, 53, 0.03);
+    background: rgba(var(--accent-rgb), 0.03);
   }
   .callout-header {
     display: flex;

--- a/web/src/pages/Skills.svelte
+++ b/web/src/pages/Skills.svelte
@@ -359,12 +359,12 @@
   .form-subtitle { font-size: 12px; color: var(--text-muted); }
   .agent-pill {
     display: inline-flex; align-items: center; gap: 6px;
-    background: rgba(192, 68, 44, 0.08); border: 1px solid rgba(192, 68, 44, 0.18);
+    background: rgba(var(--accent-rgb), 0.08); border: 1px solid rgba(var(--accent-rgb), 0.18);
     color: var(--accent); font-size: 12px; font-weight: 500;
     padding: 5px 10px; border-radius: 999px; white-space: nowrap;
   }
   :global(:root.dark) .agent-pill {
-    background: rgba(224, 122, 90, 0.12); border-color: rgba(224, 122, 90, 0.22);
+    background: rgba(var(--accent-rgb), 0.12); border-color: rgba(var(--accent-rgb), 0.22);
   }
   .form-scope-hint {
     font-size: 11.5px; color: var(--text-muted); margin-bottom: 16px;

--- a/web/src/shared.css
+++ b/web/src/shared.css
@@ -424,7 +424,7 @@
 }
 
 .row-expanded {
-  background: rgba(200, 78, 53, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
 }
 
 .chevron-toggle {


### PR DESCRIPTION
Closes #304.

## The problem

In light mode `--accent` (`#c84e35`) and `--danger` (`#c43a3a`) sat 10° apart at ΔE 11 — saturation and lightness were effectively identical, so hue was the only separator. An active filter chip, a primary button and the emergency-stop button all read as the same red: "this filter is on" carried the same visual weight as "stop everything".

## The fix

Move `--accent` to a true terracotta and leave `--danger` alone, so danger stays the reddest thing in the palette.

| | hex | ΔE vs danger | white-on-fill contrast |
|---|---|---|---|
| accent (before) | `#c84e35` | 11.0 | 4.57:1 |
| accent (after) | `#b85a28` | **23.8** | **4.63:1** |
| accent-hover (after) | `#a44e20` | 24.2 | 5.69:1 |

Contrast matters because `.btn-primary` and `.chip.active` put white text on the accent fill — this spends none of the AA headroom, it adds a little. `--accent-hover` keeps its existing relationship to the base (−5.5 L, +2.8 S).

Dark mode was already well separated (ΔE 25.1) and is untouched, so the two themes now differ by ~7° of accent hue.

## Blast radius: the derived tints

The accent-derived `rgba()` values turned out to be a bigger issue than the sidebar tokens alone — 15 hardcoded copies of the old accent across 9 files, which would all have drifted off-hue. Rather than re-hardcoding them, they now read a new `--accent-rgb` token declared beside `--accent` in each theme.

Side effect worth knowing: most of those tints used the *light* accent regardless of theme, so the dark theme's tints were stale and are now correct.

`.cat-tool` in `AuditRow.svelte` was deliberately left alone — it belongs to the categorical badge palette, not the accent.

## Regression guard

`web/src/__tests__/theme.test.js` parses the token blocks straight out of `App.svelte` and asserts:

- ΔE ≥ 20 between `--accent`/`--accent-hover` and `--danger`, in both themes
- white-on-accent contrast ≥ 4.5:1 in light mode
- `--accent-rgb` agrees with `--accent`

It fails at the old value (ΔE 11.0), so the two tokens cannot drift back together.

## Verification

835 web tests pass; `just lint-ui` clean. Also ran the dashboard against a local instance in both themes. The Audit Log is the clearest confirmation: active Type/Status/Range chips and the Timeline toggle now read as warm terracotta with the red Panic button in the same viewport. Also checked Overview, Agents (stat icons, "Supervised" pill, selected agent card) and the login/setup screens. No console or rendering errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)