### PR TITLE
docs(website): fix broken links, wrong defaults, and stale claims

### DIFF
--- a/website/content/docs/concepts/built-in-tools.md
+++ b/website/content/docs/concepts/built-in-tools.md
@@ -2,7 +2,7 @@
 title: "Built-in Tools"
 description: "Web search and fetch, JavaScript execution, the KV store, and browser automation."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 35
 toc: true
@@ -111,4 +111,4 @@ A browser with a persistent profile is the most powerful capability an agent can
 
 Identical calls to *idempotent* tools are memoized within a single turn — see [Tools (MCP)](/docs/concepts/tools-mcp/). Of the built-ins, `web_search`, `web_fetch`, `kv_get`, and `kv_list` are cache-eligible. `run_javascript` deliberately is not.
 
-See the [configuration reference](/docs/reference/configuration-reference/) for every option in `[web]`, `[script]`, `[kv]`, and `[browser]`.
+See the [configuration reference](/docs/reference/config/) for every option in `[web]`, `[script]`, `[kv]`, and `[browser]`.

--- a/website/content/docs/concepts/channels.md
+++ b/website/content/docs/concepts/channels.md
@@ -2,7 +2,7 @@
 title: "Channels"
 description: "Named routing endpoints that decouple conversations from adapter bindings."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 15
 toc: true
@@ -83,4 +83,4 @@ Channels are reachable from every surface:
 - **Config MCP** — agents can call `channel_list`, `channel_info`, and `channel_switch`.
 - **Dashboard** — the Channels page.
 
-See the [configuration reference](/docs/reference/configuration-reference/) for the full `[[channels]]` schema.
+See the [configuration reference](/docs/reference/config/) for the full `[[channels]]` schema.

--- a/website/content/docs/concepts/security.md
+++ b/website/content/docs/concepts/security.md
@@ -2,7 +2,7 @@
 title: "Security"
 description: "Denkeeper's security model: threat model, permissions, and sandboxing."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-04-03T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 50
 toc: true
@@ -22,6 +22,9 @@ Every capability in Denkeeper is opt-in. The agent starts with zero permissions 
 | Cost runaway | Per-session budget caps, global cost tracking, automatic fallback to cheaper models |
 | Plugin escape | Subprocess isolation and sandboxed execution via Docker (`--cap-drop ALL`, `--read-only`, `--network none`) or Kubernetes (ephemeral Pods with init-container network isolation, Pod Security Admission, optional gVisor/Kata); Ed25519 signature verification |
 | Config file secrets | File permissions (`0o600`), environment variable expansion for secrets |
+| SSRF via remote MCP tool servers or the browser tool | Connect-time IP blocking of link-local, loopback, and cloud-metadata addresses, plus an optional hostname allowlist |
+| Secret leakage into stdio MCP subprocesses | Children do not inherit the parent environment — they get a fixed non-secret allowlist; any `DENKEEPER_*` or otherwise denylisted name is blocked even if explicitly passed through |
+| Skill file writes escaping the skills directory | Skill writes are confined to the agent's skills directory at the OS level (Go's `os.Root`), backstopping name validation against `..` traversal and symlink escapes |
 
 Every consequential decision — tool calls, approvals, supervisor verdicts, config changes — is recorded in the audit log. See [Observability](/docs/concepts/observability/) for what is captured and how to query it.
 
@@ -49,6 +52,18 @@ The REST API uses scoped bearer tokens with constant-time comparison:
 - Per-key rate limiting via token bucket
 - Optional TLS with configurable cert/key
 - CORS origin allowlist
+
+## MCP tool security
+
+Denkeeper connects outward to MCP servers to give agents external tools (see [Tools](/docs/concepts/tools/)). A few isolation properties apply specifically to that boundary:
+
+**OAuth 2.1 for remote servers** — a tool can be configured with `auth = "oauth"` (plus optional `client_id`/`client_secret`/`scopes`) to authenticate against a remote SSE MCP server using the standard Authorization Code flow. Tokens are stored in SQLite, not the config file, and the callback routes live at `/api/v1/tools/{name}/oauth/...`.
+
+**Stdio subprocess environment scoping** — a stdio MCP server does not inherit Denkeeper's process environment. It receives only a built-in non-secret allowlist (`PATH`, `HOME`, language-runtime variables, etc.) plus the tool's own configured `env`. `env_passthrough` on `[mcp]` or a specific `[tools.*]` entry can forward additional names, but a hard denylist — every `DENKEEPER_*` variable plus a fixed list of other secret-shaped names — is enforced even on explicit passthrough entries, so a misconfigured tool cannot pull API keys or tokens out of the parent process.
+
+**Tool name collisions never silently merge** — if two connected servers advertise the same tool name, neither keeps the bare name. Both are re-advertised as `<server>__<tool>` and the bare name becomes unroutable, so a call can never be silently misrouted to the wrong server's tool.
+
+**Skill file writes are hardened** — every skill create/update/delete goes through an OS-level `os.Root` confined to the agent's skills directory (blocking `..` traversal and symlink escapes), writes land via a randomized, exclusively-created temp file and an atomic rename, and a configurable per-file byte cap (`[skills] max_bytes`, 1 MiB by default) bounds how much a single skill write can grow the file.
 
 ## Dashboard authentication
 

