### PR TITLE
fix(web): make the dry-run fire time pickable, and default it to now

### DIFF
--- a/web/src/components/SkillInvocation.svelte
+++ b/web/src/components/SkillInvocation.svelte
@@ -22,7 +22,6 @@
   let mode = $state('')
   let message = $state('')
   let args = $state('')
-  let asOf = $state('')
 
   // Mirrors the server's inference so the UI never disagrees with what it is
   // about to ask for.
@@ -36,19 +35,93 @@
     { id: 'command', label: 'As a command', disabled: !command },
   ])
 
-  function fireTime() {
-    return asOf ? new Date(asOf) : new Date()
+  // ---- Fire time ---------------------------------------------------------
+  //
+  // Every clock calculation below runs in the *agent's* zone, not the
+  // browser's: that is the zone the field is labelled with, the zone the
+  // scheduled header is stamped in, and the zone whose midnight decides which
+  // dated key the skill writes.
+
+  // An unresolvable zone would throw on every render, so a bad [api] timezone
+  // degrades to UTC instead of blanking the panel.
+  function resolveZone(tz) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: tz })
+      return tz
+    } catch {
+      return 'UTC'
+    }
   }
 
-  function isoWeek(d) {
-    const t = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()))
+  const zone = $derived(resolveZone(timezone))
+
+  // Wall-clock parts of an instant, as that zone reads them.
+  function zoneParts(d, tz) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, hourCycle: 'h23',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    }).formatToParts(d)
+    const p = {}
+    for (const { type, value } of parts) p[type] = value
+    return p
+  }
+
+  function nowIn(tz) {
+    const p = zoneParts(new Date(), tz)
+    return { date: `${p.year}-${p.month}-${p.day}`, time: `${p.hour}:${p.minute}` }
+  }
+
+  // Minutes east of UTC at a given instant — read back off the formatted wall
+  // time, so DST is handled without a table.
+  function zoneOffset(d, tz) {
+    const p = zoneParts(d, tz)
+    const wall = Date.UTC(+p.year, +p.month - 1, +p.day, +p.hour, +p.minute, +p.second)
+    return (wall - Math.floor(d.getTime() / 1000) * 1000) / 60000
+  }
+
+  // The instant a wall time in `tz` names. Solved twice because the first pass
+  // uses the offset in effect at the wrong instant — which only differs within
+  // an hour of a DST change, and the second pass lands the right side of it.
+  function instantIn(date, time, tz) {
+    const [y, mo, da] = date.split('-').map(Number)
+    const [h, mi] = time.split(':').map(Number)
+    const wall = Date.UTC(y, mo - 1, da, h, mi)
+    const first = wall - zoneOffset(new Date(wall), tz) * 60000
+    return new Date(wall - zoneOffset(new Date(first), tz) * 60000)
+  }
+
+  // Split across two native controls rather than one datetime-local: several
+  // browsers open a date-only popover for datetime-local, leaving the time half
+  // typable but not pickable. Defaults to now so the common case — preview this
+  // as if it fired right now — needs no input at all.
+  // A deliberate one-shot read: the default is "now, when you opened this",
+  // and the panel only mounts once the config that carries the zone has loaded.
+  // svelte-ignore state_referenced_locally
+  const initial = nowIn(resolveZone(timezone))
+  let asOfDate = $state(initial.date)
+  let asOfTime = $state(initial.time)
+
+  function resetToNow() {
+    const n = nowIn(zone)
+    asOfDate = n.date
+    asOfTime = n.time
+  }
+
+  // Both halves are required: browsers let either be cleared, and a half-filled
+  // pair means "unpinned", which is the server's own default.
+  const pinned = $derived(!!asOfDate && !!asOfTime)
+  const fireTime = $derived(pinned ? instantIn(asOfDate, asOfTime, zone) : new Date())
+
+  function isoWeek(y, m, d) {
+    const t = new Date(Date.UTC(y, m - 1, d))
     t.setUTCDate(t.getUTCDate() + 4 - (t.getUTCDay() || 7))
     const start = new Date(Date.UTC(t.getUTCFullYear(), 0, 1))
     return [t.getUTCFullYear(), Math.ceil(((t - start) / 86400000 + 1) / 7)]
   }
 
