### PR TITLE
fix(web): read ModelInfo pricing fields in DryRunPanel price label

### DIFF
--- a/web/src/components/DryRunPanel.svelte
+++ b/web/src/components/DryRunPanel.svelte
@@ -36,10 +36,12 @@
 
   function modelLabel(id) { return id || liveModel || 'live model' }
 
+  // `GET /models/details` returns llm.ModelInfo: top-level `input_per_mtok` /
+  // `output_per_mtok`, null when pricing is unknown.
   function priceOf(id) {
     const m = models.find(x => x.id === id || x.name === id)
-    if (!m?.pricing) return ''
-    const { input, output } = m.pricing
+    if (!m) return ''
+    const { input_per_mtok: input, output_per_mtok: output } = m
     if (input == null || output == null) return ''
     return `$${Number(input).toFixed(2)} / $${Number(output).toFixed(2)}`
   }

--- a/web/src/components/__tests__/DryRunPanel.test.js
+++ b/web/src/components/__tests__/DryRunPanel.test.js
@@ -10,10 +10,12 @@ beforeEach(() => {
   token.set('test-key')
   authMode.set('token')
   server.use(
+    // Real shape: llm.ModelInfo — top-level *_per_mtok, null = pricing unknown.
     http.get('/api/v1/models/details', () => HttpResponse.json({
       models: [
-        { id: 'moonshotai/kimi-k3', pricing: { input: 0.8, output: 3.2 } },
-        { id: 'openai/gpt-4o-mini', pricing: { input: 0.15, output: 0.6 } },
+        { id: 'moonshotai/kimi-k3', name: 'Kimi K3', provider: 'openrouter', input_per_mtok: 0.8, output_per_mtok: 3.2, supports_tools: true, weekly_tokens: 0 },
+        { id: 'openai/gpt-4o-mini', name: 'GPT-4o mini', provider: 'openrouter', input_per_mtok: 0.15, output_per_mtok: 0.6, supports_tools: true, weekly_tokens: 0 },
+        { id: 'local/mystery', name: 'Mystery', provider: 'ollama', input_per_mtok: null, output_per_mtok: null, supports_tools: false, weekly_tokens: 0 },
       ],
     })),
   )
@@ -136,6 +138,21 @@ describe('DryRunPanel', () => {
       const option = await screen.findByRole('option', { name: new RegExp(model) })
       await fireEvent.click(option)
     }
+
+    // Regression: priceOf() used to read a `pricing` object the endpoint never
+    // returns, so the label was always empty. Known pricing must render, and
+    // null (unknown) must stay blank rather than showing "$NaN".
+    test('shows per-model pricing from the models/details shape', async () => {
+      render(DryRunPanel, { props: { run: okRun } })
+      await fireEvent.click(screen.getByText(/Compare with/))
+
+      const priced = await screen.findByRole('option', { name: /moonshotai\/kimi-k3/ })
+      expect(priced.querySelector('.menu-price')).toHaveTextContent('$0.80 / $3.20')
+
+      const unknown = screen.getByRole('option', { name: /local\/mystery/ })
+      expect(unknown.querySelector('.menu-price')).toHaveTextContent('')
+      expect(unknown.textContent).not.toMatch(/\$/)
+    })
 
     test('running with a compare model calls run twice, once per model', async () => {
       const run = vi.fn()


### PR DESCRIPTION
## Summary

The dry-run panel's per-model price label was always empty. `priceOf()` read `m.pricing.input` / `m.pricing.output`, but `GET /api/v1/models/details` returns `llm.ModelInfo` with top-level `input_per_mtok` / `output_per_mtok` (`null` = unknown) and no `pricing` object. The MSW fixture mocked the wrong shape, so the existing tests passed against a response the server never sends.

## Changes

- `DryRunPanel.svelte` - `priceOf()` reads `input_per_mtok` / `output_per_mtok`; `null` on either side → empty label. Formatting unchanged, no other panel behaviour touched.
- `DryRunPanel.test.js` - fixture rewritten to the real `ModelInfo` shape (plus a null-pricing model); new test asserts the label renders `$0.80 / $3.20` for a priced model and stays empty for an unknown one.

## Verification

- `just test-ui`: 49 files, 859 tests pass.
- New test fails against the pre-fix component (`1 failed | 15 passed`), so it guards the real bug rather than the mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)