### PR TITLE
docs: retire the Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
   <a href="https://github.com/Temikus/denkeeper/actions/workflows/security.yml"><img src="https://github.com/Temikus/denkeeper/actions/workflows/security.yml/badge.svg" alt="Security"></a>
   <a href="https://github.com/Temikus/denkeeper/releases/latest"><img src="https://img.shields.io/github/v/release/Temikus/denkeeper?label=release" alt="Latest Release"></a>
   <a href="https://github.com/Temikus/denkeeper/pkgs/container/denkeeper"><img src="https://img.shields.io/github/v/release/Temikus/denkeeper?label=ghcr.io&logo=docker" alt="Docker Image"></a>
-  <a href="https://goreportcard.com/report/github.com/Temikus/denkeeper"><img src="https://goreportcard.com/badge/github.com/Temikus/denkeeper" alt="Go Report Card"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/Temikus/denkeeper" alt="License"></a>
   <a href="https://github.com/Temikus/denkeeper/actions/workflows/ci.yml"><img src="https://img.shields.io/badge/UI_coverage-enforced-blue" alt="UI Coverage"></a>
 </p>


### PR DESCRIPTION
goreportcard.com has been sunset, so the badge in the README no longer resolves. Removes the badge line; it was the only reference to the service in the repo (nothing in workflows, docs, or config pointed at it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)