### PR TITLE
fix(web): dial the dashboard WebSocket only once a credential exists

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -47,7 +47,8 @@
   }
 
   // On mount, check if we have a valid session cookie (e.g. after OIDC redirect)
-  // and initialize the global WebSocket connection.
+  // and start the global WebSocket. initWS only dials once a credential exists
+  // and redials when it changes, so calling it pre-login is safe.
   onMount(async () => {
     try {
       const sess = await api.sessionCheck()

--- a/web/src/__tests__/ws.test.js
+++ b/web/src/__tests__/ws.test.js
@@ -265,4 +265,26 @@ describe('reset', () => {
     ws.connect()
     expect(MockWebSocket.instances).toHaveLength(2)
   })
+
+  test('clears the reconnect budget after falling back to SSE', () => {
+    const { ws } = createWS()
+    ws.connect()
+
+    // Exhaust the budget: 3 reconnects, then the 4th failure falls back.
+    for (let i = 0; i < 3; i++) {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1].onclose({ code: 1006 })
+      vi.advanceTimersByTime(30000)
+    }
+    MockWebSocket.instances[MockWebSocket.instances.length - 1].onclose({ code: 1006 })
+    expect(ws.status).toBe('sse_fallback')
+
+    const before = MockWebSocket.instances.length
+    ws.reset()
+    ws.connect()
+    expect(MockWebSocket.instances).toHaveLength(before + 1)
+
+    // Budget is fresh — a failure now reconnects instead of falling back again.
+    MockWebSocket.instances[MockWebSocket.instances.length - 1].onclose({ code: 1006 })
+    expect(ws.status).toBe('reconnecting')
+  })
 })

--- a/web/src/__tests__/wsStore.test.js
+++ b/web/src/__tests__/wsStore.test.js
@@ -1,9 +1,11 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { get } from 'svelte/store'
+import { token, authMode } from '../store.js'
 
 // Track DenkeeperWS constructor calls and instances
 const mockConnect = vi.fn()
 const mockClose = vi.fn()
+const mockWSReset = vi.fn()
 const mockWSSend = vi.fn(() => true)
 let capturedOptions = null
 
@@ -12,15 +14,27 @@ vi.mock('../ws.js', () => ({
     capturedOptions = opts
     this.connect = mockConnect
     this.close = mockClose
+    this.reset = mockWSReset
     this.send = mockWSSend
   }),
 }))
 
 const { wsStatus, onSessionEvent, offSessionEvent, failAllSessionHandlers, getWSClient, initWS, destroyWS } = await import('../wsStore.js')
 
+/** Drop the credential watcher and clear auth, so each test starts logged out. */
+function resetAuth() {
+  destroyWS()
+  token.clear()
+  authMode.set(null)
+  mockConnect.mockReset()
+  mockClose.mockReset()
+  mockWSReset.mockReset()
+}
+
 beforeEach(() => {
   mockConnect.mockReset()
   mockClose.mockReset()
+  mockWSReset.mockReset()
   mockWSSend.mockReset().mockReturnValue(true)
 })
 
