### PR TITLE
fix(api): a typo'd dry-run model is a 400, not a 500

### DIFF
--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -3956,7 +3956,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid JSON or as_of",
+                        "description": "Invalid JSON, invalid as_of, or unknown model",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -5296,7 +5296,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid JSON, invalid mode, missing message, no command trigger, or invalid as_of",
+                        "description": "Invalid JSON, invalid mode, missing message, no command trigger, invalid as_of, or unknown model",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7053,7 +7053,7 @@
                     "type": "string"
                 },
                 "model": {
-                    "description": "Model runs this preview against a model other than the agent's live one.\nEmpty uses the live model. The override applies to this request only and\nchanges nothing about the agent.",
+                    "description": "Model runs this preview against a model other than the agent's live one.\nEmpty uses the live model. The override applies to this request only and\nchanges nothing about the agent. Checked against what the agent's\nprovider advertises when that list is available — see\nvalidateModelOverride, which rejects only a name the provider is known\nnot to have.",
                     "type": "string"
                 }
             }

--- a/internal/api/dryrun.go
+++ b/internal/api/dryrun.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -36,7 +37,10 @@ type dryRunInput struct {
 	AsOf string `json:"as_of"`
 	// Model runs this preview against a model other than the agent's live one.
 	// Empty uses the live model. The override applies to this request only and
-	// changes nothing about the agent.
+	// changes nothing about the agent. Checked against what the agent's
+	// provider advertises when that list is available — see
+	// validateModelOverride, which rejects only a name the provider is known
+	// not to have.
 	Model string `json:"model"`
 	// Mode selects how a skill preview is invoked: "schedule" (the scheduler
 	// fires it — no user message), "command" (the user types its command:
@@ -130,6 +134,50 @@ func parseDryRunInput(r *http.Request) (dryRunInput, time.Time, error) {
 		return input, time.Time{}, fmt.Errorf("invalid as_of: must be RFC3339")
 	}
 	return input, t, nil
+}
+
+// modelValidationTimeout bounds the provider round-trip that checking a model
+// override costs. Listing is a live call on most providers (only OpenRouter
+// caches), so an unresponsive one must degrade to "cannot validate" rather than
+// hold the request open.
+const modelValidationTimeout = 5 * time.Second
+
+// validateModelOverride returns a client-error message when the caller asked
+// for a model the agent's provider positively does not know, and "" otherwise.
+//
+// It deliberately fails open. The advertised set comes from the provider
+// (OpenRouter lists hundreds and the set moves), so an empty, stale or
+// unreachable listing means "cannot validate", not "reject" — a model that
+// genuinely works must never be turned away because a listing call failed. The
+// one thing it rejects is a name the provider does know the full set of and
+// does not contain, which is the typo this exists to catch.
+//
+// Only the agent's *default* provider is queried: an override changes the model
+// alone (llm.Router.WithModel keeps the provider map and the default provider),
+// so that is the provider that will receive it, and filtering keeps the cost at
+// one round-trip instead of one per registered provider. The check is skipped
+// entirely when there is no override, which is the common path.
+func (s *Server) validateModelOverride(ctx context.Context, e *agent.Engine, model string) string {
+	if model == "" || model == e.ModelName() {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, modelValidationTimeout)
+	defer cancel()
+
+	provider := e.ProviderName()
+	advertised := e.ListModelDetails(ctx, provider)
+	if len(advertised) == 0 {
+		s.logger.Debug("model override not validated: provider advertises no models",
+			"agent", e.Name(), "provider", provider, "model", model)
+		return ""
+	}
+	for _, m := range advertised {
+		if m.ID == model {
+			return ""
+		}
+	}
+	return fmt.Sprintf("unknown model %q for provider %q", model, provider)
 }
 
 // truncateField trims a transcript field to the render cap.