-  function offset(d) {
-    const m = -d.getTimezoneOffset()
+  function offset(d, tz) {
+    const m = zoneOffset(d, tz)
     const sign = m >= 0 ? '+' : '-'
     const p = n => String(Math.floor(Math.abs(n))).padStart(2, '0')
     return `${sign}${p(m / 60)}:${p(m % 60)}`
@@ -57,11 +130,10 @@
   // Rendered client-side purely so the user can see what will be sent before
   // spending tokens; the server builds the real one via FormatScheduledText.
   function scheduledHeader() {
-    const d = fireTime()
-    const p = n => String(n).padStart(2, '0')
-    const stamp = `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T` +
-      `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}${offset(d)}`
-    const [y, w] = isoWeek(d)
+    const p = zoneParts(fireTime, zone)
+    const stamp = `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}:${p.second}` +
+      offset(fireTime, zone)
+    const [y, w] = isoWeek(+p.year, +p.month, +p.day)
     return `[Scheduled: ${skill.name} | ${stamp} ${timezone} | ${y}-W${String(w).padStart(2, '0')}]`
   }
 
@@ -82,7 +154,7 @@
       mode: effectiveMode,
       ...(effectiveMode === 'message' ? { message } : {}),
       ...(effectiveMode === 'command' && args.trim() ? { args: args.trim() } : {}),
-      ...(asOf ? { as_of: new Date(asOf).toISOString() } : {}),
+      ...(pinned ? { as_of: fireTime.toISOString() } : {}),
     })
   }
 </script>