--- a/website/content/docs/concepts/sessions.md
+++ b/website/content/docs/concepts/sessions.md
@@ -2,7 +2,7 @@
 title: "Sessions & Permissions"
 description: "Permission tiers, session management, and approval workflows."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 40
 toc: true
@@ -15,7 +15,7 @@ Every agent session operates in one of three tiers:
 | Tier | Capabilities |
 |---|---|
 | **Autonomous** | All capabilities — intended for sandboxed environments |
-| **Supervised** | Chat, memory, tools. Self-modification actions (create skills, modify schedules, update USER.md) require human approval |
+| **Supervised** | Chat, memory, tools. Every tool call requires approval — an auto-approve rule, a supervisor LLM decision, or a human — before it runs. Self-modification actions (create skills, modify schedules, update USER.md) are one case of this, not the whole story |
 | **Restricted** | Chat and read-only tools only. No memory writes beyond MEMORY.md |
 
 Set the default tier globally:
@@ -35,7 +35,7 @@ session_tier = "restricted"
 
 ## Approval workflows
 
-In supervised mode, actions like skill creation or schedule modification produce an approval request. The user is notified via Telegram (inline keyboard with Approve/Deny buttons) or the REST API.
+In supervised mode, every tool call — not just self-modification actions like skill creation or schedule modification — produces an approval request unless an auto-approve rule or supervisor already resolved it. The user is notified via Telegram (inline keyboard with Approve/Deny buttons) or the REST API.
 
 Approval requests have a 24-hour TTL. Unapproved requests expire automatically.
 

--- a/website/content/docs/concepts/supervisors.md
+++ b/website/content/docs/concepts/supervisors.md
@@ -3,7 +3,7 @@ title: "Supervisors & Auto-Approval"
 description: "Letting an LLM reviewer, or a standing rule, answer approval prompts for you."
 slug: "supervisors"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 45
 toc: true
@@ -114,4 +114,4 @@ The reviewer is **capability-reduced, not supervised** — a deliberate design c
 It runs at the `supervised` tier rather than `restricted`, because `restricted` omits tool use altogether and would block every call it needs to make.
 {{< /callout >}}
 
-See the [configuration reference](/docs/reference/configuration-reference/) for every supervisor and reviewer knob.
+See the [configuration reference](/docs/reference/config/) for every supervisor and reviewer knob.

--- a/website/content/docs/concepts/tools.md
+++ b/website/content/docs/concepts/tools.md
@@ -2,7 +2,7 @@
 title: "Tools (MCP)"
 description: "External tool servers connected via the Model Context Protocol."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 30
 toc: true
@@ -103,9 +103,9 @@ Plugins extend the agent with external processes. Two execution strategies are a
   - **Docker** (default) — `docker run -i --rm` with `--cap-drop ALL`, `--read-only`, `--network none`
   - **Kubernetes** — ephemeral Pods with init-container network isolation, dropped capabilities, read-only root filesystem, Pod Security Admission labels, and optional gVisor/Kata RuntimeClass
 
-Select the sandbox backend in config with `[sandbox] runtime = "docker"` or `"kubernetes"`. See the [config reference](/docs/reference/configuration-reference/) for all sandbox options.
+Select the sandbox backend in config with `[sandbox] runtime = "docker"` or `"kubernetes"`. See the [config reference](/docs/reference/config/) for all sandbox options.
 
-Subprocess plugins can optionally be verified with Ed25519 signatures. Use `denkeeper plugin keygen/sign/verify` to manage signing keys and signatures. See the [security](/docs/concepts/security/), [CLI reference](/docs/reference/cli-reference/), and [config reference](/docs/reference/configuration-reference/) pages for details.
+Subprocess plugins can optionally be verified with Ed25519 signatures. Use `denkeeper plugin keygen/sign/verify` to manage signing keys and signatures. See the [security](/docs/concepts/security/), [CLI reference](/docs/reference/cli/), and [config reference](/docs/reference/config/) pages for details.
 
 ## OAuth 2.1 for remote tools
 

