### PR TITLE
feat(eval): pre-run cost estimate and read-only eval config endpoints

### DIFF
--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -2362,6 +2362,115 @@
                 }
             }
         },
+        "/eval/config": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the [eval] TOML section: the run defaults a launcher should preselect (default_k, max_cost_per_run, max_concurrent) and the policy a scorecard is judged against (completeness_floor, win_threshold, the three objective gates). Read-only by design — v1 keeps threshold edits in TOML plus a reload, and every verdict already carries the thresholds it was measured against.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "eval"
+                ],
+                "summary": "Get the eval subsystem's configured defaults and thresholds",
+                "responses": {
+                    "200": {
+                        "description": "Eval defaults and thresholds",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.evalConfigResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Eval subsystem not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/eval/estimate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Prices a run before it is created, so the launcher can show a range beside the hard cap. Per (task, variant) the basis is, in order: history (the task's source conversation has real telemetry, giving an honest per-exchange average — scaled by the list-price ratio when the variant runs a different model), list price (the variant's advertised per-million-token price against a nominal per-turn token budget), or unknown. Nothing is fabricated: a variant that can be priced neither way reports basis \"unknown\" with a zero range, and the caller shows the cap alone. When sample_tasks narrows the run the drawn subset is not known yet, so the figure scales the mean per-task cost and says so in note.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "eval"
+                ],
+                "summary": "Estimate what an eval run will cost",
+                "parameters": [
+                    {
+                        "description": "Task set, base agent and the variants to price",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.evalEstimateInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Cost range in USD with a per-variant breakdown",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.Estimate"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON, no variants, or unknown agent",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Task set not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Store error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Eval subsystem not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/eval/runs": {
             "get": {
                 "security": [
@@ -7762,6 +7871,40 @@
                 }
             }
         },
+        "github_com_Temikus_denkeeper_internal_eval.Estimate": {
+            "type": "object",
+            "properties": {
+                "basis": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "high": {
+                    "type": "number"
+                },
+                "k": {
+                    "type": "integer"
+                },
+                "low": {
+                    "type": "number"
+                },
+                "note": {
+                    "description": "Note names anything that makes the figure less than a straight sum:\na sampled subset, or tasks that could not be priced at all.",
+                    "type": "string"
+                },
+                "per_variant": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.VariantEstimate"
+                    }
+                },
+                "tasks": {
+                    "description": "Tasks is how many tasks the figure covers — the drawn subset size when\nsample_tasks narrows the run, otherwise the whole set.",
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_Temikus_denkeeper_internal_eval.Gate": {
             "type": "object",
             "properties": {
@@ -8126,6 +8269,23 @@
                 },
                 "run_id": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.VariantEstimate": {
+            "type": "object",
+            "properties": {
+                "basis": {
+                    "type": "string"
+                },
+                "high": {
+                    "type": "number"
+                },
+                "low": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },
@@ -8746,6 +8906,63 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.dryRunToolCall"
+                    }
+                }
+            }
+        },
+        "internal_api.evalConfigResponse": {
+            "type": "object",
+            "properties": {
+                "audit": {
+                    "type": "string"
+                },
+                "completeness_floor": {
+                    "type": "number"
+                },
+                "default_k": {
+                    "type": "integer"
+                },
+                "gate_cost_pct": {
+                    "type": "number"
+                },
+                "gate_rejected_rate_pp": {
+                    "type": "number"
+                },
+                "gate_rounds_pct": {
+                    "type": "number"
+                },
+                "max_concurrent": {
+                    "type": "integer"
+                },
+                "max_cost_per_run": {
+                    "type": "number"
+                },
+                "win_threshold": {
+                    "type": "number"
+                }
+            }
+        },
+        "internal_api.evalEstimateInput": {
+            "type": "object",
+            "properties": {
+                "base_agent": {
+                    "type": "string"
+                },
+                "k": {
+                    "description": "K is samples per (task, variant). Omitted uses [eval] default_k.",
+                    "type": "integer"
+                },
+                "sample_tasks": {
+                    "description": "SampleTasks is the Quick check subset size. Omitted or \u003e= the set size\nprices the whole set.",
+                    "type": "integer"
+                },
+                "task_set": {
+                    "type": "string"
+                },
+                "variants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_api.evalVariantInput"
                     }
                 }
             }

