### PR TITLE
chore(deps): bump pinned Go toolchain to 1.26.6

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.5"
+go = "1.26.6"
 hugo-extended = "0.164.0"
 "golangci-lint" = "2.12.2"
 swag = "1.16.6"


### PR DESCRIPTION
## Why

`govulncheck` is currently failing on **every** branch, not just one. The pinned `go1.26.5` in `.mise.toml` carries six standard-library advisories, all fixed in `go1.26.6`:

| Advisory | Package | Issue |
|---|---|---|
| GO-2026-6218 | `net/url` | quadratic complexity in `resolvePath` |
| GO-2026-6091 | `html/template` | JS regexp context |
| GO-2026-6090 | `crypto/tls` | handshake message limits |
| GO-2026-6089 | `net/http` | `ReadHeaderTimeout` for unencrypted HTTP/2 |
| GO-2026-5972 | `encoding/asn1` | recursion depth |
| GO-2026-5026 | `x/net/idna` | punycode validation |

These are symbol-level findings with traces into real call paths (the `net/url` one reaches `http.Client.Do` from provider health checks), so they are genuine rather than unused-code noise.

## Scope

`.mise.toml` is the only Go version pin in the repo — CI derives `GOROOT` from mise, and `go.mod` declares the language version (`go 1.26.2`), which needs no change.

## Verification

On 1.26.6 locally:

- `govulncheck ./...` → *No vulnerabilities found. Your code is affected by 0 vulnerabilities.*
- `JUST_HOOK_FORCE=1 just hook` → fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check all green on the new toolchain.

Merging this unblocks CI for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZAmipoRHZbxKn2Cj5ARRh