--- a/website/content/docs/getting-started/configuration.md
+++ b/website/content/docs/getting-started/configuration.md
@@ -2,7 +2,7 @@
 title: "Configuration"
 description: "Overview of Denkeeper's TOML configuration file."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 30
 toc: true
@@ -140,4 +140,4 @@ env = { API_KEY = "$MY_SECRET" }
 
 Denkeeper validates the config on startup using a three-phase pattern: parse TOML, apply defaults, then validate. If validation fails, the process exits with a descriptive error message and a suggested fix.
 
-See the [full configuration reference](/docs/reference/configuration-reference/) for every option.
+See the [full configuration reference](/docs/reference/config/) for every option.

--- a/website/content/docs/getting-started/first-run.md
+++ b/website/content/docs/getting-started/first-run.md
@@ -2,7 +2,7 @@
 title: "First Run"
 description: "Create your first Denkeeper configuration and connect to Telegram."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 20
 toc: true
@@ -93,4 +93,4 @@ When running as a systemd service:
 journalctl -u denkeeper -f
 ```
 
-Next: [Configuration reference](/docs/reference/configuration-reference/) for the full list of options.
+Next: [Configuration reference](/docs/reference/config/) for the full list of options.

--- a/website/content/docs/getting-started/installation.md
+++ b/website/content/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 title: "Installation"
 description: "How to install the Denkeeper binary on Linux and macOS."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 10
 toc: true
@@ -25,7 +25,7 @@ curl -fsSL https://get.denkeeper.io | sh -s -- --version v0.0.1
 ## Homebrew (macOS)
 
 ```bash
-brew install Temikus/tap/denkeeper
+brew install Temikus/denkeeper/denkeeper
 ```
 
 ## Linux packages

--- a/website/content/docs/guides/discord-setup.md
+++ b/website/content/docs/guides/discord-setup.md
@@ -2,7 +2,7 @@
 title: "Discord Setup"
 description: "Connect Denkeeper to Discord with a bot application and user allowlist."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 15
 toc: true
@@ -51,7 +51,9 @@ The environment variable takes precedence over the TOML value, which is the usua
 
 **Approval buttons** — approval requests arrive as messages with Approve/Deny action-row buttons; resolving one is a click, not a reply.
 
-**Voice** — incoming voice messages are transcribed when `[voice]` is configured.
+{{< callout context="note" >}}
+Voice transcription is Telegram-only — the Discord adapter has no voice/STT/TTS support.
+{{< /callout >}}
 
 {{< callout context="note" >}}
 The Discord adapter does **not** register slash commands. Telegram publishes `/start`, `/help`, `/clear` and the rest into its command picker, and adds skill `command:` triggers to it; on Discord those commands are not advertised.

--- a/website/content/docs/guides/mcp-server.md
+++ b/website/content/docs/guides/mcp-server.md
@@ -3,7 +3,7 @@ title: "Denkeeper as an MCP Server"
 description: "Expose your instance to other MCP clients — Claude Code, IDEs, or another agent."
 slug: "mcp-server"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 40
 toc: true
@@ -91,4 +91,4 @@ Enable TLS, or keep the port on a trusted network. Prefer several narrow keys ov
 
 Sessions are tracked by default and cleaned up after `session_timeout`. Set `stateless = true` for clients that do not keep a session, at the cost of per-session context.
 
-See the [configuration reference](/docs/reference/configuration-reference/) for every `[api.mcp_server]` option.
+See the [configuration reference](/docs/reference/config/) for every `[api.mcp_server]` option.

--- a/website/content/docs/reference/config.md
+++ b/website/content/docs/reference/config.md
@@ -2,7 +2,7 @@
 title: "Configuration Reference"
 description: "Complete reference for denkeeper.toml options."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 10
 toc: true
@@ -36,7 +36,7 @@ All configuration lives in a single TOML file. Default location: `~/.denkeeper/d
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `default_provider` | string | `"openrouter"` | Name of the provider instance to use by default (must match a configured instance name) |
-| `default_model` | string | — | Model identifier (format depends on provider) |
+| `default_model` | string | `"anthropic/claude-sonnet-4-20250514"` | Model identifier (format depends on provider) |
 | `cost_limit_soft` | float | `0` | Soft cost limit per session in USD (warns but continues) |
 | `cost_limit_hard` | float | `1.0` | Hard cost limit per session in USD (stops generation) |
 