--- a/internal/api/evalestimate.go
+++ b/internal/api/evalestimate.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Temikus/denkeeper/internal/agent"
+	"github.com/Temikus/denkeeper/internal/eval"
+	"github.com/Temikus/denkeeper/internal/llm"
+)
+
+// evalEstimateInput mirrors evalRunInput's shape so the launcher prices exactly
+// the run it is about to start.
+type evalEstimateInput struct {
+	TaskSet   string             `json:"task_set"`
+	BaseAgent string             `json:"base_agent"`
+	Variants  []evalVariantInput `json:"variants"`
+	// K is samples per (task, variant). Omitted uses [eval] default_k.
+	K int `json:"k"`
+	// SampleTasks is the Quick check subset size. Omitted or >= the set size
+	// prices the whole set.
+	SampleTasks int `json:"sample_tasks"`
+}
+
+// evalConfigResponse is the read-only [eval] policy. It exists so the launcher
+// and the results view show the defaults and thresholds the server actually
+// judges against instead of hardcoding a copy. Deliberately read-only:
+// runtime-editable thresholds were dropped from v1, so there is no writer.
+type evalConfigResponse struct {
+	DefaultK           int     `json:"default_k"`
+	MaxCostPerRun      float64 `json:"max_cost_per_run"`
+	MaxConcurrent      int     `json:"max_concurrent"`
+	CompletenessFloor  float64 `json:"completeness_floor"`
+	WinThreshold       float64 `json:"win_threshold"`
+	GateRejectedRatePP float64 `json:"gate_rejected_rate_pp"`
+	GateRoundsPct      float64 `json:"gate_rounds_pct"`
+	GateCostPct        float64 `json:"gate_cost_pct"`
+	Audit              string  `json:"audit"`
+}
+
+// handleEvalEstimate godoc
+// @Summary Estimate what an eval run will cost
+// @Description Prices a run before it is created, so the launcher can show a range beside the hard cap. Per (task, variant) the basis is, in order: history (the task's source conversation has real telemetry, giving an honest per-exchange average — scaled by the list-price ratio when the variant runs a different model), list price (the variant's advertised per-million-token price against a nominal per-turn token budget), or unknown. Nothing is fabricated: a variant that can be priced neither way reports basis "unknown" with a zero range, and the caller shows the cap alone. When sample_tasks narrows the run the drawn subset is not known yet, so the figure scales the mean per-task cost and says so in note.
+// @Tags eval
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param body body evalEstimateInput true "Task set, base agent and the variants to price"
+// @Success 200 {object} eval.Estimate "Cost range in USD with a per-variant breakdown"
+// @Failure 400 {object} map[string]string "Invalid JSON, no variants, or unknown agent"
+// @Failure 404 {object} map[string]string "Task set not found"
+// @Failure 500 {object} map[string]string "Store error"
+// @Failure 503 {object} map[string]string "Eval subsystem not configured"
+// @Router /eval/estimate [post]
+func (s *Server) handleEvalEstimate(w http.ResponseWriter, r *http.Request) {
+	if !s.evalRequired(w) {
+		return
+	}
+	var input evalEstimateInput
+	if !decodeEvalBody(w, r, &input) {
+		return
+	}
+	if len(input.Variants) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one variant is required"})
+		return
+	}
+
+	set, err := s.deps.EvalStore.GetTaskSet(r.Context(), input.TaskSet)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+	tasks, err := s.deps.EvalStore.ListTasks(r.Context(), set.ID)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+
+	e := s.deps.Dispatcher.Agent(input.BaseAgent)
+	if e == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("agent %q not found", input.BaseAgent)})
+		return
+	}
+
+	k := input.K
+	if k <= 0 {
+		k = s.deps.EvalRunner.Config().DefaultK
+	}
+
+	// Model and provider names are taken at face value here, unlike run
+	// creation: an estimate spends nothing, and an unknown name is already
+	// visible as an "unknown" basis rather than a rejection.
+	variants := make([]eval.EstimateVariant, 0, len(input.Variants))
+	for _, v := range input.Variants {
+		variants = append(variants, eval.EstimateVariant{
+			Name:     strings.TrimSpace(v.Name),
+			Model:    v.LLMModel,
+			Provider: v.LLMProvider,
+		})
+	}
+
+	est, err := s.evalEstimator().Estimate(r.Context(), eval.EstimateInput{
+		Tasks:        tasks,
+		Variants:     variants,
+		K:            k,
+		SampleTasks:  input.SampleTasks,
+		BaseModel:    e.ModelName(),
+		BaseProvider: e.ProviderName(),
+	})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, est)
+}
+
+// evalEstimator wires the two lookups the estimator needs. Either may be nil,
+// which removes the basis it serves rather than failing the request.
+func (s *Server) evalEstimator() eval.Estimator {
+	var est eval.Estimator
+	// conversation_stats lives on TelemetryStore, obtained by type assertion —
+	// a store without it simply has no history basis to offer.
+	if tel, ok := s.deps.Memory.(agent.TelemetryStore); ok {
+		est.Stats = evalStatsLookup{mem: tel}
+	}
+	if s.deps.ModelDetailLister != nil {
+		est.Prices = &evalPriceLookup{list: s.deps.ModelDetailLister, cache: map[string]map[string]eval.ModelPrice{}}
+	}
+	return est
+}
+
+// evalStatsLookup adapts the memory store to the estimator's history basis.
+type evalStatsLookup struct{ mem agent.TelemetryStore }
+
+func (l evalStatsLookup) ConversationStats(ctx context.Context, convID string) (*eval.ConvStats, error) {
+	row, err := l.mem.GetConversationStats(ctx, convID)
+	if err != nil {
+		return nil, fmt.Errorf("conversation stats: %w", err)
+	}
+	if row == nil {
+		return nil, nil
+	}
+	return &eval.ConvStats{TotalCost: row.TotalCost, TotalMessages: row.TotalMessages}, nil
+}
+
+// evalPriceLookup adapts ModelDetailLister to the estimator's list-price basis.
+// It caches one listing per provider for the life of the request: the lister
+// can be a network round-trip and a run prices the same two models against
+// every task in the set.
+//
+// Not safe for concurrent use — one instance serves one request.
+type evalPriceLookup struct {
+	list  func(ctx context.Context, providerFilter string) []llm.ModelInfo
+	cache map[string]map[string]eval.ModelPrice
+}
+
+func (l *evalPriceLookup) ModelPrice(ctx context.Context, provider, model string) (eval.ModelPrice, bool) {
+	byModel, cached := l.cache[provider]
+	if !cached {
+		lctx, cancel := context.WithTimeout(ctx, modelValidationTimeout)
+		defer cancel()
+		byModel = make(map[string]eval.ModelPrice)
+		for _, m := range l.list(lctx, provider) {
+			var p eval.ModelPrice
+			if m.InputPerMTok != nil {
+				p.InputPerMTok = *m.InputPerMTok
+			}
+			if m.OutputPerMTok != nil {
+				p.OutputPerMTok = *m.OutputPerMTok
+			}
+			byModel[m.ID] = p
+		}
+		l.cache[provider] = byModel
+	}
+	p, ok := byModel[model]
+	return p, ok
+}
+
+// handleEvalConfig godoc
+// @Summary Get the eval subsystem's configured defaults and thresholds
+// @Description Returns the [eval] TOML section: the run defaults a launcher should preselect (default_k, max_cost_per_run, max_concurrent) and the policy a scorecard is judged against (completeness_floor, win_threshold, the three objective gates). Read-only by design — v1 keeps threshold edits in TOML plus a reload, and every verdict already carries the thresholds it was measured against.
+// @Tags eval
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} evalConfigResponse "Eval defaults and thresholds"
+// @Failure 503 {object} map[string]string "Eval subsystem not configured"
+// @Router /eval/config [get]
+func (s *Server) handleEvalConfig(w http.ResponseWriter, _ *http.Request) {
+	if !s.evalRequired(w) {
+		return
+	}
+	if s.deps.Config == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "server config not available"})
+		return
+	}
+	c := s.deps.Config.Eval
+	writeJSON(w, http.StatusOK, evalConfigResponse{
+		DefaultK:           c.DefaultK,
+		MaxCostPerRun:      c.MaxCostPerRun,
+		MaxConcurrent:      c.MaxConcurrent,
+		CompletenessFloor:  c.CompletenessFloor,
+		WinThreshold:       c.WinThreshold,
+		GateRejectedRatePP: c.GateRejectedRatePP,
+		GateRoundsPct:      c.GateRoundsPct,
+		GateCostPct:        c.GateCostPct,
+		Audit:              c.AuditMode(),
+	})
+}

