### PR TITLE
fix(web): stop the tier badge stretching when agent card meta wraps

### DIFF
--- a/web/src/pages/Overview.svelte
+++ b/web/src/pages/Overview.svelte
@@ -228,8 +228,12 @@
   }
   .agent-card:hover { border-color: var(--accent); }
   .agent-name { font-weight: 600; margin-bottom: 6px; }
-  .agent-meta { display: flex; gap: 10px; font-size: 12px; color: var(--text-muted); margin-bottom: 4px; }
-  .tier { background: var(--border); padding: 2px 8px; border-radius: 10px; }
+  .agent-meta {
+    display: flex; flex-wrap: wrap; align-items: center; gap: 4px 10px;
+    font-size: 12px; color: var(--text-muted); margin-bottom: 4px;
+  }
+  .agent-meta > span { white-space: nowrap; }
+  .tier { flex: none; background: var(--border); padding: 2px 8px; border-radius: 10px; }
   .agent-model { font-size: 11px; color: var(--text-muted); font-family: monospace; }
   .loading { color: var(--text-muted); }
 


### PR DESCRIPTION
## Problem

On the Overview page's agent cards, the permission-tier badge could render as an oversized lozenge roughly twice its normal height, with the neighbouring meta text broken mid-phrase (`0 / skills`, `has / tools`).

It looked like a bug specific to the `autonomous` tier, because that is where it shows up first — but the tier word is only what tips it over.

## Cause

`.agent-meta` was a non-wrapping flex row:

```css
.agent-meta { display: flex; gap: 10px; ... }
.tier { background: var(--border); padding: 2px 8px; border-radius: 10px; }
```

Every child is a flex item with the default `flex-shrink: 1`, so once the row exceeds the card width they all shrink below their content width and the text inside them wraps between words. That makes the row two lines tall — and `.tier`, under the default `align-items: stretch`, grows to match the full row height.

Whether it triggers depends on the *rendered width* of the tier word, so `autonomous` breaks at card widths where the narrower `supervised` still fits on one line. Same card width, different outcome — which is exactly what the report showed.

## Fix

Let the row wrap as whole items instead of letting items shrink and break internally:

- `flex-wrap: wrap` + a 4px row gap — overflow moves to a second line
- `align-items: center` and `flex: none` on `.tier` — the badge keeps its intrinsic height and is never squeezed
- `white-space: nowrap` on the meta spans — `0 skills` / `has tools` move down as units rather than splitting between words

## Verification

Reproduced the glitch in isolation with the page's exact CSS at card widths of 190px and 210px (the wrapped meta text and the stretched pill both appear), then confirmed the patched CSS renders a normal-height badge with clean wrapping at the same widths, and is unchanged at full width.

`just hook` passes (fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check); 841 web UI tests green.

No test added: this is a pure layout regression and the UI suite runs on jsdom, which has no layout engine — an assertion there could not observe the stretched badge.