### PR TITLE
fix(cli): honour data_dir and env overrides when resolving the CLI DB path

### DIFF
--- a/cmd/denkeeper/keys.go
+++ b/cmd/denkeeper/keys.go
@@ -118,29 +118,43 @@ func runKeysList() error {
 	return w.Flush()
 }
 
-// resolveDBPath returns the memory.db_path from the config file, falling back
-// to the default location if the file is absent or does not set the field.
+// resolveDBPath returns the SQLite path the server would use for this config,
+// applying the same precedence as config.Load: DENKEEPER_MEMORY_DB_PATH >
+// [memory].db_path > <data dir>/data/memory.db, where the data dir is
+// DENKEEPER_DATA_DIR > data_dir > ~/.denkeeper.
 // It intentionally skips full config validation so it works before a valid
 // config exists (e.g. on first run when no adapter tokens are configured yet).
 func resolveDBPath(cfgPath string) string {
 	if cfgPath == "" {
-		cfgPath = config.DefaultConfigPath()
+		cfgPath = resolveConfigPath()
 	}
 
-	// Partially parse just the memory section — skip adapter/LLM validation.
+	// Partially parse just the path fields — skip adapter/LLM validation.
 	type partialMemory struct {
 		DBPath string `toml:"db_path"`
 	}
 	type partialConfig struct {
-		Memory partialMemory `toml:"memory"`
+		DataDir string        `toml:"data_dir"`
+		Memory  partialMemory `toml:"memory"`
 	}
 
-	data, err := os.ReadFile(cfgPath) // #nosec G304 -- path from CLI flag / config, not user input
-	if err == nil {
-		var cfg partialConfig
-		if toml.Unmarshal(data, &cfg) == nil && cfg.Memory.DBPath != "" {
-			return cfg.Memory.DBPath
+	var cfg partialConfig
+	if data, err := os.ReadFile(cfgPath); err == nil { // #nosec G304 -- path from CLI flag / config, not user input
+		if toml.Unmarshal(data, &cfg) != nil {
+			cfg = partialConfig{} // malformed config: fall back to defaults
 		}
+	}
+
+	if v := os.Getenv("DENKEEPER_MEMORY_DB_PATH"); v != "" {
+		return v
+	}
+	if cfg.Memory.DBPath != "" {
+		return cfg.Memory.DBPath
+	}
+	// config.DefaultDBPath already honours DENKEEPER_DATA_DIR, which outranks
+	// the TOML data_dir — so only consult data_dir when the env var is unset.
+	if cfg.DataDir != "" && os.Getenv("DENKEEPER_DATA_DIR") == "" {
+		return filepath.Join(cfg.DataDir, "data", "memory.db")
 	}
 
 	return config.DefaultDBPath()

--- a/cmd/denkeeper/keys_test.go
+++ b/cmd/denkeeper/keys_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestResolveDBPath_NoConfigFile(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", "")
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
 	got := resolveDBPath("/nonexistent/path/denkeeper.toml")
 	if got == "" {
 		t.Fatal("expected non-empty path")
@@ -49,6 +52,9 @@ default_provider = "openrouter"
 }
 
 func TestResolveDBPath_MissingMemorySection(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", "")
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
 	dir := t.TempDir()
 	cfgContent := `[llm]
 default_provider = "openrouter"
@@ -66,7 +72,105 @@ default_provider = "openrouter"
 	}
 }
 
+// writeCfg writes a config file into a temp dir and returns its path.
+func writeCfg(t *testing.T, content string) string {
+	t.Helper()
+	cfgPath := filepath.Join(t.TempDir(), "denkeeper.toml")
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return cfgPath
+}
+
+func TestResolveDBPath_DBPathWinsOverDataDir(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", "")
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
+	cfgPath := writeCfg(t, `data_dir = "/srv/denkeeper"
+
+[memory]
+db_path = "/custom/path/memory.db"
+`)
+
+	got := resolveDBPath(cfgPath)
+	want := "/custom/path/memory.db"
+	if got != want {
+		t.Errorf("resolveDBPath = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDBPath_DataDirUsedWhenDBPathAbsent(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", "")
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
+	cfgPath := writeCfg(t, `data_dir = "/srv/denkeeper"
+
+[llm]
+default_provider = "openrouter"
+`)
+
+	got := resolveDBPath(cfgPath)
+	want := filepath.Join("/srv/denkeeper", "data", "memory.db")
+	if got != want {
+		t.Errorf("resolveDBPath = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDBPath_EnvDataDirWinsOverConfigDataDir(t *testing.T) {
+	envDir := t.TempDir()
+	t.Setenv("DENKEEPER_DATA_DIR", envDir)
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
+	cfgPath := writeCfg(t, `data_dir = "/srv/denkeeper"
+
+[llm]
+default_provider = "openrouter"
+`)
+
+	got := resolveDBPath(cfgPath)
+	want := filepath.Join(envDir, "data", "memory.db")
+	if got != want {
+		t.Errorf("resolveDBPath = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDBPath_EnvDBPathWinsOverAll(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", t.TempDir())
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "/env/memory.db")
+
+	cfgPath := writeCfg(t, `data_dir = "/srv/denkeeper"
+
+[memory]
+db_path = "/custom/path/memory.db"
+`)
+
+	got := resolveDBPath(cfgPath)
+	want := "/env/memory.db"
+	if got != want {
+		t.Errorf("resolveDBPath = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDBPath_DefaultWhenNeitherSet(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", "")
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
+	cfgPath := writeCfg(t, `[llm]
+default_provider = "openrouter"
+`)
+
+	got := resolveDBPath(cfgPath)
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".denkeeper", "data", "memory.db")
+	if got != want {
+		t.Errorf("resolveDBPath = %q, want %q", got, want)
+	}
+}
+
 func TestResolveDBPath_MalformedTOML(t *testing.T) {
+	t.Setenv("DENKEEPER_DATA_DIR", "")
+	t.Setenv("DENKEEPER_MEMORY_DB_PATH", "")
+
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "denkeeper.toml")
 	if err := os.WriteFile(cfgPath, []byte(`not valid toml {{{{`), 0o600); err != nil {


### PR DESCRIPTION
## Problem

`resolveDBPath` in `cmd/denkeeper/keys.go` partially parsed the TOML config and honoured only `[memory].db_path`, falling back to `config.DefaultDBPath()` otherwise. It ignored the `data_dir` key and the `DENKEEPER_DATA_DIR` env var — the documented primary way to relocate all default paths.

On a config that sets `data_dir` without `[memory].db_path`:

```bash
denkeeper keys create ci-bot --config /etc/denkeeper/denkeeper.toml
```

silently created the key in `~/.denkeeper/data/memory.db` instead of the configured instance's database. The key looked created, the target server never saw it, and a stray **admin-scoped** key was written into an unrelated instance. `denkeeper keys list` and every `denkeeper sessions` subcommand (they share the helper via `openMemoryStore`) read the wrong database for the same reason.

## Fix

`resolveDBPath` now applies the same precedence `config.Load` does:

```
DENKEEPER_MEMORY_DB_PATH > [memory].db_path > <data dir>/data/memory.db
   where data dir = DENKEEPER_DATA_DIR > data_dir TOML > ~/.denkeeper
```

`data_dir` is consulted only when `DENKEEPER_DATA_DIR` is unset, because `config.DefaultDBPath` already applies that env var itself — checking it in both places would be redundant, not additive.

The helper still only partially parses the TOML (now `data_dir` alongside `memory.db_path`), preserving the "skip full config validation" property so it works before a valid config exists. A malformed file still falls back to defaults.

## Reviewer notes

- **Other call sites.** The only other caller is `openMemoryStore()` in `cmd/denkeeper/sessions.go`, which shares the helper and is fixed by the same change. `passwd.go` does not touch the database (bcrypt only). `oauth_init.go` and the server path go through `config.Load` and were already correct.
- **Two adjacent gaps fixed here too**, both the same "CLI resolves paths differently than the server" defect and both one line. Flagging them explicitly since they were not in the original report — happy to split either out:
  - `DENKEEPER_MEMORY_DB_PATH` was ignored entirely (the server's highest-priority override).
  - With no `--config`, the helper called `config.DefaultConfigPath()` directly and ignored `DENKEEPER_CONFIG`; it now uses the existing `resolveConfigPath()` from `main.go`, so the CLI reads the same config file the server would.
- **Behaviour change worth noting:** a user who set `data_dir` and worked around this bug by also exporting `DENKEEPER_DATA_DIR` sees no change; a user relying on the buggy fallback pointing at `~/.denkeeper` will now correctly hit their configured instance.

## Tests

Five new cases in `cmd/denkeeper/keys_test.go`: `db_path` wins over `data_dir`; `data_dir` used when `db_path` absent; env data dir beats TOML `data_dir`; env `db_path` beats everything; default when neither is set.

Three pre-existing tests asserting the `~/.denkeeper` default now clear the env vars first — they would have failed on a machine with `DENKEEPER_DATA_DIR` exported.

All 10 `TestResolveDBPath_*` pass under `-race`; `just lint` and `just fmt-check` clean.