--- a/internal/api/evalestimate_test.go
+++ b/internal/api/evalestimate_test.go
@@ -1,0 +1,302 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Temikus/denkeeper/internal/agent"
+	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/eval"
+	"github.com/Temikus/denkeeper/internal/llm"
+)
+
+// noEvalScopeKey carries neither eval scope, so it cannot even estimate.
+func noEvalScopeKey() config.APIKeyConfig {
+	return config.APIKeyConfig{Name: "chat-only", Key: "dk-chat-only", Scopes: []string{"chat"}}
+}
+
+// seedConvStats writes n exchanges worth of telemetry against convID. Each
+// call to UpdateConversationStats adds one message, so 2n calls make n
+// exchanges — the same shape a real conversation accumulates.
+func seedConvStats(t *testing.T, srv *Server, convID string, messages int, costEach float64) {
+	t.Helper()
+	store, ok := srv.deps.Memory.(agent.TelemetryStore)
+	if !ok {
+		t.Fatal("test memory store is not a TelemetryStore")
+	}
+	if err := srv.deps.Memory.GetOrCreateConversationByID(context.Background(), convID, "api", "test"); err != nil {
+		t.Fatalf("GetOrCreateConversationByID: %v", err)
+	}
+	for i := 0; i < messages; i++ {
+		if err := store.UpdateConversationStats(context.Background(), convID, "default",
+			agent.StoredMessage{Cost: costEach}, 0, 0); err != nil {
+			t.Fatalf("UpdateConversationStats: %v", err)
+		}
+	}
+}
+
+// pricedModels wires a ModelDetailLister advertising one priced model.
+func pricedModels(srv *Server, id string, in, out float64) {
+	srv.deps.ModelDetailLister = func(_ context.Context, _ string) []llm.ModelInfo {
+		return []llm.ModelInfo{{ID: id, Name: id, Provider: "mock", InputPerMTok: &in, OutputPerMTok: &out}}
+	}
+}
+
+func decodeEstimate(t *testing.T, body []byte) eval.Estimate {
+	t.Helper()
+	var got eval.Estimate
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decoding estimate: %v (body %s)", err, body)
+	}
+	return got
+}
+
+// estimateBody is the standard request against a set named "set".
+const estimateBody = `{"task_set":"set","base_agent":"default","variants":[{"name":"current"}],"k":1}`
+
+// --- Scope gating ---
+
+func TestEvalEstimate_ReadScopeIsEnough(t *testing.T) {
+	srv, store := evalTestServer(t, allScopesKey(), evalReadOnlyKey())
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate", estimateBody, "dk-eval-readonly")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 — an estimate spends nothing", rec.Code)
+	}
+}
+
+func TestEvalEstimate_WithoutAnEvalScopeIsForbidden(t *testing.T) {
+	srv, store := evalTestServer(t, allScopesKey(), noEvalScopeKey())
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate", estimateBody, "dk-chat-only")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestEvalConfig_ReadScopeIsEnough(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey(), evalReadOnlyKey())
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/config", "", "dk-eval-readonly")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestEvalConfig_WithoutAnEvalScopeIsForbidden(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey(), noEvalScopeKey())
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/config", "", "dk-chat-only")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+// --- Request validation ---
+
+func TestEvalEstimate_UnknownTaskSetIs404(t *testing.T) {
+	srv, _ := evalTestServer(t)
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate",
+		`{"task_set":"nope","base_agent":"default","variants":[{"name":"current"}]}`, "dk-test-key")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestEvalEstimate_UnknownAgentIs400(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate",
+		`{"task_set":"set","base_agent":"ghost","variants":[{"name":"current"}]}`, "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEvalEstimate_NoVariantsIs400(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate",
+		`{"task_set":"set","base_agent":"default","variants":[]}`, "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEvalEstimate_UnknownModelIsPricedUnknownNotRejected(t *testing.T) {
+	// Unlike run creation, an estimate does not validate the overlay: it costs
+	// nothing, and an unknown name already shows up as an unknown basis.
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate",
+		`{"task_set":"set","base_agent":"default","variants":[{"name":"c","llm_model":"not-a-real-model"}],"k":1}`,
+		"dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decodeEstimate(t, rec.Body.Bytes())
+	if got.Basis != eval.BasisUnknown {
+		t.Errorf("basis = %q, want %q", got.Basis, eval.BasisUnknown)
+	}
+}
+
+// --- Bases end to end ---
+
+func TestEvalEstimate_HistoryBasisFromTheSourceConversation(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedConvStats(t, srv, "tg:1", 4, 0.25) // $1.00 over 4 messages = $0.50 a turn
+
+	set, err := store.CreateTaskSet(context.Background(), "set", "")
+	if err != nil {
+		t.Fatalf("CreateTaskSet: %v", err)
+	}
+	if _, err := store.AddTask(context.Background(), set.ID, eval.Task{
+		Prompt: "hi", Category: eval.CategoryChat, SourceConversationID: "tg:1",
+	}); err != nil {
+		t.Fatalf("AddTask: %v", err)
+	}
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate", estimateBody, "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	got := decodeEstimate(t, rec.Body.Bytes())
+	if got.Basis != eval.BasisHistory {
+		t.Fatalf("basis = %q, want %q", got.Basis, eval.BasisHistory)
+	}
+	if got.Currency != "USD" || got.Tasks != 1 || got.K != 1 {
+		t.Errorf("envelope = %+v, want currency USD, tasks 1, k 1", got)
+	}
+	if got.Low <= 0 || got.High <= got.Low {
+		t.Errorf("range = %v..%v, want a real widening range", got.Low, got.High)
+	}
+	if len(got.PerVariant) != 1 || got.PerVariant[0].Name != "current" {
+		t.Errorf("per_variant = %+v, want one entry named current", got.PerVariant)
+	}
+}
+
+func TestEvalEstimate_ListPriceBasisFromModelDetails(t *testing.T) {
+	srv, store := evalTestServer(t)
+	// The test engine's default model; no task carries a source conversation.
+	pricedModels(srv, "test-model", 3, 15)
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate", estimateBody, "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	got := decodeEstimate(t, rec.Body.Bytes())
+	if got.Basis != eval.BasisListPrice {
+		t.Fatalf("basis = %q, want %q", got.Basis, eval.BasisListPrice)
+	}
+	if got.Low <= 0 || got.High <= got.Low {
+		t.Errorf("range = %v..%v, want prompt-only below prompt+output", got.Low, got.High)
+	}
+}
+
+func TestEvalEstimate_UnknownBasisWithoutHistoryOrPricing(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate", estimateBody, "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decodeEstimate(t, rec.Body.Bytes())
+	if got.Basis != eval.BasisUnknown {
+		t.Fatalf("basis = %q, want %q", got.Basis, eval.BasisUnknown)
+	}
+	if got.Low != 0 || got.High != 0 {
+		t.Errorf("range = %v..%v, want 0..0 — the caller shows the cap alone", got.Low, got.High)
+	}
+}
+
+func TestEvalEstimate_OmittedKTakesTheConfiguredDefault(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "hi")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate",
+		`{"task_set":"set","base_agent":"default","variants":[{"name":"current"}]}`, "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := decodeEstimate(t, rec.Body.Bytes()); got.K != 3 {
+		t.Errorf("k = %d, want the runner's default_k of 3", got.K)
+	}
+}
+
+func TestEvalEstimate_SampleTasksNarrowsTheReportedTaskCount(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "a", "b", "c", "d")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/estimate",
+		`{"task_set":"set","base_agent":"default","variants":[{"name":"current"}],"k":1,"sample_tasks":2}`,
+		"dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	got := decodeEstimate(t, rec.Body.Bytes())
+	if got.Tasks != 2 {
+		t.Errorf("tasks = %d, want 2 — the drawn subset, not the set size", got.Tasks)
+	}
+	if got.Note == "" {
+		t.Error("note is empty; the subset is drawn at run time and the figure is a mean")
+	}
+}
+
+// --- Config endpoint ---
+
+func TestEvalConfig_ReflectsTOMLValues(t *testing.T) {
+	srv, _ := evalTestServer(t)
+	srv.deps.Config.Eval = config.EvalConfig{
+		Audit:              "summary",
+		MaxConcurrent:      4,
+		MaxCostPerRun:      7.5,
+		DefaultK:           5,
+		CompletenessFloor:  0.9,
+		WinThreshold:       0.6,
+		GateRejectedRatePP: 1.5,
+		GateRoundsPct:      10,
+		GateCostPct:        30,
+	}
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/config", "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got evalConfigResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding config: %v", err)
+	}
+	want := evalConfigResponse{
+		DefaultK: 5, MaxCostPerRun: 7.5, MaxConcurrent: 4,
+		CompletenessFloor: 0.9, WinThreshold: 0.6,
+		GateRejectedRatePP: 1.5, GateRoundsPct: 10, GateCostPct: 30,
+		Audit: "summary",
+	}
+	if got != want {
+		t.Errorf("config = %+v, want %+v", got, want)
+	}
+}
+
+func TestEvalConfig_AuditDefaultsToFull(t *testing.T) {
+	srv, _ := evalTestServer(t)
+	srv.deps.Config.Eval = config.EvalConfig{DefaultK: 3}
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/config", "", "dk-test-key")
+	var got evalConfigResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding config: %v", err)
+	}
+	if got.Audit != "full" {
+		t.Errorf("audit = %q, want full", got.Audit)
+	}
+}