@@ -42,15 +56,87 @@ describe('getWSClient', () => {
 })
 
 describe('initWS / destroyWS lifecycle', () => {
-  test('initWS calls connect on the client', () => {
+  beforeEach(resetAuth)
+
+  test('initWS calls connect on the client when a token is already stored', () => {
+    token.set('stored-key')
+    mockConnect.mockReset()
     initWS()
     expect(mockConnect).toHaveBeenCalled()
+    resetAuth()
   })
 
   test('destroyWS calls close on the client', () => {
     getWSClient() // ensure client exists
     destroyWS()
     expect(mockClose).toHaveBeenCalled()
+  })
+})
+
+describe('credential-gated connect', () => {
+  beforeEach(resetAuth)
+
+  test('initWS does not dial while unauthenticated', () => {
+    initWS()
+    expect(mockConnect).not.toHaveBeenCalled()
+    resetAuth()
+  })
+
+  test('logging in with an API key after initWS connects the socket', () => {
+    initWS()
+    expect(mockConnect).not.toHaveBeenCalled()
+
+    token.set('login-key')
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    // reset() before connect clears the reconnect budget, so a pre-login
+    // failure streak can't leave the session stranded on SSE.
+    expect(mockWSReset).toHaveBeenCalledTimes(1)
+    resetAuth()
+  })
+
+  test('session auth after initWS connects the socket', () => {
+    initWS()
+    authMode.set('session')
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    resetAuth()
+  })
+
+  test('swapping the API key redials with a fresh reconnect budget', () => {
+    token.set('first-key')
+    initWS()
+    mockConnect.mockReset()
+    mockWSReset.mockReset()
+
+    token.set('second-key')
+
+    expect(mockWSReset).toHaveBeenCalledTimes(1)
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    resetAuth()
+  })
+
+  test('re-setting the same credential does not redial', () => {
+    token.set('same-key')
+    initWS()
+    mockConnect.mockReset()
+
+    token.set('same-key')
+
+    expect(mockConnect).not.toHaveBeenCalled()
+    resetAuth()
+  })
+
+  test('logging out closes the socket without redialling', () => {
+    token.set('bye-key')
+    initWS()
+    mockConnect.mockReset()
+
+    token.clear()
+    authMode.set(null)
+
+    expect(mockClose).toHaveBeenCalled()
+    expect(mockConnect).not.toHaveBeenCalled()
+    resetAuth()
   })
 })
 

--- a/web/src/wsStore.js
+++ b/web/src/wsStore.js
@@ -1,6 +1,16 @@
-import { writable, get } from 'svelte/store'
+import { writable, derived, get } from 'svelte/store'
 import { token, authMode } from './store.js'
 import { DenkeeperWS } from './ws.js'
+
+/**
+ * The credential the WS URL is built from — 'session' for cookie auth, the API
+ * key for token auth, '' when unauthenticated. Mirrors `_buildURL`, so a change
+ * here is exactly a change in how the upgrade would authenticate.
+ */
+const credential = derived(
+  [token, authMode],
+  ([$t, $m]) => ($m === 'session' ? 'session' : $t)
+)
 
 /**
  * Connection status store.
@@ -87,10 +97,37 @@ export function getWSClient() {
   return wsClient
 }
 
-/** Initialize the WS connection. Call once on app startup. */
+/** Last credential the socket was connected with; '' means none. */
+let lastCredential = ''
+
+/** Unsubscribe for the credential watcher, null when not watching. */
+let credentialUnsub = null
+
+/**
+ * Start the WS connection and keep it tracking the credential. Call once on app
+ * startup.
+ *
+ * Connecting is gated on having a credential: an upgrade sent before login 401s,
+ * and three of those exhaust the reconnect budget and strand the session on SSE
+ * until a reload. The watcher also covers the reverse transition (logout) and a
+ * key swap, resetting the budget so a stale failure count can't leak across
+ * credentials.
+ */
 export function initWS() {
   const client = getWSClient()
-  client.connect()
+  if (credentialUnsub) return client
+
+  credentialUnsub = credential.subscribe((cred) => {
+    if (cred === lastCredential) return
+    lastCredential = cred
+    if (!cred) {
+      client.close()
+      return
+    }
+    client.reset()
+    client.connect()
+  })
+
   return client
 }
 
@@ -100,8 +137,13 @@ export function onActivity(cb) {
   return () => activityCallbacks.delete(cb)
 }
 
-/** Tear down the WS connection. */
+/** Tear down the WS connection and stop tracking the credential. */
 export function destroyWS() {
+  if (credentialUnsub) {
+    credentialUnsub()
+    credentialUnsub = null
+  }
+  lastCredential = ''
   if (wsClient) {
     wsClient.close()
   }


### PR DESCRIPTION
`App.svelte` called `initWS()` unconditionally on mount, before login. With no token the upgrade omits `?token=`, the server 401s it, and three of those exhaust the reconnect budget and pin the client to `sse_fallback`. Nothing watched `token`/`authMode`, so logging in afterwards left the whole session on SSE until a page reload.

## The fix

`initWS()` now installs a watcher on a `credential` store derived from `token`/`authMode`, collapsed to exactly what `ws.js` `_buildURL` reads - so a change there is a change in how the upgrade would authenticate. It dials only when a credential exists, and calls the existing `reset()` first so a failure streak cannot leak across credentials. An empty credential closes without redialling.

**Why the store subscription rather than gating `initWS()` on `$isAuthenticated` in `App.svelte`:** credentials only ever mutate through those two stores, so one subscription covers login, logout, the `api.js` 401 auto-clear, and the OIDC redirect. A component-level gate only covers the paths that happen to re-render it.

`reset()` already existed in `ws.js`, doc-commented "e.g., after auth change". It had no caller.

Three transitions are covered, not just the reported one:

- logged out to API key / session: dials (the bug)
- key swap: redials with a fresh budget
- logout: closes, no redial

`App.svelte` is a comment-only change. The `onMount` call site is unchanged and still unconditional; it is now safe pre-login by construction.

## Testing

`just test-ui`: 49 files, 865 tests pass.

<details>
<summary>Verification that the new tests are load-bearing</summary>

With `wsStore.js` stashed, four of the six new `wsStore` cases fail: `does not dial while unauthenticated`, `logging in with an API key`, `swapping the API key`, and `logging out closes`. The other two pin behaviour rather than catch this regression.

The `ws.js` case pins the mechanism the fix leans on: after exhausting the budget to `sse_fallback`, `reset()` + `connect()` dials again and the next failure reconnects rather than falling back immediately.

The mocked `DenkeeperWS` in `wsStore.test.js` needed a `reset` member added, since the store now calls it.
</details>

Not verified against a running instance - the evidence here is test-level transition coverage, not an end-to-end check that the upgrade now 101s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
