### PR TITLE
fix(website): actually enable docs search (flexSearch + search-index output)

### DIFF
--- a/website/config/_default/hugo.toml
+++ b/website/config/_default/hugo.toml
@@ -17,7 +17,15 @@ copyRight = "Copyright (c) 2025-2026 Temikus"
   enable = true
 
 [outputs]
-  home = ["HTML", "RSS"]
+  home = ["HTML", "RSS", "searchIndex"]
+
+# Feeds the theme's FlexSearch modal ([doks] flexSearch in params.toml);
+# rendered by the theme's home.searchindex.json layout.
+[outputFormats.searchIndex]
+  mediaType = "application/json"
+  baseName = "search-index"
+  isPlainText = true
+  notAlternative = true
 
 [sitemap]
   changefreq = "monthly"

--- a/website/config/_default/params.toml
+++ b/website/config/_default/params.toml
@@ -8,12 +8,23 @@ images = ["cover.png"]
   breadcrumb = true
   headlineAnchor = true
   scrollSpy = true
-  search = true
   colorMode = "auto"
   darkColorMode = true
   repo = "https://github.com/Temikus/denkeeper"
   editURL = "/edit/main/website/content"
   lastMod = false
+
+  # FlexSearch — needs the `searchIndex` output format in hugo.toml to feed it
+  flexSearch = true
+  searchExclKinds = [] # page kinds to exclude from the index
+  searchExclTypes = [] # content types to exclude from the index
+  showSearch = [] # [] = every page; otherwise "homepage" and/or section names
+  indexSummary = false # index full .Content rather than just .Summary
+
+  ## Search results
+  showDate = false
+  showSummary = true
+  searchLimit = 99
 
 [social]
   github = "https://github.com/Temikus/denkeeper"


### PR DESCRIPTION
## What

Docs-site search was declared but dead. `website/config/_default/params.toml` set `[doks] search = true`, but the Doks/Thulite theme reads `site.Params.doks.flexSearch` — there is no `search` param anywhere in the theme. Nothing rendered the search UI, and nothing produced an index for it to query.

The site's own header override (`website/layouts/_partials/header/header.html`) was already fully wired for FlexSearch — the toggle buttons and the modal are gated on exactly that param — so this is config-only.

## Changes

`params.toml`
- `search = true` → `flexSearch = true`
- Add the companion keys the theme's layouts dereference. `searchExclKinds` / `searchExclTypes` are read with `len` in `home.searchindex.json`, so they have to exist or the build errors; the rest (`showSearch`, `indexSummary`, `showDate`, `showSummary`, `searchLimit`) are set to upstream defaults so the behaviour is explicit rather than implied.

`hugo.toml`
- Add the `searchIndex` output format (`application/json`, `baseName = "search-index"`) and list it under `[outputs] home`. This is what renders the theme's `home.searchindex.json` layout to `/search-index.json`, which the client-side FlexSearch fetches on first query.

Both blocks match the upstream Doks starter config, so they stay in step with the theme.

## Verification

Local production build (`npm run build`):

- `public/search-index.json` emitted, 20 pages / 76 KB
- `searchModal`, `searchToggleDesktop`, `searchToggleMobile` present in the built HTML on both the home page and docs pages
- `flexsearch.*.js` and `search-modal.*.js` bundles loaded
- Served the build and drove the real UI: opening the modal and querying `telegram` returns 14 ranked results (Agents, Configuration Reference, Telegram Setup, …); `supervisor` returns Configuration Reference


🤖 Generated with [Claude Code](https://claude.com/claude-code)