--- a/internal/api/llmstxt.go
+++ b/internal/api/llmstxt.go
@@ -43,6 +43,8 @@ API keys are scoped. Required scopes are noted per endpoint below.
 - POST /api/v1/eval/task-sets/{name}/tasks (scope: eval:write)  Save a test case
 - POST /api/v1/eval/runs               (scope: eval:write)      Compare agent config variants on a test set
 - GET  /api/v1/eval/runs/{id}/summary  (scope: eval:read)       Scorecard, gate table and verdict for a run
+- POST /api/v1/eval/estimate           (scope: eval:read)       Cost range for a run before starting it
+- GET  /api/v1/eval/config             (scope: eval:read)       Eval defaults and verdict thresholds
 - POST /api/v1/panic                   (scope: admin)           Emergency stop all in-flight requests
 
 ## Full API Reference

--- a/internal/api/llmstxt_test.go
+++ b/internal/api/llmstxt_test.go
@@ -45,6 +45,34 @@ func TestLLMsTxt_NoAuth(t *testing.T) {
 	}
 }
 
+// TestLLMsTxt_ListsEvalEndpoints pins the eval entries, including the two
+// D0.2 additions. llms.txt is how an LLM-driven caller discovers the API
+// without reading the OpenAPI spec, so an endpoint missing here is invisible
+// to exactly the audience this file exists for.
+func TestLLMsTxt_ListsEvalEndpoints(t *testing.T) {
+	s := &Server{
+		cfg:    config.APIConfig{},
+		logger: testLogger(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/llms.txt", nil)
+	rec := httptest.NewRecorder()
+	s.handleLLMsTxt(rec, req)
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"GET  /api/v1/eval/task-sets",
+		"POST /api/v1/eval/runs",
+		"GET  /api/v1/eval/runs/{id}/summary",
+		"POST /api/v1/eval/estimate",
+		"GET  /api/v1/eval/config",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
 func TestLLMsTxt_IncludesBaseURL(t *testing.T) {
 	s := &Server{
 		cfg:    config.APIConfig{ExternalURL: "https://my.denkeeper.example.com"},

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -288,6 +288,9 @@ func New(cfg config.APIConfig, deps Deps, logger *slog.Logger) *Server {
 	mux.HandleFunc("POST /api/v1/eval/runs/{id}/stop", s.RequireScope("eval:write", s.handleStopEvalRun))
 	mux.HandleFunc("GET /api/v1/eval/runs/{id}/summary", s.RequireScope("eval:read", s.handleEvalRunSummary))
 	mux.HandleFunc("GET /api/v1/eval/runs/{id}/samples", s.RequireScope("eval:read", s.handleEvalRunSamples))
+	// Estimating and reading the policy spend nothing, so both are read-scoped.
+	mux.HandleFunc("POST /api/v1/eval/estimate", s.RequireScope("eval:read", s.handleEvalEstimate))
+	mux.HandleFunc("GET /api/v1/eval/config", s.RequireScope("eval:read", s.handleEvalConfig))
 
 	// Browser profile and session endpoints.
 	mux.HandleFunc("GET /api/v1/browser/profiles", s.RequireScope("browser:read", s.handleListBrowserProfiles))

--- a/internal/eval/estimate.go
+++ b/internal/eval/estimate.go
@@ -1,0 +1,375 @@
+package eval
+
+import (
+	"context"
+	"fmt"
+	"math"
+)
+
+// Estimate bases, weakest last. A figure is only ever labelled with a basis
+// that actually contributed to it.
+const (
+	// BasisHistory: the task's source conversation has real telemetry, so the
+	// per-turn figure is a measurement rather than a model.
+	BasisHistory = "history"
+	// BasisListPrice: no usable history, so the figure is the variant's list
+	// price times a nominal token budget.
+	BasisListPrice = "list_price"
+	// BasisUnknown: neither was available. The caller shows the hard cap alone
+	// rather than a fabricated number.
+	BasisUnknown = "unknown"
+)
+
+// Estimator constants. Deliberately in one place: they are the whole model
+// behind a list-price figure, and a reader comparing an estimate against a
+// finished run needs to see what was assumed.
+const (
+	// nominalSystemPromptTokens stands in for the assembled system prompt
+	// (persona + skills + date injection). The Engine exposes no accessor for
+	// the built prompt and building one costs a full turn setup, so a fixed
+	// stand-in is used instead — it dominates a short task prompt, which is
+	// why it is modelled at all. Roughly a medium persona plus two skills.
+	nominalSystemPromptTokens = 2000
+	// nominalOutputTokens is the per-turn completion allowance. It is what
+	// separates a variant's low (prompt only) from its high (prompt + output).
+	nominalOutputTokens = 600
+	// charsPerToken is the usual English rule of thumb, applied to the task
+	// prompt and its pinned history.
+	charsPerToken = 4
+	// historySpreadLow and historySpreadHigh bracket a history-derived
+	// per-turn figure. A saved exchange average measures a different turn on
+	// the same agent, so the range is wide on purpose.
+	historySpreadLow  = 0.5
+	historySpreadHigh = 2.0
+	// tokensPerMTok converts a per-million-token list price to per-token.
+	tokensPerMTok = 1_000_000
+)
+
+// ConvStats is the slice of conversation telemetry the history basis reads.
+type ConvStats struct {
+	TotalCost     float64
+	TotalMessages int
+}
+
+// StatsLookup resolves a task's source conversation to its aggregate
+// telemetry. A nil result means the conversation carries no stats — pruned by
+// retention, cleared, or never real — and is not an error.
+type StatsLookup interface {
+	ConversationStats(ctx context.Context, convID string) (*ConvStats, error)
+}
+
+// ModelPrice is a model's list price in USD per million tokens.
+type ModelPrice struct {
+	InputPerMTok  float64
+	OutputPerMTok float64
+}
+
+// PriceLookup resolves a (provider, model) pair to its list price. An empty
+// provider means the base agent's own provider. ok=false means the price is
+// unknown, which is a valid answer, not a failure.
+type PriceLookup interface {
+	ModelPrice(ctx context.Context, provider, model string) (ModelPrice, bool)
+}
+
+// EstimateVariant is one side of the comparison being priced. An empty Model
+// is the incumbent overlay: it runs the base agent's live model.
+type EstimateVariant struct {
+	Name     string
+	Model    string
+	Provider string
+}
+
+// EstimateInput is everything the estimator needs that it cannot look up.
+type EstimateInput struct {
+	Tasks    []Task
+	Variants []EstimateVariant
+	K        int
+	// SampleTasks, when set below len(Tasks), is the size of the stratified
+	// subset a Quick check draws. The drawn set is not known at estimate time,
+	// so the figure scales the mean per-task cost instead.
+	SampleTasks int
+	// BaseModel and BaseProvider are the agent's live config — the model the
+	// history basis actually measured, and what an empty overlay runs.
+	BaseModel    string
+	BaseProvider string
+}
+
+// VariantEstimate is one variant's share of the range.
+type VariantEstimate struct {
+	Name  string  `json:"name"`
+	Low   float64 `json:"low"`
+	High  float64 `json:"high"`
+	Basis string  `json:"basis"`
+}
+
+// Estimate is a pre-run cost range in USD.
+type Estimate struct {
+	Low      float64 `json:"low"`
+	High     float64 `json:"high"`
+	Currency string  `json:"currency"`
+	Basis    string  `json:"basis"`
+	// Tasks is how many tasks the figure covers — the drawn subset size when
+	// sample_tasks narrows the run, otherwise the whole set.
+	Tasks      int               `json:"tasks"`
+	K          int               `json:"k"`
+	PerVariant []VariantEstimate `json:"per_variant"`
+	// Note names anything that makes the figure less than a straight sum:
+	// a sampled subset, or tasks that could not be priced at all.
+	Note string `json:"note,omitempty"`
+}
+
+// Estimator computes a pre-run cost estimate. Both lookups are optional: a nil
+// Stats removes the history basis, a nil Prices removes the list-price basis,
+// and with neither the estimate is honestly unknown.
+type Estimator struct {
+	Stats  StatsLookup
+	Prices PriceLookup
+}
+
+// taskCost is one (task, variant) per-turn figure and the basis behind it.
+// outputCost is the completion allowance inside perTurn on the list-price
+// basis, carried here so spread cannot drift from listPricePerTurn.
+type taskCost struct {
+	perTurn    float64
+	outputCost float64
+	basis      string
+}
+
+// Estimate prices a run before it is created.
+//
+// Per (task, variant) the basis order is history → list price → unknown.
+// History measures the incumbent; a variant running a different model only
+// keeps it when both models are priced and the figure can be scaled by their
+// list-price ratio, otherwise that variant falls to list price outright.
+func (e Estimator) Estimate(ctx context.Context, in EstimateInput) (*Estimate, error) {
+	k := in.K
+	if k < 1 {
+		k = 1
+	}
+	drawn := len(in.Tasks)
+	sampled := in.SampleTasks > 0 && in.SampleTasks < drawn
+	if sampled {
+		drawn = in.SampleTasks
+	}
+
+	perTurnHistory, err := e.historyPerTurn(ctx, in.Tasks)
+	if err != nil {
+		return nil, err
+	}
+	basePrice, basePriced := e.price(ctx, in.BaseProvider, in.BaseModel)
+
+	out := &Estimate{Currency: "USD", Tasks: drawn, K: k, Basis: BasisUnknown}
+	unpriced := 0
+	for _, v := range in.Variants {
+		ve, miss := e.variantEstimate(ctx, v, in, perTurnHistory, basePrice, basePriced, drawn, k)
+		if miss > unpriced {
+			unpriced = miss
+		}
+		out.PerVariant = append(out.PerVariant, ve)
+		out.Low += ve.Low
+		out.High += ve.High
+	}
+	out.Basis = rollUpBasis(out.PerVariant)
+	out.Note = estimateNote(sampled, drawn, len(in.Tasks), unpriced)
+	out.Low = roundCents(out.Low)
+	out.High = roundCents(out.High)
+	return out, nil
+}
+
+// variantEstimate prices one variant across the task set, returning its range
+// and how many tasks it could not price at all.
+func (e Estimator) variantEstimate(ctx context.Context, v EstimateVariant, in EstimateInput,
+	perTurnHistory []float64, basePrice ModelPrice, basePriced bool, drawn, k int) (VariantEstimate, int) {
+
+	model, provider := v.Model, v.Provider
+	if model == "" {
+		model = in.BaseModel
+	}
+	if provider == "" {
+		provider = in.BaseProvider
+	}
+	price, priced := e.price(ctx, provider, model)
+
+	// A history figure measures the base model. Keep it for a different model
+	// only when both are priced, so the scale is a real ratio rather than an
+	// assumption that two models cost the same.
+	ratio, scalable := 1.0, true
+	if model != in.BaseModel {
+		ratio, scalable = priceRatio(basePrice, price, basePriced && priced)
+	}
+
+	var sum, sumLow, sumHigh float64
+	var priceable int
+	usedHistory, usedList := false, false
+	for i, task := range in.Tasks {
+		tc := taskCost{basis: BasisUnknown}
+		switch {
+		case scalable && perTurnHistory[i] > 0:
+			tc = taskCost{perTurn: perTurnHistory[i] * ratio, basis: BasisHistory}
+		case priced:
+			total, output := listPricePerTurn(task, price)
+			tc = taskCost{perTurn: total, outputCost: output, basis: BasisListPrice}
+		}
+		low, high := spread(tc)
+		switch tc.basis {
+		case BasisHistory:
+			usedHistory = true
+		case BasisListPrice:
+			usedList = true
+		default:
+			continue
+		}
+		priceable++
+		sum += tc.perTurn
+		sumLow += low
+		sumHigh += high
+	}
+
+	ve := VariantEstimate{Name: v.Name, Basis: variantBasis(usedHistory, usedList)}
+	if priceable == 0 {
+		return ve, len(in.Tasks)
+	}
+	// A sampled run draws its subset server-side at creation, so the mean is
+	// the only honest per-task figure available here.
+	if drawn != len(in.Tasks) {
+		scale := float64(drawn) / float64(priceable)
+		sumLow, sumHigh = sumLow*scale, sumHigh*scale
+	}
+	ve.Low = roundCents(sumLow * float64(k))
+	ve.High = roundCents(sumHigh * float64(k))
+	return ve, len(in.Tasks) - priceable
+}
+
+// spread turns a per-turn figure into a low/high pair. The history basis
+// brackets a measurement; the list-price basis brackets prompt-only against
+// prompt plus the output allowance, which is where its own low already sits.
+func spread(tc taskCost) (low, high float64) {
+	switch tc.basis {
+	case BasisHistory:
+		return tc.perTurn * historySpreadLow, tc.perTurn * historySpreadHigh
+	case BasisListPrice:
+		// perTurn is the prompt+output figure; the low strips the allowance
+		// back out rather than recomputing it.
+		return tc.perTurn - tc.outputCost, tc.perTurn
+	default:
+		return 0, 0
+	}
+}
+
+// listPricePerTurn prices one turn at list: the nominal system prompt plus the
+// task's own text and pinned history, plus the output allowance. The second
+// return is the output share of the first.
+func listPricePerTurn(task Task, price ModelPrice) (total, output float64) {
+	promptTokens := nominalSystemPromptTokens +
+		len(task.Prompt)/charsPerToken +
+		len(task.PinnedHistory)/charsPerToken
+	output = nominalOutputTokens * price.OutputPerMTok / tokensPerMTok
+	return float64(promptTokens)*price.InputPerMTok/tokensPerMTok + output, output
+}
+
+// priceRatio blends the input and output list prices of two models by the
+// nominal token budget, so a model that is cheap on input but dear on output
+// is not treated as uniformly cheap.
+func priceRatio(base, candidate ModelPrice, bothPriced bool) (float64, bool) {
+	if !bothPriced {
+		return 0, false
+	}
+	denom := base.InputPerMTok*nominalSystemPromptTokens + base.OutputPerMTok*nominalOutputTokens
+	if denom <= 0 {
+		return 0, false
+	}
+	num := candidate.InputPerMTok*nominalSystemPromptTokens + candidate.OutputPerMTok*nominalOutputTokens
+	return num / denom, true
+}
+
+// historyPerTurn returns each task's per-exchange cost from its source
+// conversation, or 0 where there is none. conversation_stats counts both sides
+// of an exchange, hence the halving.
+func (e Estimator) historyPerTurn(ctx context.Context, tasks []Task) ([]float64, error) {
+	out := make([]float64, len(tasks))
+	if e.Stats == nil {
+		return out, nil
+	}
+	seen := make(map[string]float64, len(tasks))
+	for i, t := range tasks {
+		if t.SourceConversationID == "" {
+			continue
+		}
+		if cached, ok := seen[t.SourceConversationID]; ok {
+			out[i] = cached
+			continue
+		}
+		stats, err := e.Stats.ConversationStats(ctx, t.SourceConversationID)
+		if err != nil {
+			return nil, fmt.Errorf("reading conversation stats for %q: %w", t.SourceConversationID, err)
+		}
+		var perTurn float64
+		if stats != nil && stats.TotalMessages > 0 && stats.TotalCost > 0 {
+			exchanges := math.Ceil(float64(stats.TotalMessages) / 2)
+			perTurn = stats.TotalCost / exchanges
+		}
+		seen[t.SourceConversationID] = perTurn
+		out[i] = perTurn
+	}
+	return out, nil
+}
+
+// price resolves a model's list price, tolerating a nil lookup.
+func (e Estimator) price(ctx context.Context, provider, model string) (ModelPrice, bool) {
+	if e.Prices == nil || model == "" {
+		return ModelPrice{}, false
+	}
+	p, ok := e.Prices.ModelPrice(ctx, provider, model)
+	if !ok || (p.InputPerMTok <= 0 && p.OutputPerMTok <= 0) {
+		return ModelPrice{}, false
+	}
+	return p, true
+}
+
+// variantBasis labels a variant by the weakest basis that contributed. Tasks
+// that could not be priced at all are reported through the note instead, so a
+// partial figure is not mislabelled "unknown".
+func variantBasis(usedHistory, usedList bool) string {
+	switch {
+	case usedList:
+		return BasisListPrice
+	case usedHistory:
+		return BasisHistory
+	default:
+		return BasisUnknown
+	}
+}
+
+// rollUpBasis applies the same weakest-wins rule across variants.
+func rollUpBasis(vs []VariantEstimate) string {
+	basis := BasisUnknown
+	for _, v := range vs {
+		switch v.Basis {
+		case BasisListPrice:
+			return BasisListPrice
+		case BasisHistory:
+			basis = BasisHistory
+		}
+	}
+	return basis
+}
+
+// estimateNote states anything that makes the figure less than a straight sum.
+func estimateNote(sampled bool, drawn, total, unpriced int) string {
+	switch {
+	case sampled && unpriced > 0:
+		return fmt.Sprintf("%d of %d tasks are drawn at run time, so the figure scales the mean per-task cost; %d task(s) could not be priced and are excluded from that mean",
+			drawn, total, unpriced)
+	case sampled:
+		return fmt.Sprintf("%d of %d tasks are drawn at run time, so the figure scales the mean per-task cost", drawn, total)
+	case unpriced > 0:
+		return fmt.Sprintf("%d of %d tasks could not be priced and are not represented in this figure", unpriced, total)
+	}
+	return ""
+}
+
+// roundCents trims the float noise a chain of ratios accumulates. Sub-cent
+// precision is kept because a Quick check can genuinely cost a few cents.
+func roundCents(v float64) float64 {
+	return math.Round(v*10000) / 10000
+}

--- a/internal/eval/estimate_test.go
+++ b/internal/eval/estimate_test.go
@@ -1,0 +1,440 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+)
+
+// --- Hand-written lookups ---
+
+// stubStats answers the history basis from a fixed map. A conversation absent
+// from the map returns (nil, nil), which is how the real store reports a
+// conversation that retention pruned.
+type stubStats struct {
+	rows map[string]ConvStats
+	err  error
+	// calls counts lookups so the per-conversation memoisation can be asserted.
+	calls int
+}
+
+func (s *stubStats) ConversationStats(_ context.Context, convID string) (*ConvStats, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	row, ok := s.rows[convID]
+	if !ok {
+		return nil, nil
+	}
+	return &row, nil
+}
+
+// stubPrices answers the list-price basis, keyed by model id alone — the
+// provider is carried through but the estimator never keys on it.
+type stubPrices map[string]ModelPrice
+
+func (p stubPrices) ModelPrice(_ context.Context, _, model string) (ModelPrice, bool) {
+	price, ok := p[model]
+	return price, ok
+}
+
+// --- Helpers ---
+
+func incumbentOnly() []EstimateVariant {
+	return []EstimateVariant{{Name: "current"}}
+}
+
+// nearly compares money to the estimator's own rounding granularity.
+func nearly(got, want float64) bool { return math.Abs(got-want) < 1e-6 }
+
+// --- History basis ---
+
+func TestEstimate_HistoryBasisIsThePerExchangeAverage(t *testing.T) {
+	est := Estimator{Stats: &stubStats{rows: map[string]ConvStats{
+		// $1.00 over 4 messages = 2 exchanges = $0.50 a turn.
+		"tg:1": {TotalCost: 1.0, TotalMessages: 4},
+	}}}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Basis != BasisHistory {
+		t.Fatalf("basis = %q, want %q", got.Basis, BasisHistory)
+	}
+	if !nearly(got.Low, 0.25) || !nearly(got.High, 1.0) {
+		t.Errorf("range = %v..%v, want 0.25..1.00 (the 0.5x/2x spread on $0.50)", got.Low, got.High)
+	}
+	if got.Note != "" {
+		t.Errorf("note = %q, want empty — nothing about this figure is partial", got.Note)
+	}
+}
+
+func TestEstimate_HistoryScalesToACandidateByListPriceRatio(t *testing.T) {
+	est := Estimator{
+		Stats: &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}},
+		Prices: stubPrices{
+			"base-model": {InputPerMTok: 1, OutputPerMTok: 1},
+			"candidate":  {InputPerMTok: 2, OutputPerMTok: 2},
+		},
+	}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  []EstimateVariant{{Name: "candidate", Model: "candidate"}},
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Basis != BasisHistory {
+		t.Fatalf("basis = %q, want %q — both models are priced, so the measurement scales", got.Basis, BasisHistory)
+	}
+	// $0.50 a turn on the base model, doubled by the 2x price ratio.
+	if !nearly(got.Low, 0.5) || !nearly(got.High, 2.0) {
+		t.Errorf("range = %v..%v, want 0.50..2.00", got.Low, got.High)
+	}
+}
+
+func TestEstimate_UnpricedCandidateCannotScaleHistory(t *testing.T) {
+	// The candidate's price is unknown, so the incumbent's measured cost
+	// cannot be honestly rescaled and there is no list price to fall back to.
+	est := Estimator{
+		Stats:  &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}},
+		Prices: stubPrices{"base-model": {InputPerMTok: 1, OutputPerMTok: 1}},
+	}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  []EstimateVariant{{Name: "candidate", Model: "mystery-model"}},
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Basis != BasisUnknown {
+		t.Fatalf("basis = %q, want %q — a scaled figure would be invented", got.Basis, BasisUnknown)
+	}
+	if got.Low != 0 || got.High != 0 {
+		t.Errorf("range = %v..%v, want 0..0", got.Low, got.High)
+	}
+}
+
+func TestEstimate_HistoryReadsEachConversationOnce(t *testing.T) {
+	stats := &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}}
+	est := Estimator{Stats: stats}
+
+	if _, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks: []Task{
+			{Prompt: "a", SourceConversationID: "tg:1"},
+			{Prompt: "b", SourceConversationID: "tg:1"},
+			{Prompt: "c", SourceConversationID: "tg:1"},
+		},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	}); err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if stats.calls != 1 {
+		t.Errorf("stats lookups = %d, want 1 — three tasks share one conversation", stats.calls)
+	}
+}
+
+func TestEstimate_StatsErrorFailsTheEstimate(t *testing.T) {
+	boom := errors.New("db is on fire")
+	est := Estimator{Stats: &stubStats{err: boom}}
+
+	_, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want it to wrap the store error", err)
+	}
+}
+
+// --- List-price basis ---
+
+func TestEstimate_ListPriceBasisWhenATaskHasNoHistory(t *testing.T) {
+	est := Estimator{Prices: stubPrices{"base-model": {InputPerMTok: 3, OutputPerMTok: 15}}}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		// "hello" is 5 chars = 1 token, so the prompt is 2001 tokens.
+		Tasks:     []Task{{Prompt: "hello"}},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Basis != BasisListPrice {
+		t.Fatalf("basis = %q, want %q", got.Basis, BasisListPrice)
+	}
+	// Low is prompt only: 2001 tokens at $3/Mtok.
+	if !nearly(got.Low, 0.006) {
+		t.Errorf("low = %v, want 0.006 (prompt only)", got.Low)
+	}
+	// High adds the 600-token output allowance at $15/Mtok.
+	if !nearly(got.High, 0.015) {
+		t.Errorf("high = %v, want 0.015 (prompt + output allowance)", got.High)
+	}
+}
+
+func TestEstimate_ListPriceCountsPinnedHistoryInThePrompt(t *testing.T) {
+	est := Estimator{Prices: stubPrices{"base-model": {InputPerMTok: 1000, OutputPerMTok: 0}}}
+	in := EstimateInput{Variants: incumbentOnly(), K: 1, BaseModel: "base-model"}
+
+	in.Tasks = []Task{{Prompt: "hello"}}
+	bare, err := est.Estimate(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	// 400 chars of pinned history = 100 tokens = $0.10 at $1000/Mtok.
+	in.Tasks = []Task{{Prompt: "hello", PinnedHistory: string(make([]byte, 400))}}
+	pinned, err := est.Estimate(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if !nearly(pinned.High-bare.High, 0.1) {
+		t.Errorf("pinned history added %v, want 0.10", pinned.High-bare.High)
+	}
+}
+
+// --- Unknown basis ---
+
+func TestEstimate_UnknownBasisWithNeitherLookup(t *testing.T) {
+	got, err := Estimator{}.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Basis != BasisUnknown {
+		t.Fatalf("basis = %q, want %q", got.Basis, BasisUnknown)
+	}
+	if got.Low != 0 || got.High != 0 {
+		t.Errorf("range = %v..%v, want 0..0 — a fabricated number is worse than none", got.Low, got.High)
+	}
+	if got.PerVariant[0].Basis != BasisUnknown {
+		t.Errorf("per_variant basis = %q, want %q", got.PerVariant[0].Basis, BasisUnknown)
+	}
+}
+
+func TestEstimate_PartiallyPricedSetNamesTheGapInTheNote(t *testing.T) {
+	// Only the history basis is available, so the task without a source
+	// conversation cannot be priced at all.
+	est := Estimator{Stats: &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}}}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks: []Task{
+			{Prompt: "a", SourceConversationID: "tg:1"},
+			{Prompt: "b"},
+		},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Basis != BasisHistory {
+		t.Errorf("basis = %q, want %q — a partial figure is not mislabelled unknown", got.Basis, BasisHistory)
+	}
+	if !nearly(got.High, 1.0) {
+		t.Errorf("high = %v, want 1.00 — only the priced task contributes", got.High)
+	}
+	if got.Note == "" {
+		t.Error("note is empty; an unpriced task must be declared")
+	}
+}
+
+// --- Per-variant breakdown ---
+
+func TestEstimate_PerVariantBreakdownSumsToTheTotal(t *testing.T) {
+	est := Estimator{
+		Stats: &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}},
+		Prices: stubPrices{
+			"base-model": {InputPerMTok: 1, OutputPerMTok: 1},
+			"candidate":  {InputPerMTok: 3, OutputPerMTok: 3},
+		},
+	}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  []EstimateVariant{{Name: "current"}, {Name: "candidate", Model: "candidate"}},
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if len(got.PerVariant) != 2 {
+		t.Fatalf("per_variant has %d entries, want 2", len(got.PerVariant))
+	}
+	if got.PerVariant[0].Name != "current" || got.PerVariant[1].Name != "candidate" {
+		t.Errorf("per_variant names = %q, %q — request order must be preserved",
+			got.PerVariant[0].Name, got.PerVariant[1].Name)
+	}
+	// The incumbent runs the base model verbatim; the candidate is 3x.
+	if !nearly(got.PerVariant[0].High, 1.0) {
+		t.Errorf("incumbent high = %v, want 1.00", got.PerVariant[0].High)
+	}
+	if !nearly(got.PerVariant[1].High, 3.0) {
+		t.Errorf("candidate high = %v, want 3.00", got.PerVariant[1].High)
+	}
+	if !nearly(got.Low, got.PerVariant[0].Low+got.PerVariant[1].Low) ||
+		!nearly(got.High, got.PerVariant[0].High+got.PerVariant[1].High) {
+		t.Errorf("total %v..%v is not the sum of the per-variant figures", got.Low, got.High)
+	}
+}
+
+func TestEstimate_VariantBasisIsReportedPerVariant(t *testing.T) {
+	// The incumbent has a measurement; the candidate is priced but its history
+	// cannot be scaled because the base model has no list price.
+	est := Estimator{
+		Stats:  &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}},
+		Prices: stubPrices{"candidate": {InputPerMTok: 3, OutputPerMTok: 15}},
+	}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  []EstimateVariant{{Name: "current"}, {Name: "candidate", Model: "candidate"}},
+		K:         1,
+		BaseModel: "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.PerVariant[0].Basis != BasisHistory {
+		t.Errorf("incumbent basis = %q, want %q", got.PerVariant[0].Basis, BasisHistory)
+	}
+	if got.PerVariant[1].Basis != BasisListPrice {
+		t.Errorf("candidate basis = %q, want %q", got.PerVariant[1].Basis, BasisListPrice)
+	}
+	if got.Basis != BasisListPrice {
+		t.Errorf("roll-up basis = %q, want %q — the weakest contributing basis wins", got.Basis, BasisListPrice)
+	}
+}
+
+// --- Subset and k scaling ---
+
+func TestEstimate_SampleTasksScalesByTheMeanPerTask(t *testing.T) {
+	// Four tasks costing $2, $4, $6 and $8 a turn (one exchange each): mean
+	// $5.00, so a drawn subset of two is $10.00 before the spread.
+	est := Estimator{Stats: &stubStats{rows: map[string]ConvStats{
+		"c1": {TotalCost: 2, TotalMessages: 2},
+		"c2": {TotalCost: 4, TotalMessages: 2},
+		"c3": {TotalCost: 6, TotalMessages: 2},
+		"c4": {TotalCost: 8, TotalMessages: 2},
+	}}}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks: []Task{
+			{Prompt: "a", SourceConversationID: "c1"},
+			{Prompt: "b", SourceConversationID: "c2"},
+			{Prompt: "c", SourceConversationID: "c3"},
+			{Prompt: "d", SourceConversationID: "c4"},
+		},
+		Variants:    incumbentOnly(),
+		K:           1,
+		SampleTasks: 2,
+		BaseModel:   "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Tasks != 2 {
+		t.Errorf("tasks = %d, want 2 — the drawn size, not the set size", got.Tasks)
+	}
+	if !nearly(got.High, 20.0) {
+		t.Errorf("high = %v, want 20.00 (2 tasks x $5.00 mean x the 2x spread)", got.High)
+	}
+	if got.Note == "" {
+		t.Error("note is empty; the subset is drawn at run time and the figure is a mean")
+	}
+}
+
+func TestEstimate_SampleTasksAtOrAboveTheSetSizePricesEverything(t *testing.T) {
+	est := Estimator{Stats: &stubStats{rows: map[string]ConvStats{
+		"c1": {TotalCost: 2, TotalMessages: 2},
+		"c2": {TotalCost: 4, TotalMessages: 2},
+	}}}
+
+	got, err := est.Estimate(context.Background(), EstimateInput{
+		Tasks: []Task{
+			{Prompt: "a", SourceConversationID: "c1"},
+			{Prompt: "b", SourceConversationID: "c2"},
+		},
+		Variants:    incumbentOnly(),
+		K:           1,
+		SampleTasks: 50,
+		BaseModel:   "base-model",
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Tasks != 2 {
+		t.Errorf("tasks = %d, want 2", got.Tasks)
+	}
+	if !nearly(got.High, 12.0) {
+		t.Errorf("high = %v, want 12.00 ((2+4) x the 2x spread)", got.High)
+	}
+	if got.Note != "" {
+		t.Errorf("note = %q, want empty — nothing is sampled", got.Note)
+	}
+}
+
+func TestEstimate_KMultipliesTheRange(t *testing.T) {
+	est := Estimator{Stats: &stubStats{rows: map[string]ConvStats{"tg:1": {TotalCost: 1.0, TotalMessages: 4}}}}
+	in := EstimateInput{
+		Tasks:     []Task{{Prompt: "hello", SourceConversationID: "tg:1"}},
+		Variants:  incumbentOnly(),
+		K:         1,
+		BaseModel: "base-model",
+	}
+
+	one, err := est.Estimate(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	in.K = 3
+	three, err := est.Estimate(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if three.K != 3 {
+		t.Errorf("k = %d, want 3 echoed back", three.K)
+	}
+	if !nearly(three.Low, one.Low*3) || !nearly(three.High, one.High*3) {
+		t.Errorf("k=3 range %v..%v is not 3x the k=1 range %v..%v",
+			three.Low, three.High, one.Low, one.High)
+	}
+}
+
+func TestEstimate_CurrencyIsAlwaysUSD(t *testing.T) {
+	got, err := Estimator{}.Estimate(context.Background(), EstimateInput{
+		Tasks: []Task{{Prompt: "hello"}}, Variants: incumbentOnly(), K: 1,
+	})
+	if err != nil {
+		t.Fatalf("Estimate: %v", err)
+	}
+	if got.Currency != "USD" {
+		t.Errorf("currency = %q, want USD", got.Currency)
+	}
+}


### PR DESCRIPTION
Stage D0.2 of `design/eval-subsystem.md`. Two read-scoped endpoints the launcher (D1) needs before it can be honest about money.

## What changed

**`POST /api/v1/eval/estimate`** (`eval:read`) — prices a run before it is created. Body is `evalRunInput`'s shape plus `sample_tasks`.

Per `(task, variant)` the basis is picked in one order and never fudged:

1. **`history`** — the task's `source_conversation_id` has telemetry, so the figure is `total_cost / ceil(total_messages / 2)`: a real per-exchange average. That measures the *incumbent*. A variant on a different model keeps it only when both models are priced, scaled by a list-price ratio blended over the nominal token budget; otherwise that variant falls through.
2. **`list_price`** — the variant's `input_per_mtok`/`output_per_mtok` against a nominal per-turn token budget.
3. **`unknown`** — neither was available. `low`/`high` are `0` and the caller shows the hard cap alone. Nothing is fabricated.

`low`/`high` are a real range: history brackets a measurement at 0.5x/2x, list price brackets prompt-only against prompt + output allowance. Total is `sum x k x variants`. With `sample_tasks` set below the set size the drawn subset does not exist yet, so the figure scales the mean per-task cost and `note` says so.

**`GET /api/v1/eval/config`** (`eval:read`) — the `[eval]` section, read-only.

**Response shapes** (D1 is building against these):

```jsonc
// POST /eval/estimate
{"low":0.245,"high":0.98,"currency":"USD","basis":"history","tasks":10,"k":1,
 "per_variant":[{"name":"current","low":0.12,"high":0.49,"basis":"history"}],
 "note":"..."}                                    // note is omitempty

// GET /eval/config
{"default_k":3,"max_cost_per_run":2.0,"max_concurrent":2,"completeness_floor":0.8,
 "win_threshold":0.55,"gate_rejected_rate_pp":2.0,"gate_rounds_pct":20,
 "gate_cost_pct":25,"audit":"full"}
```

The estimator lives in `internal/eval/estimate.go` behind two small interfaces (`StatsLookup`, `PriceLookup`) so it unit-tests without an engine or a router. Either being nil removes the basis it serves rather than failing the request.

## Notes for the reviewer

- **`GET /eval/config` is an addition beyond the design doc**, which specs only `/eval/estimate` in D0.2. It is the read-only half of *Decisions Stage D needs from the owner* item 2 (runtime-editable thresholds: skip for v1). No writer, no PATCH.
- **`buildSystemPrompt` has no exported accessor**, contrary to the doc's "system prompt size is knowable". It is unexported and needs an `adapter.IncomingMessage` plus a `*ExecPolicy`, i.e. a full turn setup. Rather than add engine surgery, `nominalSystemPromptTokens = 2000` is a documented stand-in; every estimator constant sits in one block with the reasoning, since they are the whole model behind a list-price figure.
- **`GetConversationStats` is on `agent.TelemetryStore`, not `agent.MemoryStore`** — obtained by type assertion, the house pattern. A store without it simply has no history basis to offer.
- **The estimate deliberately skips `buildEvalVariants`' provider/model validation.** Run creation rejects an unregistered provider up front because it would fail every sample; an estimate spends nothing, and an unknown name already surfaces honestly as `basis: "unknown"`. Pinned by `TestEvalEstimate_UnknownModelIsPricedUnknownNotRejected`.
- `evalPriceLookup` caches one `ModelDetailLister` listing per provider for the life of the request — the lister can be a network round-trip and a run prices the same two models against every task.

## Outside the slice

Three lines: two routes in `server.go`'s eval block, two lines in `llmstxt.go`, and the regenerated `swagger.json`. Expect trivial conflicts with the sibling D0 slices in all three.

## Test evidence

`just hook` green: fmt-check, vet, lint, lint-ui, test (-race), test-ui, openapi-check.

<details>
<summary>New tests</summary>

`internal/eval/estimate_test.go` (15) — the three bases each on their own test; history scaled by list-price ratio; an unpriced candidate refusing to scale; per-conversation memoisation; store error propagation; pinned history counted into the prompt; per-variant breakdown summing to the total and preserving request order; per-variant basis with the weakest-wins roll-up; a partially-priced set labelled by its real basis with the gap in `note`; `sample_tasks` scaling by the mean and the at-or-above-set-size no-op; k multiplication; currency.

`internal/api/evalestimate_test.go` (14) — scope gating both ways on both endpoints, unknown task set 404, unknown agent 400, no variants 400, unknown model priced-unknown rather than rejected, all three bases end to end through the router, omitted `k` taking `default_k`, `sample_tasks` narrowing the reported task count, and the config endpoint reflecting TOML values plus the `audit` default.

`internal/api/llmstxt_test.go` — `TestLLMsTxt_ListsEvalEndpoints` pins all five eval entries.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