@@ -195,8 +195,8 @@ Users switch channels at runtime with `/session <name>`; the selection is persis
 | `retention_days` | int | `90` | How long conversations are kept. 0 = unlimited |
 | `max_conversations` | int | `10000` | Cap on stored conversations. 0 = unlimited |
 | `cleanup_interval` | string | `"1h"` | How often retention is enforced |
-| `persona_memory_char_limit` | int | `0` | Cap on `MEMORY.md` size in characters. 0 = unlimited |
-| `persona_user_char_limit` | int | `0` | Cap on `USER.md` size in characters. 0 = unlimited |
+| `persona_memory_char_limit` | int | `2200` | Cap on `MEMORY.md` size in characters. `0` in TOML falls back to this default — there is currently no way to request an unlimited cap |
+| `persona_user_char_limit` | int | `1375` | Cap on `USER.md` size in characters. `0` in TOML falls back to this default — there is currently no way to request an unlimited cap |
 
 ## `[log]`
 
@@ -392,6 +392,7 @@ Note the direction: `[tools.*]` is Denkeeper connecting *outward* to MCP servers
 | `channel` | string | — | Delivery channel (e.g., `"telegram:12345"`) |
 | `tags` | string[] | — | Freeform labels |
 | `enabled` | bool | `true` | Enable/disable without removing |
+| `session_mode` | string | `"shared"` | `"shared"` reuses the target channel's existing conversation history; `"isolated"` starts a fresh conversation with no prior context for each run. Note: schedules created via `POST /schedules` default to `"isolated"` instead — the default differs by creation path |
 
 ## `[plugins.*]`
 
@@ -458,6 +459,11 @@ Global settings that apply to all MCP tool servers.
 | `restart_cooldown` | string | `"5m"` | Duration a server must stay connected to reset the failure counter |
 | `drain_timeout` | string | `"35s"` | How long teardown waits for in-flight tool calls before forcing the transport closed |
 | `url_allowlist` | string[] | — | Allowed hostnames/wildcards for SSE tool server URLs (empty = all non-blocked hosts) |
+| `health_fail_threshold` | int | `3` | Consecutive health-probe failures before a `health_fail` audit event fires for remote (sse/http) servers. Stdio servers always emit on the first failure |
+| `init_retry_attempts` | int | `5` | Retries for a server's initial connection attempt |
+| `init_retry_backoff` | string | `"2s"` | Base backoff duration between initial-connection retries |
+| `sse_keep_alive_secs` | int | `15` | TCP keepalive interval for SSE connections (overridable per server) |
+| `env_passthrough` | string[] | — | Extra parent-process environment variable names forwarded to stdio server subprocesses, on top of the built-in non-secret allowlist. `DENKEEPER_*` and other denylisted names are always blocked, even here |
 
 Removing, disabling, restarting or reconfiguring a tool server tears it down in
 two phases. The server stops being offered immediately — its tools leave the

--- a/website/content/docs/reference/rest-api.md
+++ b/website/content/docs/reference/rest-api.md
@@ -2,7 +2,7 @@
 title: "REST API Reference"
 description: "HTTP API endpoints for external integrations."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-14T00:00:00+00:00
 draft: false
 weight: 30
 toc: true
@@ -317,7 +317,7 @@ Replace a persona section's contents.
 
 ## Channels
 
-Named routing endpoints. See the [config reference](/docs/reference/configuration-reference/) for the `[[channels]]` schema.
+Named routing endpoints. See the [config reference](/docs/reference/config/) for the `[[channels]]` schema.
 
 ### `GET /api/v1/channels`
 

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -82,7 +82,7 @@
         </div>
         <p class="mt-4 mb-3">Or via Homebrew:</p>
         <div class="install-command text-start">
-          {{- highlight "brew install Temikus/tap/denkeeper" "bash" "" -}}
+          {{- highlight "brew install Temikus/denkeeper/denkeeper" "bash" "" -}}
         </div>
         <p class="mt-4">Or grab a <code>.deb</code>/<code>.rpm</code> package from the <a href="https://github.com/Temikus/denkeeper/releases">releases page</a>.</p>
         <a class="btn btn-primary rounded-pill btn-lg mt-3" href="/docs/getting-started/installation/" role="button">Read the guide</a>

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -176,13 +176,12 @@ fi
 
 # ── Done ─────────────────────────────────────────────────────────────────────
 