@@ -108,8 +180,15 @@
 
   {#if effectiveMode === 'schedule'}
     <div class="row">
-      <label class="row-label" for="dry-run-asof">Fire time</label>
-      <input id="dry-run-asof" type="datetime-local" bind:value={asOf} />
+      <label class="row-label" for="dry-run-asof-date">Fire time</label>
+      <div class="datetime">
+        <input id="dry-run-asof-date" type="date" bind:value={asOfDate}
+          aria-label="Fire date" />
+        <input id="dry-run-asof-time" type="time" bind:value={asOfTime}
+          aria-label="Fire time of day" />
+        <button class="btn-sm" onclick={resetToNow}
+          title="Reset to the current time in {timezone}">Now</button>
+      </div>
       <span class="hint">{timezone} &middot; pins dated keys the skill writes</span>
     </div>
   {:else if effectiveMode === 'command'}
@@ -166,6 +245,19 @@
 
   .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .row-label { font-size: 12px; color: var(--text-muted); }
+
+  .datetime { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+  .datetime input {
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: var(--radius); color: var(--text);
+    padding: 6px 10px; font-size: 13px; font-family: inherit;
+  }
+  .datetime input:focus { outline: none; border-color: var(--accent); }
+  /* Native pickers draw their own chrome — tell them which theme they are in,
+     or the popover and its indicator icon come back light on a dark page. */
+  .datetime input { color-scheme: light; }
+  :global(:root.dark) .datetime input { color-scheme: dark; }
+  .datetime .btn-sm { margin-right: 0; }
 
   .command-row {
     display: flex; align-items: stretch;

--- a/web/src/components/__tests__/SkillInvocation.test.js
+++ b/web/src/components/__tests__/SkillInvocation.test.js
@@ -60,6 +60,79 @@ describe('SkillInvocation', () => {
     expect(outgoing).toMatch(/\d{4}-W\d{2}\]$/)
   })
 
+  // Empty defaults made the common case — "run this as if it fired now" — an
+  // act of typing, and left the header preview claiming a time nothing sent.
+  test('fire time defaults to now in the agent timezone', () => {
+    render(SkillInvocation, {
+      props: { skill: scheduled, timezone: 'Australia/Sydney', onrun: vi.fn() },
+    })
+
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'Australia/Sydney', hourCycle: 'h23',
+      year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit',
+    }).formatToParts(new Date()).reduce((a, p) => ({ ...a, [p.type]: p.value }), {})
+
+    expect(screen.getByLabelText('Fire date')).toHaveValue(
+      `${parts.year}-${parts.month}-${parts.day}`)
+    expect(screen.getByLabelText('Fire time of day')).toHaveValue(
+      `${parts.hour}:${parts.minute}`)
+  })
+
+  // datetime-local opens a date-only popover in several browsers, so the time
+  // was typable but not pickable. Two controls, both with a native picker.
+  test('the time of day is its own control, and moves the previewed header', async () => {
+    const { container } = render(SkillInvocation, {
+      props: { skill: scheduled, timezone: 'Australia/Sydney', onrun: vi.fn() },
+    })
+
+    await fireEvent.input(screen.getByLabelText('Fire date'), { target: { value: '2026-08-11' } })
+    await fireEvent.input(screen.getByLabelText('Fire time of day'), { target: { value: '01:00' } })
+
+    // Stamped in the agent's zone (+10:00 in August), not the browser's — the
+    // zone the label names is the one whose midnight rolls the dated key.
+    expect(container.querySelector('.outgoing-body')).toHaveTextContent(
+      '[Scheduled: hello | 2026-08-11T01:00:00+10:00 Australia/Sydney | 2026-W33]')
+
+    await fireEvent.input(screen.getByLabelText('Fire time of day'), { target: { value: '23:30' } })
+    expect(container.querySelector('.outgoing-body')).toHaveTextContent('2026-08-11T23:30:00+10:00')
+  })
+
+  test('the chosen fire time is sent as the instant it names in that zone', async () => {
+    const onrun = vi.fn()
+    render(SkillInvocation, {
+      props: { skill: scheduled, timezone: 'Australia/Sydney', onrun },
+    })
+
+    await fireEvent.input(screen.getByLabelText('Fire date'), { target: { value: '2026-08-11' } })
+    await fireEvent.input(screen.getByLabelText('Fire time of day'), { target: { value: '01:00' } })
+    await fireEvent.click(screen.getByText('Run'))
+
+    expect(onrun).toHaveBeenCalledWith(expect.objectContaining({
+      as_of: '2026-08-10T15:00:00.000Z',
+    }))
+  })
+
+  // Browsers let either half be cleared; a half-filled pair is not a time.
+  test('clearing the date unpins the clock instead of sending a partial one', async () => {
+    const onrun = vi.fn()
+    render(SkillInvocation, { props: { skill: scheduled, timezone: 'UTC', onrun } })
+
+    await fireEvent.input(screen.getByLabelText('Fire date'), { target: { value: '' } })
+    await fireEvent.click(screen.getByText('Run'))
+
+    expect(onrun.mock.calls[0][0].as_of).toBeUndefined()
+  })
+
+  test('Now resets a fiddled-with fire time', async () => {
+    render(SkillInvocation, { props: { skill: scheduled, timezone: 'UTC', onrun: vi.fn() } })
+
+    await fireEvent.input(screen.getByLabelText('Fire date'), { target: { value: '2020-01-01' } })
+    await fireEvent.click(screen.getByText('Now'))
+
+    const today = new Date().toISOString().slice(0, 10)
+    expect(screen.getByLabelText('Fire date')).toHaveValue(today)
+  })
+
   test('shows the command with its arguments as it will be sent', async () => {
     const { container } = render(SkillInvocation, { props: { skill: commanded, onrun: vi.fn() } })
 

--- a/web/src/pages/Skills.svelte
+++ b/web/src/pages/Skills.svelte
@@ -37,7 +37,8 @@
       const [skillsRes, agentsRes, cfg] = await Promise.all([
         api.skills().catch(() => []),
         api.agents().catch(() => []),
-        // Only used to label the scheduled-run fire time; a miss is cosmetic.
+        // The zone the scheduled-run fire time is picked in, so a miss falls
+        // back to UTC rather than to the browser's zone.
         api.serverConfig().catch(() => null),
       ])
       skills = skillsRes || []


### PR DESCRIPTION
The skill dry-run "Fire time" field was a single datetime-local that opened
a date-only popover in several browsers, so the time half was typable but
not pickable, and it started empty — the commonest preview ("run this as if
it fired right now") required typing a full timestamp before it would say
anything true.

Split it into a date and a time input, each with its own native picker, and
default both to now. A "Now" button resets after fiddling; clearing either
half unpins the clock, which is the server's own default (as_of omitted).

The clock work now runs in the agent's timezone rather than the browser's.
The field was always labelled with the agent's zone, but the previewed
[Scheduled: ...] header was stamped with the browser's UTC offset and the
sent as_of interpreted the typed wall time as browser-local — a mismatch
that was invisible while the two zones agreed, and silently pinned the wrong
instant when they didn't. Offsets are read back off Intl-formatted wall time
so DST needs no table, and the wall-time-to-instant solve runs twice so a
fire time within an hour of a DST change lands the right side of it.

Also theme the inputs, which were unstyled browser defaults, and set
color-scheme so the native pickers and their indicator icons follow dark
mode.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Un3iomkSrxbUGz5LLvXJhD