@@ -254,7 +302,7 @@ func (s *Server) runDryRun(w http.ResponseWriter, r *http.Request, e *agent.Engi
 // @Param name path string true "Schedule name"
 // @Param body body dryRunInput false "Optional as_of (RFC3339) to pin the clock and model to override the agent's model"
 // @Success 200 {object} dryRunTranscript "Dry-run transcript"
-// @Failure 400 {object} map[string]string "Invalid JSON or as_of"
+// @Failure 400 {object} map[string]string "Invalid JSON, invalid as_of, or unknown model"
 // @Failure 404 {object} map[string]string "Schedule or agent not found"
 // @Failure 500 {object} map[string]string "Dry run failed"
 // @Failure 503 {object} map[string]string "Schedule management not available"
@@ -289,6 +337,11 @@ func (s *Server) handleDryRunSchedule(w http.ResponseWriter, r *http.Request) {
 	e := s.deps.Dispatcher.Agent(agentName)
 	if e == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("agent %q not found", agentName)})
+		return
+	}
+
+	if errMsg := s.validateModelOverride(r.Context(), e, input.Model); errMsg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": errMsg})
 		return
 	}
 
@@ -329,7 +382,7 @@ func (s *Server) handleDryRunSchedule(w http.ResponseWriter, r *http.Request) {
 // @Param name path string true "Skill name"
 // @Param body body dryRunInput true "Invocation: mode (schedule|command|message), plus message or args for the mode that needs one, and optional as_of (RFC3339) / model override. Omitting mode infers it from the skill's triggers and from whether a schedule names it."
 // @Success 200 {object} dryRunTranscript "Dry-run transcript"
-// @Failure 400 {object} map[string]string "Invalid JSON, invalid mode, missing message, no command trigger, or invalid as_of"
+// @Failure 400 {object} map[string]string "Invalid JSON, invalid mode, missing message, no command trigger, invalid as_of, or unknown model"
 // @Failure 404 {object} map[string]string "Agent or skill not found"
 // @Failure 500 {object} map[string]string "Dry run failed"
 // @Router /skills/{agent}/{name}/dry-run [post]
@@ -352,6 +405,11 @@ func (s *Server) handleDryRunSkill(w http.ResponseWriter, r *http.Request) {
 	input, asOf, err := parseDryRunInput(r)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if errMsg := s.validateModelOverride(r.Context(), e, input.Model); errMsg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": errMsg})
 		return
 	}
 

--- a/internal/api/dryrun_test.go
+++ b/internal/api/dryrun_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Temikus/denkeeper/internal/agent"
 	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/llm"
 	"github.com/Temikus/denkeeper/internal/scheduler"
 )
 
@@ -357,6 +359,83 @@ func TestTruncateField(t *testing.T) {
 	}
 }
 