-INSTALLED_VERSION="$("${INSTALL_DIR}/denkeeper" --version 2>/dev/null || echo "${VERSION}")"
+INSTALLED_VERSION="$("${INSTALL_DIR}/denkeeper" version 2>/dev/null | head -n1 | awk '{print $NF}' || echo "${VERSION}")"
 
 printf '\n'
 info "denkeeper ${INSTALLED_VERSION} installed to ${INSTALL_DIR}/denkeeper"
 printf '\n'
 log "Get started:"
-log "  denkeeper setup       # first-run configuration wizard"
-log "  denkeeper serve       # start the agent"
+log "  denkeeper serve       # start the agent (first run opens the setup wizard)"
 log ""
 log "Documentation: https://github.com/${REPO}"


### PR DESCRIPTION
## Summary

Periodic staleness/accuracy sweep of the marketing + docs website (`website/`) against the current codebase. Grouped by category:

**Broken links** — 9 internal links across 8 pages pointed at nonexistent permalinks (`/docs/reference/configuration-reference/`, `/docs/reference/cli-reference/`) instead of the real ones (`/docs/reference/config/`, `/docs/reference/cli/`). Every "See the config reference" / "CLI reference" pointer on the site was a 404.

**Install flow** — the Homebrew command (homepage hero + installation guide) referenced a nonexistent `Temikus/tap/denkeeper` tap; the real tap is `Temikus/denkeeper/denkeeper` per `.goreleaser.yaml`'s `homebrew_casks` config (matches `README.md`, which already had it right). `install.sh` printed `denkeeper setup` as a next step — that subcommand doesn't exist, so a user following the installer's own output would immediately hit "unknown command". It also verified the install with a `--version` flag that doesn't exist on the binary (only a `version` subcommand does), so the "installed version" confirmation was silently falling back to the requested version instead of actually checking the binary.

**`reference/config.md`** — 4 real drifts from `internal/config/config.go`:
- `default_model` showed no default; code sets `"anthropic/claude-sonnet-4-20250514"` when unset.
- `persona_memory_char_limit` / `persona_user_char_limit` claimed `0` = unlimited; code actually rewrites `0` to `2200`/`1375` — there's currently no way to get unlimited via this key.
- `[[schedules]]` was missing `session_mode` entirely, including that its default differs by creation path: `"shared"` for TOML-loaded schedules, `"isolated"` for schedules created via `POST /schedules`.
- `[mcp]` was missing five keys that exist with real defaults and meaningful behavior (`health_fail_threshold`, `init_retry_attempts`, `init_retry_backoff`, `sse_keep_alive_secs`, `env_passthrough`).

**`concepts/security.md`** — hadn't been touched since April while `tools.md` and others moved on through August. Added coverage for mitigations that exist in code but weren't mentioned anywhere on the page: SSRF protection (connect-time IP blocking for remote MCP servers and the browser tool), MCP OAuth 2.1, stdio subprocess environment scoping (`DENKEEPER_*`/denylist backstop even on explicit passthrough), tool-name collision qualification, and skill-file write hardening (`os.Root` confinement, atomic rename, per-file byte cap).

**`concepts/sessions.md`** — the permission-tier table implied only "self-modification actions" (skill creation, schedule edits, etc.) need approval in supervised tier. Actually every tool call goes through the approval chain (auto-approve → supervisor → human); self-modification is one case of that, not the whole story.

**`guides/discord-setup.md`** — claimed voice messages are transcribed when `[voice]` is configured. Confirmed against `internal/adapter/discord/discord.go`: there's no voice/STT/TTS support in the Discord adapter at all — that's Telegram-only.

All reference/CLI/REST-API docs I could cross-check the other way (i.e. things the docs claimed that code backs up) checked out clean — `cli.md`, `rest-api.md`, `getting-started/*`, `llms.txt`/`llms-full.txt`, and most of `concepts/*` matched the implementation.

## Test plan

- [x] Cross-checked every changed claim against the corresponding Go source (`internal/config/config.go`, `internal/adapter/discord/`, `.goreleaser.yaml`, `cmd/denkeeper/main.go`) before editing.
- [x] `grep`-verified no remaining `configuration-reference`/`cli-reference` link targets in `website/content/`.
- [x] Ran `npx prettier --check` on every edited markdown file; pre-existing warnings (table width) confirmed present on `main` too, not introduced by this change.
- [ ] `hugo --minify --gc` site build could not be verified in this sandbox (fails on `Dart Sass` not being installed, unrelated to content — confirmed the same failure occurs on `main` before these changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pp1Q7jFreQFWKnAhWsQXgy)_