### PR TITLE
feat(eval): expose message ids and dispatch eval_progress frames

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1386,7 +1386,10 @@ func (s *Server) handleSessionMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ID is exposed so a caller can cite the exact turn it read — the eval
+	// "save as test case" flow stores it as source_message_id.
 	type messageInfo struct {
+		ID               int64     `json:"id"`
 		Role             string    `json:"role"`
 		Content          string    `json:"content"`
 		TokensUsed       int       `json:"tokens_used,omitempty"`
@@ -1402,6 +1405,7 @@ func (s *Server) handleSessionMessages(w http.ResponseWriter, r *http.Request) {
 	out := make([]messageInfo, len(messages))
 	for i, m := range messages {
 		out[i] = messageInfo{
+			ID:               m.ID,
 			Role:             m.Role,
 			Content:          m.Content,
 			TokensUsed:       m.TokensUsed,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -919,6 +919,45 @@ func TestSessionMessages_ReturnsMessages(t *testing.T) {
 	}
 }
 
+// The eval "save as test case" flow stores the id as source_message_id, so a
+// stripped id costs provenance on every test case saved from the browser.
+func TestSessionMessages_ExposesMessageID(t *testing.T) {
+	cfg := testConfig(allScopesKey())
+	deps := testDeps()
+	ctx := context.Background()
+	_, _ = deps.Memory.GetOrCreateConversation(ctx, "telegram", "12345")
+	userID, err := deps.Memory.AddMessage(ctx, "telegram:12345", agent.StoredMessage{
+		Role: "user", Content: "hello",
+	})
+	if err != nil {
+		t.Fatalf("add message: %v", err)
+	}
+
+	srv := New(cfg, deps, testLogger())
+
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, authedRequest(http.MethodGet, "/api/v1/sessions/telegram:12345/messages"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var messages []map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&messages); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("messages count = %d, want 1", len(messages))
+	}
+	gotID, ok := messages[0]["id"].(float64)
+	if !ok {
+		t.Fatalf("id missing from %v", messages[0])
+	}
+	if int64(gotID) != userID {
+		t.Errorf("id = %d, want %d", int64(gotID), userID)
+	}
+}
+
 func TestSessionMessages_EmptyForUnknown(t *testing.T) {
 	cfg := testConfig(allScopesKey())
 	srv := New(cfg, testDeps(), testLogger())

--- a/web/src/__tests__/chatStore.test.js
+++ b/web/src/__tests__/chatStore.test.js
@@ -330,6 +330,18 @@ describe('loadSession', () => {
     expect(state.sessionId).toBe('sess-1')
   })
 
+  test('carries the stored message id so a saved test case can cite its source', async () => {
+    mockSessionMessages.mockResolvedValue([
+      { id: 41, role: 'user', content: 'Hello' },
+      { id: 42, role: 'assistant', content: 'Hi there' },
+    ])
+
+    await loadSession('sess-1', 'default')
+    const state = get(chatState)
+    expect(state.messages[0].id).toBe(41)
+    expect(state.messages[1].id).toBe(42)
+  })
+
   test('sets restoring during fetch', async () => {
     let resolveMessages
     mockSessionMessages.mockImplementation(() => new Promise(r => { resolveMessages = r }))

--- a/web/src/__tests__/wsStore.test.js
+++ b/web/src/__tests__/wsStore.test.js
@@ -25,7 +25,7 @@ vi.mock('../api.js', () => ({
   api: { panicStatus: (...args) => mockPanicStatus(...args) },
 }))
 
-const { wsStatus, panicStatus, refreshPanicStatus, onSessionEvent, offSessionEvent, failAllSessionHandlers, getWSClient, initWS, destroyWS } = await import('../wsStore.js')
+const { wsStatus, panicStatus, evalProgress, refreshPanicStatus, onSessionEvent, offSessionEvent, failAllSessionHandlers, getWSClient, initWS, destroyWS } = await import('../wsStore.js')
 
 /** Drop the credential watcher and clear auth, so each test starts logged out. */
 function resetAuth() {
@@ -44,6 +44,7 @@ beforeEach(() => {
   mockWSSend.mockReset().mockReturnValue(true)
   mockPanicStatus.mockReset().mockResolvedValue({ panicked: false, panic_time: '0001-01-01T00:00:00Z' })
   panicStatus.set({ active: false, message: '', since: '' })
+  evalProgress.set(new Map())
 })
 
 describe('getWSClient', () => {
@@ -445,5 +446,62 @@ describe('panic status hydration', () => {
 
     expect(get(panicStatus).active).toBe(true)
     expect(get(panicStatus).since).toBe('2026-08-18T10:00:00Z')
+  })
+})
+
+describe('eval progress frames', () => {
+  beforeEach(() => {
+    getWSClient()
+  })
+
+  test('an eval_progress frame lands in the store keyed by run_id', () => {
+    capturedOptions.onEvent({
+      type: 'eval_progress',
+      run_id: 7,
+      status: 'running',
+      samples_done: 3,
+      samples_total: 20,
+      cost_spent: 0.12,
+      cost_cap: 2,
+      eta_seconds: 90,
+    })
+
+    const frame = get(evalProgress).get(7)
+    expect(frame.status).toBe('running')
+    expect(frame.samples_done).toBe(3)
+    expect(frame.eta_seconds).toBe(90)
+  })
+
+  test('a later frame for the same run replaces the earlier one', () => {
+    capturedOptions.onEvent({ type: 'eval_progress', run_id: 7, status: 'running', samples_done: 3, samples_total: 20 })
+    capturedOptions.onEvent({ type: 'eval_progress', run_id: 7, status: 'done', samples_done: 20, samples_total: 20 })
+
+    expect(get(evalProgress).size).toBe(1)
+    expect(get(evalProgress).get(7).status).toBe('done')
+    expect(get(evalProgress).get(7).samples_done).toBe(20)
+  })
+
+  test('runs are tracked independently', () => {
+    capturedOptions.onEvent({ type: 'eval_progress', run_id: 7, status: 'running', samples_done: 3 })
+    capturedOptions.onEvent({ type: 'eval_progress', run_id: 8, status: 'capped', samples_done: 11 })
+
+    expect(get(evalProgress).get(7).samples_done).toBe(3)
+    expect(get(evalProgress).get(8).status).toBe('capped')
+  })
+
+  // The store publishes a new Map rather than mutating in place, so Svelte
+  // subscribers actually see the update.
+  test('each frame publishes a new Map instance', () => {
+    capturedOptions.onEvent({ type: 'eval_progress', run_id: 7, status: 'running' })
+    const first = get(evalProgress)
+    capturedOptions.onEvent({ type: 'eval_progress', run_id: 7, status: 'done' })
+
+    expect(get(evalProgress)).not.toBe(first)
+  })
+
+  test('unknown session-less frames are still dropped', () => {
+    capturedOptions.onEvent({ type: 'something_new', run_id: 7 })
+
+    expect(get(evalProgress).size).toBe(0)
   })
 })

--- a/web/src/chatStore.js
+++ b/web/src/chatStore.js
@@ -77,6 +77,7 @@ export async function loadSession(sessionId, agent) {
       sessionId,
       agent: agent || s.agent,
       messages: (history || []).map(m => ({
+        id: m.id,
         role: m.role === 'assistant' ? 'agent' : 'user',
         text: m.content,
       })),
@@ -117,6 +118,7 @@ async function restoreSession() {
       sessionId: saved.sessionId,
       agent: saved.agent || s.agent,
       messages: history.map(m => ({
+        id: m.id,
         role: m.role === 'assistant' ? 'agent' : 'user',
         text: m.content,
       })),

--- a/web/src/components/SaveTestCase.svelte
+++ b/web/src/components/SaveTestCase.svelte
@@ -10,7 +10,17 @@
   // last; the operator picks how many to pin. Pinned history is captured *now*
   // and replayed verbatim at run time: the source conversation drifts, so its
   // latest window would not be the window that preceded this message.
-  let { prompt = '', precedingTurns = [], conversationId = '', onclose = undefined } = $props()
+  //
+  // `sourceMessageId` is the stored message row id, present only for turns read
+  // back from GET /sessions/{id}/messages — a message still streaming in this
+  // session has no id yet, and provenance stays partial rather than wrong.
+  let {
+    prompt = '',
+    precedingTurns = [],
+    conversationId = '',
+    sourceMessageId = null,
+    onclose = undefined,
+  } = $props()
 
   const CATEGORIES = [
     { value: 'chat', label: 'Chat / persona' },
@@ -105,9 +115,7 @@
         notes: notes.trim() || undefined,
         pinned_history: pinned,
         source_conversation_id: conversationId || undefined,
-        // Message ids are stripped from the sessions API, so full provenance
-        // is not available from the browser yet.
-        source_message_id: null,
+        source_message_id: sourceMessageId ?? null,
       })
       saved = true
       selectedSet = setName

--- a/web/src/components/__tests__/SaveTestCase.test.js
+++ b/web/src/components/__tests__/SaveTestCase.test.js
@@ -51,7 +51,9 @@ describe('SaveTestCase', () => {
   })
 
   test('saves the prompt with the chosen category and set', async () => {
-    render(SaveTestCase, { props: { prompt: 'do the thing', conversationId: 'chan:main' } })
+    render(SaveTestCase, {
+      props: { prompt: 'do the thing', conversationId: 'chan:main', sourceMessageId: 417 },
+    })
 
     await waitFor(() => expect(screen.getByLabelText('Test set')).toBeTruthy())
     await fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'tool_heavy' } })
@@ -62,7 +64,16 @@ describe('SaveTestCase', () => {
     expect(addedTasks[0].body.prompt).toBe('do the thing')
     expect(addedTasks[0].body.category).toBe('tool_heavy')
     expect(addedTasks[0].body.source_conversation_id).toBe('chan:main')
-    // Message ids are stripped from the sessions API, so provenance is partial.
+    expect(addedTasks[0].body.source_message_id).toBe(417)
+  })
+
+  test('sends a null source_message_id for a turn that has no stored id yet', async () => {
+    render(SaveTestCase, { props: { prompt: 'just sent', conversationId: 'chan:main' } })
+
+    await waitFor(() => expect(screen.getByLabelText('Test set')).toBeTruthy())
+    await fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(addedTasks.length).toBe(1))
     expect(addedTasks[0].body.source_message_id).toBeNull()
   })
 

--- a/web/src/pages/Chat.svelte
+++ b/web/src/pages/Chat.svelte
@@ -549,6 +549,7 @@
             prompt={msg.text}
             precedingTurns={$chatState.messages.slice(0, msgIndex)}
             conversationId={$chatState.sessionId}
+            sourceMessageId={msg.id ?? null}
             onclose={closeSaveTestCase}
           />
         {/if}

--- a/web/src/test/fixtures/index.js
+++ b/web/src/test/fixtures/index.js
@@ -32,8 +32,8 @@ export const sessionSkillUsages = [
 ]
 
 export const messages = [
-  { role: 'user', content: 'Hello' },
-  { role: 'assistant', content: 'Hi there' },
+  { id: 41, role: 'user', content: 'Hello' },
+  { id: 42, role: 'assistant', content: 'Hi there' },
 ]
 
 export const approvals = [

--- a/web/src/wsStore.js
+++ b/web/src/wsStore.js
@@ -30,6 +30,16 @@ export const wsStatus = writable('disconnected')
  */
 export const panicStatus = writable({ active: false, message: '', since: '' })
 
+/**
+ * Latest eval_progress frame per run — a Map keyed by run_id.
+ *
+ * The frame is a wake-up, not truth: progress frames are droppable and are
+ * never replayed, so a consumer treats an update as "re-read the run" and
+ * takes GET /eval/runs/{id} as authoritative. A lost frame costs a stale
+ * progress bar until the next sample, never a wrong terminal status.
+ */
+export const evalProgress = writable(new Map())
+
 const PANIC_MESSAGE = 'Emergency stop triggered — all processing paused'
 
 /** Bumped by every panic_status frame, so a slow hydrate can tell it is stale. */
@@ -123,6 +133,16 @@ export function getWSClient() {
           active: frame.active,
           message: frame.message || '',
           since: frame.active ? (frame.since || '') : '',
+        })
+        return
+      }
+      // Handle eval run progress broadcasts. A new Map is set rather than
+      // mutated in place, so Svelte subscribers actually see the change.
+      if (frame.type === 'eval_progress') {
+        evalProgress.update((m) => {
+          const next = new Map(m)
+          next.set(frame.run_id, frame)
+          return next
         })
         return
       }


### PR DESCRIPTION
Two small, independent Stage D0 items from the eval subsystem plan. No shared surface between them beyond both being backend prerequisites the Evals page (D1/D2) needs.

## D0.3 - `messageInfo.id`

`GET /sessions/{id}/messages` stripped `StoredMessage.ID`, so `SaveTestCase.svelte` had no choice but to write `source_message_id: null`. A saved test case could name its conversation but not the turn inside it.

- `messageInfo` gains `id` (int64, JSON `id`), set from `m.ID` (already selected by `GetMessages`).
- `chatStore.js` carries `id` through both history mapping sites (`loadSession`, `restoreSession`); `Chat.svelte` passes it as `sourceMessageId`.
- A turn still streaming in this session has no stored id, so the field stays `null` there - partial provenance rather than a wrong one.
- Message list keys are unaffected: the `{#each}` in `Chat.svelte` is unkeyed.
- No OpenAPI diff: the handler's annotation is `@Success 200 {array} object`, so the spec never described the shape. `just openapi` regenerated clean.

## D0.6 - `eval_progress` client dispatch

`EvalProgressFrame` is emitted and broadcast server-side, but `wsStore.js` dispatched session-less frames via an if-chain that handled `activity` and `panic_status` and dropped everything else, so the frame went into a void.

- New exported `evalProgress` writable: a `Map` keyed by `run_id` holding the latest frame. A new `Map` is published on each update so Svelte subscribers see it.
- A branch next to `panic_status`. The frame stays droppable and is not added to the replay buffer - it is a wake-up, and `GET /eval/runs/{id}` stays authoritative.
- No page built here; D1 consumes the store.

## Test evidence

`just hook` green: fmt-check, vet, lint, lint-ui, test (-race), test-ui, openapi-check.

New tests:
- `TestSessionMessages_ExposesMessageID` - asserts the JSON `id` equals the id `AddMessage` returned.
- `SaveTestCase.test.js` - the POST body carries the real `source_message_id`, plus a case asserting `null` for a turn with no stored id.
- `chatStore.test.js` - `loadSession` carries the id onto the message objects.
- `wsStore.test.js` - a frame lands keyed by `run_id`, a later frame for the same run replaces it, runs are tracked independently, each update publishes a new Map, and unknown session-less frames are still dropped.

MSW: the shared `messages` fixture now carries ids, which is what the `GET /sessions/{id}/messages` handler serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