+// listingProvider is the test mock that also advertises a model list, so the
+// dry-run model check has something to validate against. It registers under the
+// same name as mockProvider, replacing it on the router.
+type listingProvider struct {
+	mockProvider
+	models []string
+}
+
+func (l *listingProvider) ListModels(_ context.Context) ([]string, error) { return l.models, nil }
+
+// withListedModels makes the default agent's provider advertise models, turning
+// the override check from "cannot validate, allow" into a real check.
+func withListedModels(t *testing.T, deps Deps, models ...string) {
+	t.Helper()
+	e := deps.Dispatcher.Agent("default")
+	if e == nil {
+		t.Fatal("default agent missing from test deps")
+	}
+	e.LLMRouter().RegisterProvider(&listingProvider{
+		mockProvider: mockProvider{response: &llm.ChatResponse{
+			Content:      "Hello from mock!",
+			TokensUsed:   llm.TokenUsage{Prompt: 10, Completion: 5, Total: 15},
+			Model:        "test-model",
+			FinishReason: "stop",
+		}},
+		models: models,
+	})
+}
+
+func TestDryRunSkill_UnknownModelOverrideIsRejected(t *testing.T) {
+	deps := testDeps()
+	withListedModels(t, deps, "test-model", "other-model")
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	rec := postDryRun(t, srv, "/api/v1/skills/default/greet/dry-run",
+		`{"message":"hi","model":"typo-model"}`, "dk-test-key")
+	// A model the provider does not know is a client mistake, not a server
+	// fault — before this it reached the provider and came back as a 500.
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "typo-model") {
+		t.Errorf("body = %s, want the unknown name echoed back", rec.Body.String())
+	}
+}
+
+func TestDryRunSchedule_UnknownModelOverrideIsRejected(t *testing.T) {
+	deps := testDeps()
+	registerTestSchedule(t, deps, "nightly")
+	withListedModels(t, deps, "test-model")
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	rec := postDryRun(t, srv, "/api/v1/schedules/nightly/dry-run",
+		`{"model":"typo-model"}`, "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDryRunSkill_AdvertisedModelOverrideIsAccepted(t *testing.T) {
+	deps := testDeps()
+	withListedModels(t, deps, "test-model", "other-model")
+	srv := New(testConfig(allScopesKey()), deps, testLogger())
+
+	rec := postDryRun(t, srv, "/api/v1/skills/default/greet/dry-run",
+		`{"message":"hi","model":"other-model"}`, "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := decodeTranscript(t, rec).RequestedModel; got != "other-model" {
+		t.Errorf("RequestedModel = %q, want the advertised override to run", got)
+	}
+}
+
+// TestDryRunSkill_ModelOverrideIsEchoed doubles as the fail-open case: the
+// default mock provider advertises nothing, so the override cannot be checked
+// and must pass through rather than be rejected.
 func TestDryRunSkill_ModelOverrideIsEchoed(t *testing.T) {
 	deps := testDeps()
 	srv := New(testConfig(allScopesKey()), deps, testLogger())


### PR DESCRIPTION
Fixes #299.

## What

Both dry-run endpoints (`POST /schedules/{name}/dry-run`, `POST /skills/{agent}/{name}/dry-run`) accept an optional `model` override and passed it straight through to the provider. An unrecognised name surfaced as a **500** wrapping the provider's rejection — indistinguishable from a genuine outage, for what is a client mistake. The `as_of` parameter next to it already 400s on a bad value, so the pair was inconsistent.

`validateModelOverride` (`internal/api/dryrun.go`) now runs in both handlers before the turn starts, and returns `400 {"error":"unknown model \"typo-model\" for provider \"openrouter\""}`.

## Why it fails open

The advertised set is fetched from the provider — OpenRouter lists hundreds and the set moves — so an empty, stale or unreachable listing means **"cannot validate"**, not "reject". A model that genuinely works must never be turned away because a listing call failed, or because the provider doesn't implement `ListModels` at all. The only rejection is a name a provider that *does* publish its full set does not contain, which is the typo this exists to catch.

## Which catalogue it validates against

Through the **agent's own router**, not `Deps.ModelDetailLister`. That lister answers from the *fallback* agent across every provider it has, which is the wrong catalogue to judge a per-agent override by. Only the agent's **default** provider is queried: `Router.WithModel` changes the model alone, so that is the provider which will receive it. That also keeps the cost at one round-trip rather than one per registered provider, bounded by a 5s timeout, and skipped entirely when there is no override (the common path) or when it matches the live model.

## Reviewer notes

- **No behaviour change for the dashboard**, whose model menu is populated from `GET /models/details`. Worth knowing: in a multi-provider setup that menu comes from the fallback agent unfiltered, so it can still offer a model the *target* agent's provider doesn't have. That request now names the provider instead of reading as a server fault — the right answer, but a UI rough edge that remains open.
- `TestDryRunSkill_ModelOverrideIsEchoed` is unchanged and now doubles as the fail-open case: the default test mock advertises nothing, so the override passes through.
- Swagger 400 descriptions updated; `just openapi` re-run, `just hook` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)