### PR TITLE
feat(eval): pin a run's task list and allow a stratified subset

### DIFF
--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -2427,7 +2427,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates and launches a background run: every task in the set is executed k times against each variant, on the base agent's live engine under the eval execution policy. Reads run for real, writes are suppressed, and nothing is persisted to conversations, telemetry or memory. Costs real tokens, bounded by cost_cap and by [eval] max_concurrent. By convention the first variant is the incumbent (empty overlay = live config) and per-task deltas are measured against it.",
+                "description": "Creates and launches a background run: every task in the set is executed k times against each variant, on the base agent's live engine under the eval execution policy. Reads run for real, writes are suppressed, and nothing is persisted to conversations, telemetry or memory. Costs real tokens, bounded by cost_cap and by [eval] max_concurrent. By convention the first variant is the incumbent (empty overlay = live config) and per-task deltas are measured against it. Pass sample_tasks to run a stratified random subset instead of the whole set; the drawn task ids are pinned on the run, so a task added to the set later cannot retroactively change what the run was measured over.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2502,7 +2502,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the run with its variants, samples done out of expected, spend against the cap, and a rough ETA (mean sample latency times remaining, divided by concurrency). This is the authoritative view; the eval_progress WebSocket frame is a droppable convenience on top.",
+                "description": "Returns the run with its variants, samples done out of expected, spend against the cap, and a rough ETA (mean sample latency times remaining, divided by concurrency). samples_total counts the run's pinned task list when it has one, so a task added to the set after the run was created does not inflate it. This is the authoritative view; the eval_progress WebSocket frame is a droppable convenience on top.",
                 "produces": [
                     "application/json"
                 ],
@@ -7869,6 +7869,17 @@
                 "status": {
                     "type": "string"
                 },
+                "task_count": {
+                    "description": "TaskCount is how many tasks the run covers: the pinned count when pinned,\notherwise the set's current size. It is a display figure — the\nauthoritative dispatch count is len(RunTasks), which also drops a pinned\ntask deleted after the run was created.",
+                    "type": "integer"
+                },
+                "task_ids": {
+                    "description": "TaskIDs pins the run's task list at creation; nil means the whole set.\nPinning is what makes a sampled subset possible, and it also stops a task\nadded to the set later from retroactively inflating samples_expected and\nflipping a finished run to inconclusive.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "task_set_id": {
                     "type": "integer"
                 }
@@ -8791,6 +8802,17 @@
                 "status": {
                     "type": "string"
                 },
+                "task_count": {
+                    "description": "TaskCount is how many tasks the run covers: the pinned count when pinned,\notherwise the set's current size. It is a display figure — the\nauthoritative dispatch count is len(RunTasks), which also drops a pinned\ntask deleted after the run was created.",
+                    "type": "integer"
+                },
+                "task_ids": {
+                    "description": "TaskIDs pins the run's task list at creation; nil means the whole set.\nPinning is what makes a sampled subset possible, and it also stops a task\nadded to the set later from retroactively inflating samples_expected and\nflipping a finished run to inconclusive.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "task_set_id": {
                     "type": "integer"
                 },
@@ -8847,6 +8869,17 @@
                 "status": {
                     "type": "string"
                 },
+                "task_count": {
+                    "description": "TaskCount is how many tasks the run covers: the pinned count when pinned,\notherwise the set's current size. It is a display figure — the\nauthoritative dispatch count is len(RunTasks), which also drops a pinned\ntask deleted after the run was created.",
+                    "type": "integer"
+                },
+                "task_ids": {
+                    "description": "TaskIDs pins the run's task list at creation; nil means the whole set.\nPinning is what makes a sampled subset possible, and it also stops a task\nadded to the set later from retroactively inflating samples_expected and\nflipping a finished run to inconclusive.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "task_set_id": {
                     "type": "integer"
                 },
@@ -8874,6 +8907,10 @@
                 },
                 "k": {
                     "description": "K is samples per (task, variant). Omitted uses [eval] default_k.",
+                    "type": "integer"
+                },
+                "sample_tasks": {
+                    "description": "SampleTasks runs a stratified random subset of the set instead of all of\nit. 0 or a value at or above the set size runs everything. The server\ndraws, because the drawn ids are recorded on the run and every expected-\nsample figure counts what was drawn.",
                     "type": "integer"
                 },
                 "task_set": {

--- a/internal/api/eval.go
+++ b/internal/api/eval.go
@@ -55,6 +55,11 @@ type evalRunInput struct {
 	CostCap float64 `json:"cost_cap"`
 	// AsOf pins the clock (RFC3339) so a replay is date-deterministic.
 	AsOf string `json:"as_of"`
+	// SampleTasks runs a stratified random subset of the set instead of all of
+	// it. 0 or a value at or above the set size runs everything. The server
+	// draws, because the drawn ids are recorded on the run and every expected-
+	// sample figure counts what was drawn.
+	SampleTasks int `json:"sample_tasks"`
 }
 
 // evalTaskSetDetail is a task set with its tasks.
@@ -532,7 +537,7 @@ func (s *Server) handleImportEvalTaskSet(w http.ResponseWriter, r *http.Request)
 
 // handleCreateEvalRun godoc
 // @Summary Start an eval comparison run
-// @Description Creates and launches a background run: every task in the set is executed k times against each variant, on the base agent's live engine under the eval execution policy. Reads run for real, writes are suppressed, and nothing is persisted to conversations, telemetry or memory. Costs real tokens, bounded by cost_cap and by [eval] max_concurrent. By convention the first variant is the incumbent (empty overlay = live config) and per-task deltas are measured against it.
+// @Description Creates and launches a background run: every task in the set is executed k times against each variant, on the base agent's live engine under the eval execution policy. Reads run for real, writes are suppressed, and nothing is persisted to conversations, telemetry or memory. Costs real tokens, bounded by cost_cap and by [eval] max_concurrent. By convention the first variant is the incumbent (empty overlay = live config) and per-task deltas are measured against it. Pass sample_tasks to run a stratified random subset instead of the whole set; the drawn task ids are pinned on the run, so a task added to the set later cannot retroactively change what the run was measured over.
 // @Tags eval
 // @Accept json
 // @Produce json
@@ -577,13 +582,46 @@ func (s *Server) handleCreateEvalRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	draft, errMsg, err := s.draftEvalRun(r, set, input)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+	if errMsg != "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": errMsg})
+		return
+	}
+
+	run, created, err := s.deps.EvalStore.CreateRun(r.Context(), draft, variants)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+	if err := s.deps.EvalRunner.StartRun(r.Context(), run.ID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("starting run: %v", err)})
+		return
+	}
+	s.logger.Info("eval run started", "run", run.ID, "agent", input.BaseAgent,
+		"task_set", input.TaskSet, "k", run.K, "cost_cap", run.CostCap,
+		"variants", len(created), "tasks", run.TaskCount, "sampled", len(run.TaskIDs) > 0)
+	writeJSON(w, http.StatusCreated, evalRunCreated{Run: *run, Variants: created})
+}
+
+// draftEvalRun resolves the run's own parameters — clock, k, cap and the
+// pinned task list — returning a client-error message instead on rejection.
+//
+// The subset is drawn here rather than by the caller because the drawn ids are
+// what the run is measured over: they go on the row, and every expected-sample
+// figure counts them.
+func (s *Server) draftEvalRun(r *http.Request, set *eval.TaskSet, input evalRunInput) (eval.Run, string, error) {
 	asOf := time.Now()
 	if input.AsOf != "" {
-		asOf, err = time.Parse(time.RFC3339, input.AsOf)
+		parsed, err := time.Parse(time.RFC3339, input.AsOf)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid as_of: must be RFC3339"})
-			return
+			return eval.Run{}, "invalid as_of: must be RFC3339", nil
 		}
+		asOf = parsed
 	}
 
 	cfg := s.deps.EvalRunner.Config()
@@ -596,25 +634,26 @@ func (s *Server) handleCreateEvalRun(w http.ResponseWriter, r *http.Request) {
 		costCap = cfg.MaxCostPerRun
 	}
 
-	run, created, err := s.deps.EvalStore.CreateRun(r.Context(), eval.Run{
+	var taskIDs eval.TaskIDList
+	if input.SampleTasks < 0 {
+		return eval.Run{}, "sample_tasks cannot be negative", nil
+	}
+	if input.SampleTasks > 0 {
+		tasks, err := s.deps.EvalStore.ListTasks(r.Context(), set.ID)
+		if err != nil {
+			return eval.Run{}, "", err
+		}
+		taskIDs = eval.DrawStratified(tasks, input.SampleTasks)
+	}
+
+	return eval.Run{
 		TaskSetID: set.ID,
 		BaseAgent: input.BaseAgent,
 		K:         k,
 		CostCap:   costCap,
 		AsOf:      asOf,
-	}, variants)
-	if err != nil {
-		writeEvalError(w, err)
-		return
-	}
-	if err := s.deps.EvalRunner.StartRun(r.Context(), run.ID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{
-			"error": fmt.Sprintf("starting run: %v", err)})
-		return
-	}
-	s.logger.Info("eval run started", "run", run.ID, "agent", input.BaseAgent,
-		"task_set", input.TaskSet, "k", k, "cost_cap", costCap, "variants", len(created))
-	writeJSON(w, http.StatusCreated, evalRunCreated{Run: *run, Variants: created})
+		TaskIDs:   taskIDs,
+	}, "", nil
 }
 
 // buildEvalVariants validates the requested variants and encodes their
@@ -694,7 +733,7 @@ func (s *Server) handleListEvalRuns(w http.ResponseWriter, r *http.Request) {
 
 // handleGetEvalRun godoc
 // @Summary Get an eval run's status and progress
-// @Description Returns the run with its variants, samples done out of expected, spend against the cap, and a rough ETA (mean sample latency times remaining, divided by concurrency). This is the authoritative view; the eval_progress WebSocket frame is a droppable convenience on top.
+// @Description Returns the run with its variants, samples done out of expected, spend against the cap, and a rough ETA (mean sample latency times remaining, divided by concurrency). samples_total counts the run's pinned task list when it has one, so a task added to the set after the run was created does not inflate it. This is the authoritative view; the eval_progress WebSocket frame is a droppable convenience on top.
 // @Tags eval
 // @Produce json
 // @Security BearerAuth
@@ -722,7 +761,7 @@ func (s *Server) handleGetEvalRun(w http.ResponseWriter, r *http.Request) {
 		writeEvalError(w, err)
 		return
 	}
-	tasks, err := s.deps.EvalStore.ListTasks(r.Context(), run.TaskSetID)
+	tasks, err := s.deps.EvalStore.RunTasks(r.Context(), run)
 	if err != nil {
 		writeEvalError(w, err)
 		return

--- a/internal/api/eval_test.go
+++ b/internal/api/eval_test.go
@@ -665,3 +665,128 @@ func TestEvalETA_ScalesByConcurrency(t *testing.T) {
 		t.Errorf("eta = %d, want 7", got)
 	}
 }
+
+// seedCategorisedTaskSet builds a set with one task per named category, so a
+// stratified draw has something to stratify over.
+func seedCategorisedTaskSet(t *testing.T, store *eval.Store, name string, perCategory int, categories ...string) *eval.TaskSet {
+	t.Helper()
+	set, err := store.CreateTaskSet(context.Background(), name, "")
+	if err != nil {
+		t.Fatalf("CreateTaskSet: %v", err)
+	}
+	for _, cat := range categories {
+		for i := 0; i < perCategory; i++ {
+			if _, err := store.AddTask(context.Background(), set.ID,
+				eval.Task{Prompt: cat + " prompt", Category: cat}); err != nil {
+				t.Fatalf("AddTask: %v", err)
+			}
+		}
+	}
+	return set
+}
+
+func TestEvalRuns_SampleTasksPinsAStratifiedSubset(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedCategorisedTaskSet(t, store, "set", 4,
+		eval.CategoryChat, eval.CategorySkillCommand, eval.CategoryToolHeavy)
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/runs",
+		`{"task_set":"set","base_agent":"default","k":1,"sample_tasks":5,`+
+			`"variants":[{"name":"incumbent"},{"name":"candidate"}]}`, "dk-test-key")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rec.Code, rec.Body.String())
+	}
+	var created evalRunCreated
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(created.TaskIDs) != 5 {
+		t.Fatalf("task_ids = %v, want the 5 drawn tasks recorded on the run", created.TaskIDs)
+	}
+	if created.TaskCount != 5 {
+		t.Errorf("task_count = %d, want the drawn 5 (of a 12-task set)", created.TaskCount)
+	}
+
+	rec = evalRequest(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/v1/eval/runs/%d", created.ID), "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var detail evalRunDetail
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.SamplesTotal != 10 {
+		t.Errorf("samples_total = %d, want 5 drawn tasks x 2 variants x k=1 = 10", detail.SamplesTotal)
+	}
+}
+
+func TestEvalRuns_SampleTasksAtOrAboveSetSizeRunsEverything(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "a", "b")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/runs",
+		`{"task_set":"set","base_agent":"default","k":1,"sample_tasks":9,`+
+			`"variants":[{"name":"incumbent"},{"name":"candidate"}]}`, "dk-test-key")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rec.Code, rec.Body.String())
+	}
+	var created evalRunCreated
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.TaskIDs != nil {
+		t.Errorf("task_ids = %v, want no pin when the sample covers the whole set", created.TaskIDs)
+	}
+	if created.TaskCount != 2 {
+		t.Errorf("task_count = %d, want the set's 2 tasks", created.TaskCount)
+	}
+}
+
+func TestEvalRuns_CreateRejectsNegativeSampleTasks(t *testing.T) {
+	srv, store := evalTestServer(t)
+	seedTaskSet(t, store, "set", "a")
+
+	rec := evalRequest(t, srv, http.MethodPost, "/api/v1/eval/runs",
+		`{"task_set":"set","base_agent":"default","sample_tasks":-1,`+
+			`"variants":[{"name":"incumbent"},{"name":"candidate"}]}`, "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A task added to the set after the run was created must not move the run's
+// expected-sample count; before pinning it did, and could flip a finished run
+// to inconclusive.
+func TestEvalRuns_GetTotalsIgnoreTasksAddedAfterAPinnedRun(t *testing.T) {
+	srv, store := evalTestServer(t)
+	set := seedTaskSet(t, store, "set", "a", "b", "c")
+	tasks, err := store.ListTasks(context.Background(), set.ID)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	run, _, err := store.CreateRun(context.Background(), eval.Run{
+		TaskSetID: set.ID, BaseAgent: "default", K: 1, CostCap: 1, AsOf: time.Now(),
+		TaskIDs: eval.TaskIDList{tasks[0].ID},
+	}, []eval.Variant{{Name: "a"}, {Name: "b"}})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := store.AddTask(context.Background(), set.ID,
+		eval.Task{Prompt: "added later", Category: eval.CategoryChat}); err != nil {
+		t.Fatalf("AddTask: %v", err)
+	}
+
+	rec := evalRequest(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/v1/eval/runs/%d", run.ID), "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var detail evalRunDetail
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.SamplesTotal != 2 {
+		t.Errorf("samples_total = %d, want 1 pinned task x 2 variants x k=1 = 2", detail.SamplesTotal)
+	}
+}

--- a/internal/eval/pairing.go
+++ b/internal/eval/pairing.go
@@ -72,7 +72,7 @@ func (s *Store) loadPairingGrid(ctx context.Context, runID int64) (pairingGrid, 
 	if g.variants, err = s.ListVariants(ctx, runID); err != nil {
 		return g, err
 	}
-	if g.tasks, err = s.ListTasks(ctx, run.TaskSetID); err != nil {
+	if g.tasks, err = s.RunTasks(ctx, run); err != nil {
 		return g, err
 	}
 	samples, err := s.ListSamples(ctx, runID)

--- a/internal/eval/runner.go
+++ b/internal/eval/runner.go
@@ -313,11 +313,14 @@ func (r *Runner) finishBeforeStart(ctx, bookkeeping context.Context, run *Run, e
 // prepare resolves everything a run needs before the first sample: its tasks,
 // variants and the live engine it will execute on.
 func (r *Runner) prepare(ctx context.Context, run *Run) (*runState, error) {
-	tasks, err := r.store.ListTasks(ctx, run.TaskSetID)
+	tasks, err := r.store.RunTasks(ctx, run)
 	if err != nil {
 		return nil, err
 	}
 	if len(tasks) == 0 {
+		if len(run.TaskIDs) > 0 {
+			return nil, fmt.Errorf("run %d pins %d task(s), none of which still exist", run.ID, len(run.TaskIDs))
+		}
 		return nil, fmt.Errorf("task set %d has no tasks", run.TaskSetID)
 	}
 	variants, err := r.store.ListVariants(ctx, run.ID)

--- a/internal/eval/runner_test.go
+++ b/internal/eval/runner_test.go
@@ -814,3 +814,92 @@ func waitForCalls(t *testing.T, m *mockEngine, n int) {
 	}
 	t.Fatalf("engine saw %d calls, waited for %d", m.callCount(), n)
 }
+
+// createPinnedRun mirrors createRun but pins the run to a subset of the set's
+// tasks, the shape POST /eval/runs produces when sample_tasks is set.
+func (f *runnerFixture) createPinnedRun(t *testing.T, k int, costCap float64, pin TaskIDList, variants ...Variant) *Run {
+	t.Helper()
+	run, _, err := f.store.CreateRun(context.Background(), Run{
+		TaskSetID: f.setID, BaseAgent: "pamela", K: k, CostCap: costCap,
+		AsOf: time.Now().UTC(), TaskIDs: pin,
+	}, variants)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return run
+}
+
+func TestRunner_DispatchesOnlyThePinnedTasks(t *testing.T) {
+	f := newRunnerFixture(t, Config{MaxConcurrent: 2}, nil)
+	tasks := f.addTasks(t, "first", "second", "third", "fourth")
+	run := f.createPinnedRun(t, 1, 10.0,
+		TaskIDList{tasks[0].ID, tasks[2].ID}, twoVariants()...)
+
+	if err := f.runner.StartRun(context.Background(), run.ID); err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if got := waitForTerminal(t, f.store, run.ID); got.Status != StatusDone {
+		t.Fatalf("status = %q, want %q (error %q)", got.Status, StatusDone, got.Error)
+	}
+
+	samples, err := f.store.ListSamples(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("ListSamples: %v", err)
+	}
+	if len(samples) != 4 {
+		t.Fatalf("got %d samples, want 2 pinned tasks x 2 variants x k=1 = 4", len(samples))
+	}
+	pinned := map[int64]bool{tasks[0].ID: true, tasks[2].ID: true}
+	for _, smp := range samples {
+		if !pinned[smp.TaskID] {
+			t.Errorf("sample ran task %d, which the run does not pin", smp.TaskID)
+		}
+	}
+}
+
+// The runner's dispatch count and the summary's samples_expected are read from
+// the same pinned list; a disagreement would make every finished sampled run
+// look incomplete.
+func TestRunner_PinnedRunIsSampleComplete(t *testing.T) {
+	f := newRunnerFixture(t, Config{MaxConcurrent: 2}, nil)
+	tasks := f.addTasks(t, "first", "second", "third")
+	run := f.createPinnedRun(t, 2, 10.0, TaskIDList{tasks[1].ID}, twoVariants()...)
+
+	if err := f.runner.StartRun(context.Background(), run.ID); err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForTerminal(t, f.store, run.ID)
+
+	sum, err := f.store.Summarize(context.Background(), run.ID, SummaryOpts{})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if sum.Completeness.SamplesExpected != 4 {
+		t.Errorf("samples_expected = %d, want 1 pinned task x 2 variants x k=2 = 4",
+			sum.Completeness.SamplesExpected)
+	}
+	if sum.Completeness.SamplesOK != 4 || !sum.Completeness.Conclusive {
+		t.Errorf("completeness = %+v, want a complete, conclusive run", sum.Completeness)
+	}
+}
+
+func TestRunner_PinnedRunWhoseTasksAllVanishedFails(t *testing.T) {
+	f := newRunnerFixture(t, Config{MaxConcurrent: 1}, nil)
+	tasks := f.addTasks(t, "only", "other")
+	run := f.createPinnedRun(t, 1, 10.0, TaskIDList{tasks[0].ID}, twoVariants()...)
+	if err := f.store.DeleteTask(context.Background(), f.setID, tasks[0].ID); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+
+	if err := f.runner.StartRun(context.Background(), run.ID); err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	got := waitForTerminal(t, f.store, run.ID)
+	if got.Status != StatusFailed {
+		t.Fatalf("status = %q, want %q - a run with nothing left to dispatch is a failure, not a silent no-op",
+			got.Status, StatusFailed)
+	}
+	if !strings.Contains(got.Error, "pins") {
+		t.Errorf("error = %q, want it to name the vanished pin", got.Error)
+	}
+}

--- a/internal/eval/sampling.go
+++ b/internal/eval/sampling.go
@@ -1,0 +1,78 @@
+package eval
+
+import "sort"
+
+// DrawStratified picks n task ids spread across the four curation categories,
+// for the "quick check" shape: a cheap first signal that still touches every
+// kind of turn the set covers.
+//
+// The draw cycles the categories in their canonical order, taking one random
+// unpicked task from each pass and skipping exhausted ones, so category counts
+// differ by at most one wherever the set allows. Ranking by anything else — or
+// drawing uniformly — would let a set that is 70 % chat produce a subset that
+// is all chat, which is the one thing a stratified sample exists to prevent.
+//
+// n <= 0 or n >= len(tasks) returns nil, meaning "the whole set": the pin is
+// only worth recording when it actually narrows something, and a nil pin is
+// what every reader treats as unpinned.
+//
+// Randomness comes from randIndex (crypto/rand), like the blinding coin — the
+// package deliberately has one source rather than a security-grade one next to
+// a seeded one, and there is no seed knob to make a draw reproducible.
+func DrawStratified(tasks []Task, n int) TaskIDList {
+	if n <= 0 || n >= len(tasks) {
+		return nil
+	}
+	order, buckets := bucketByCategory(tasks)
+
+	picked := make([]int64, 0, n)
+	for len(picked) < n {
+		progressed := false
+		for _, cat := range order {
+			b := buckets[cat]
+			if len(b) == 0 {
+				continue
+			}
+			i := randIndex(len(b))
+			picked = append(picked, b[i])
+			// Swap-remove: order inside a bucket is irrelevant once the pick is
+			// random, and the final list is sorted anyway.
+			b[i] = b[len(b)-1]
+			buckets[cat] = b[:len(b)-1]
+			progressed = true
+			if len(picked) == n {
+				break
+			}
+		}
+		if !progressed {
+			break
+		}
+	}
+	sort.Slice(picked, func(i, j int) bool { return picked[i] < picked[j] })
+	return picked
+}
+
+// bucketByCategory groups task ids by category and returns the cycle order:
+// the four canonical categories first, then anything unrecognised, sorted. A
+// stored category is validated on write, so the tail is defensive — but a task
+// the draw cannot classify must still be drawable.
+func bucketByCategory(tasks []Task) ([]string, map[string][]int64) {
+	buckets := make(map[string][]int64)
+	for _, t := range tasks {
+		buckets[t.Category] = append(buckets[t.Category], t.ID)
+	}
+	order := make([]string, 0, len(buckets))
+	for _, cat := range Categories() {
+		if len(buckets[cat]) > 0 {
+			order = append(order, cat)
+		}
+	}
+	var extra []string
+	for cat := range buckets {
+		if !ValidCategory(cat) {
+			extra = append(extra, cat)
+		}
+	}
+	sort.Strings(extra)
+	return append(order, extra...), buckets
+}

--- a/internal/eval/sampling_test.go
+++ b/internal/eval/sampling_test.go
@@ -1,0 +1,316 @@
+package eval
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func mustCategorisedTask(t *testing.T, s *Store, setID int64, prompt, category string) *Task {
+	t.Helper()
+	task, err := s.AddTask(context.Background(), setID, Task{Prompt: prompt, Category: category})
+	if err != nil {
+		t.Fatalf("adding %s task: %v", category, err)
+	}
+	return task
+}
+
+// categoriesOf resolves drawn ids back to their categories, so a draw can be
+// checked for balance rather than only for size.
+func categoriesOf(tasks []Task, drawn TaskIDList) map[string]int {
+	byID := make(map[int64]string, len(tasks))
+	for _, t := range tasks {
+		byID[t.ID] = t.Category
+	}
+	counts := make(map[string]int)
+	for _, id := range drawn {
+		counts[byID[id]]++
+	}
+	return counts
+}
+
+func seedCategorised(t *testing.T, s *Store, setID int64, perCategory int, categories ...string) []Task {
+	t.Helper()
+	out := make([]Task, 0, perCategory*len(categories))
+	for _, cat := range categories {
+		for i := 0; i < perCategory; i++ {
+			out = append(out, *mustCategorisedTask(t, s, setID, cat+" prompt", cat))
+		}
+	}
+	return out
+}
+
+func TestDrawStratified_BalancesAcrossCategories(t *testing.T) {
+	s := newTestStore(t)
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 4, CategoryChat, CategorySkillCommand, CategoryToolHeavy)
+
+	drawn := DrawStratified(tasks, 5)
+	if len(drawn) != 5 {
+		t.Fatalf("drew %d tasks, want 5", len(drawn))
+	}
+	seen := make(map[int64]struct{}, len(drawn))
+	for _, id := range drawn {
+		if _, dup := seen[id]; dup {
+			t.Fatalf("task %d drawn twice", id)
+		}
+		seen[id] = struct{}{}
+	}
+	counts := categoriesOf(tasks, drawn)
+	if len(counts) != 3 {
+		t.Fatalf("counts = %v, want all three categories represented", counts)
+	}
+	for cat, n := range counts {
+		if n < 1 || n > 2 {
+			t.Errorf("category %s drew %d of 5, want counts within one of each other", cat, n)
+		}
+	}
+}
+
+func TestDrawStratified_TakesTheRemainderFromLiveCategories(t *testing.T) {
+	s := newTestStore(t)
+	set := mustTaskSet(t, s, "set")
+	tasks := []Task{*mustCategorisedTask(t, s, set.ID, "lonely", CategoryChat)}
+	tasks = append(tasks, seedCategorised(t, s, set.ID, 5, CategoryToolHeavy)...)
+
+	drawn := DrawStratified(tasks, 4)
+	counts := categoriesOf(tasks, drawn)
+	if counts[CategoryChat] != 1 {
+		t.Errorf("chat drew %d, want its only task", counts[CategoryChat])
+	}
+	if counts[CategoryToolHeavy] != 3 {
+		t.Errorf("tool_heavy drew %d, want the remaining 3 once chat is exhausted", counts[CategoryToolHeavy])
+	}
+}
+
+func TestDrawStratified_SampleAtOrAboveTaskCountIsTheWholeSet(t *testing.T) {
+	s := newTestStore(t)
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 2, CategoryChat, CategoryScheduled)
+
+	for _, n := range []int{len(tasks), len(tasks) + 10} {
+		if drawn := DrawStratified(tasks, n); drawn != nil {
+			t.Errorf("DrawStratified(%d of %d) = %v, want nil meaning the whole set", n, len(tasks), drawn)
+		}
+	}
+}
+
+func TestDrawStratified_ZeroIsTheWholeSet(t *testing.T) {
+	s := newTestStore(t)
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 3, CategoryChat)
+
+	if drawn := DrawStratified(tasks, 0); drawn != nil {
+		t.Errorf("DrawStratified(0) = %v, want nil meaning the whole set", drawn)
+	}
+}
+
+func TestDrawStratified_ReturnsIDsInCreationOrder(t *testing.T) {
+	s := newTestStore(t)
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 4, CategoryChat, CategoryToolHeavy)
+
+	drawn := DrawStratified(tasks, 5)
+	for i := 1; i < len(drawn); i++ {
+		if drawn[i-1] >= drawn[i] {
+			t.Fatalf("drawn ids %v are not ascending — the pin must read in creation order", drawn)
+		}
+	}
+}
+
+// --- RunTasks ---
+
+func pinnedRun(t *testing.T, s *Store, setID int64, k int, pin TaskIDList) *Run {
+	t.Helper()
+	run, _, err := s.CreateRun(context.Background(), Run{
+		TaskSetID: setID, BaseAgent: "pamela", K: k, CostCap: 2.0,
+		AsOf: time.Now().UTC(), TaskIDs: pin,
+	}, []Variant{{Name: "incumbent"}, {Name: "candidate"}})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return run
+}
+
+func TestRunTasks_UnpinnedRunCoversTheWholeSet(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	set := mustTaskSet(t, s, "set")
+	seedCategorised(t, s, set.ID, 3, CategoryChat)
+
+	run := pinnedRun(t, s, set.ID, 1, nil)
+	got, err := s.RunTasks(ctx, run)
+	if err != nil {
+		t.Fatalf("RunTasks: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("RunTasks returned %d tasks, want the whole set of 3", len(got))
+	}
+	if run.TaskCount != 3 {
+		t.Errorf("task_count = %d, want the set size of 3", run.TaskCount)
+	}
+	if run.TaskIDs != nil {
+		t.Errorf("task_ids = %v, want nil on an unpinned run", run.TaskIDs)
+	}
+}
+
+func TestRunTasks_PinSurvivesALaterTaskAdd(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 3, CategoryChat)
+
+	run := pinnedRun(t, s, set.ID, 1, TaskIDList{tasks[0].ID, tasks[1].ID})
+	if run.TaskCount != 2 {
+		t.Errorf("task_count = %d, want the pinned 2", run.TaskCount)
+	}
+
+	// The set grows after the run was created — the run must not notice.
+	mustCategorisedTask(t, s, set.ID, "added later", CategoryToolHeavy)
+
+	reread, err := s.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	got, err := s.RunTasks(ctx, reread)
+	if err != nil {
+		t.Fatalf("RunTasks: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != tasks[0].ID || got[1].ID != tasks[1].ID {
+		t.Fatalf("RunTasks = %v, want exactly the two pinned tasks", taskIDsOf(got))
+	}
+	if reread.TaskCount != 2 {
+		t.Errorf("task_count = %d after the set grew, want the pinned 2", reread.TaskCount)
+	}
+}
+
+func TestRunTasks_SkipsAPinnedTaskDeletedAfterTheRun(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 3, CategoryChat)
+
+	run := pinnedRun(t, s, set.ID, 1, TaskIDList{tasks[0].ID, tasks[1].ID})
+	if err := s.DeleteTask(ctx, set.ID, tasks[1].ID); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+
+	got, err := s.RunTasks(ctx, run)
+	if err != nil {
+		t.Fatalf("RunTasks: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != tasks[0].ID {
+		t.Fatalf("RunTasks = %v, want only the surviving pinned task", taskIDsOf(got))
+	}
+}
+
+func taskIDsOf(tasks []Task) []int64 {
+	out := make([]int64, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, t.ID)
+	}
+	return out
+}
+
+// --- The denominator the pin exists to stabilise ---
+
+func TestSummarize_SamplesExpectedCountsOnlyPinnedTasks(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 4, CategoryChat)
+
+	run := pinnedRun(t, s, set.ID, 1, TaskIDList{tasks[0].ID, tasks[1].ID})
+	sum, err := s.Summarize(ctx, run.ID, SummaryOpts{})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if sum.Completeness.SamplesExpected != 4 {
+		t.Errorf("samples_expected = %d, want 2 pinned tasks × 2 variants × k=1 = 4",
+			sum.Completeness.SamplesExpected)
+	}
+}
+
+// A task added to the set after a run was created used to inflate
+// samples_expected retroactively, which could drag a finished run's ratio
+// under the completeness floor and flip its verdict to inconclusive. The pin
+// is what stops that.
+func TestSummarize_LaterTaskAddCannotFlipAFinishedRunToInconclusive(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 2, CategoryChat)
+
+	run := pinnedRun(t, s, set.ID, 1, TaskIDList{tasks[0].ID, tasks[1].ID})
+	variants, err := s.ListVariants(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListVariants: %v", err)
+	}
+	for _, task := range tasks {
+		for _, v := range variants {
+			if _, err := s.AddSample(ctx, Sample{
+				RunID: run.ID, VariantID: v.ID, TaskID: task.ID,
+				Status: SampleOK, Rounds: 1, Cost: 0.01,
+			}); err != nil {
+				t.Fatalf("AddSample: %v", err)
+			}
+		}
+	}
+
+	before, err := s.Summarize(ctx, run.ID, SummaryOpts{})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if !before.Completeness.Conclusive || before.Completeness.Ratio != 1 {
+		t.Fatalf("completeness = %+v, want a complete, conclusive run", before.Completeness)
+	}
+
+	// Curation continues after the run finished.
+	for i := 0; i < 6; i++ {
+		mustCategorisedTask(t, s, set.ID, "added later", CategoryChat)
+	}
+
+	after, err := s.Summarize(ctx, run.ID, SummaryOpts{})
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if after.Completeness.SamplesExpected != before.Completeness.SamplesExpected {
+		t.Errorf("samples_expected moved from %d to %d after tasks were added to the set",
+			before.Completeness.SamplesExpected, after.Completeness.SamplesExpected)
+	}
+	if !after.Completeness.Conclusive {
+		t.Error("a finished, complete run went inconclusive because the set grew underneath it")
+	}
+}
+
+func TestCreatePairs_PairsOnlyPinnedTasks(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	set := mustTaskSet(t, s, "set")
+	tasks := seedCategorised(t, s, set.ID, 3, CategoryChat)
+
+	run := pinnedRun(t, s, set.ID, 1, TaskIDList{tasks[0].ID})
+	variants, err := s.ListVariants(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListVariants: %v", err)
+	}
+	// Samples exist for an unpinned task too — a stale row from an earlier
+	// shape must not create judging work this run never asked for.
+	for _, task := range tasks[:2] {
+		for _, v := range variants {
+			if _, err := s.AddSample(ctx, Sample{
+				RunID: run.ID, VariantID: v.ID, TaskID: task.ID, Status: SampleOK,
+			}); err != nil {
+				t.Fatalf("AddSample: %v", err)
+			}
+		}
+	}
+
+	n, err := s.CreatePairs(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("CreatePairs: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("created %d pairs, want 1 — only the pinned task is in the run", n)
+	}
+}

--- a/internal/eval/store.go
+++ b/internal/eval/store.go
@@ -8,6 +8,8 @@ package eval
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -171,6 +173,7 @@ CREATE TABLE IF NOT EXISTS eval_runs (
     cost_spent  REAL     NOT NULL DEFAULT 0,
     as_of       DATETIME NOT NULL,
     error       TEXT     NOT NULL DEFAULT '',
+    task_ids    TEXT,
     created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     finished_at DATETIME
 );
@@ -261,6 +264,9 @@ var evalMigrations = []string{
 	// upstream: OpenRouter's provider-reported serving upstream for the sample,
 	// empty for providers without the concept.
 	`ALTER TABLE eval_samples ADD COLUMN upstream TEXT NOT NULL DEFAULT ''`,
+	// task_ids: the run's task list, pinned at creation. NULL means the whole
+	// set, resolved at read time.
+	`ALTER TABLE eval_runs ADD COLUMN task_ids TEXT`,
 }
 
 // TaskSet is a named collection of eval tasks.
@@ -289,19 +295,81 @@ type Task struct {
 	CreatedAt            time.Time `db:"created_at"             json:"created_at"`
 }
 
+// TaskIDList is eval_runs.task_ids: a JSON array of task ids, or NULL for the
+// whole set. It carries its own SQL codec so a run row round-trips without the
+// callers ever handling the raw JSON.
+type TaskIDList []int64
+
+// Scan decodes the stored JSON. NULL and the empty string both mean "not
+// pinned", which is the same thing a caller sees as a nil slice.
+func (l *TaskIDList) Scan(src any) error {
+	var raw string
+	switch v := src.(type) {
+	case nil:
+		*l = nil
+		return nil
+	case string:
+		raw = v
+	case []byte:
+		raw = string(v)
+	default:
+		return fmt.Errorf("scanning task_ids: unsupported type %T", src)
+	}
+	if strings.TrimSpace(raw) == "" {
+		*l = nil
+		return nil
+	}
+	var ids []int64
+	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+		return fmt.Errorf("scanning task_ids: %w", err)
+	}
+	*l = ids
+	return nil
+}
+
+// Value encodes the pin, storing NULL rather than "[]" when absent: NULL is
+// what every reader tests for, and an empty array would read as "run nothing".
+func (l TaskIDList) Value() (driver.Value, error) {
+	if len(l) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal([]int64(l))
+	if err != nil {
+		return nil, fmt.Errorf("encoding task_ids: %w", err)
+	}
+	return string(raw), nil
+}
+
 // Run is one comparison run.
 type Run struct {
-	ID         int64      `db:"id"          json:"id"`
-	TaskSetID  int64      `db:"task_set_id" json:"task_set_id"`
-	BaseAgent  string     `db:"base_agent"  json:"base_agent"`
-	Status     string     `db:"status"      json:"status"`
-	K          int        `db:"k"           json:"k"`
-	CostCap    float64    `db:"cost_cap"    json:"cost_cap"`
-	CostSpent  float64    `db:"cost_spent"  json:"cost_spent"`
-	AsOf       time.Time  `db:"as_of"       json:"as_of"`
+	ID        int64     `db:"id"          json:"id"`
+	TaskSetID int64     `db:"task_set_id" json:"task_set_id"`
+	BaseAgent string    `db:"base_agent"  json:"base_agent"`
+	Status    string    `db:"status"      json:"status"`
+	K         int       `db:"k"           json:"k"`
+	CostCap   float64   `db:"cost_cap"    json:"cost_cap"`
+	CostSpent float64   `db:"cost_spent"  json:"cost_spent"`
+	AsOf      time.Time `db:"as_of"       json:"as_of"`
+	// TaskIDs pins the run's task list at creation; nil means the whole set.
+	// Pinning is what makes a sampled subset possible, and it also stops a task
+	// added to the set later from retroactively inflating samples_expected and
+	// flipping a finished run to inconclusive.
+	TaskIDs TaskIDList `db:"task_ids" json:"task_ids,omitempty"`
+	// TaskCount is how many tasks the run covers: the pinned count when pinned,
+	// otherwise the set's current size. It is a display figure — the
+	// authoritative dispatch count is len(RunTasks), which also drops a pinned
+	// task deleted after the run was created.
+	TaskCount  int        `db:"task_count"  json:"task_count"`
 	Error      string     `db:"error"       json:"error,omitempty"`
 	CreatedAt  time.Time  `db:"created_at"  json:"created_at"`
 	FinishedAt *time.Time `db:"finished_at" json:"finished_at,omitempty"`
+}
+
+// resolveTaskCount narrows the set-wide count the SQL returns to the pin.
+func (r *Run) resolveTaskCount() {
+	if len(r.TaskIDs) > 0 {
+		r.TaskCount = len(r.TaskIDs)
+	}
 }
 
 // Variant is one side of a comparison: a named overlay on the base agent's
@@ -717,6 +785,13 @@ func (s *Store) DeleteTask(ctx context.Context, setID, taskID int64) error {
 
 // --- Runs & variants ---
 
+// runColumns is the shared select list for run reads. task_count comes back as
+// the *set's* current size; resolveTaskCount narrows it to the pin, which is
+// cheaper and clearer than counting a JSON array in SQL.
+const runColumns = `id, task_set_id, base_agent, status, k, cost_cap, cost_spent, as_of,
+	        error, task_ids, created_at, finished_at,
+	        (SELECT COUNT(*) FROM eval_tasks t WHERE t.set_id = eval_runs.task_set_id) AS task_count`
+
 // CreateRun inserts a run in the pending status together with its variants,
 // in one transaction: a run without variants has nothing to compare and must
 // never be visible.
@@ -730,11 +805,19 @@ func (s *Store) CreateRun(ctx context.Context, run Run, variants []Variant) (*Ru
 	run.Status = StatusPending
 	run.CreatedAt = time.Now().UTC()
 	res, err := tx.ExecContext(ctx,
-		`INSERT INTO eval_runs (task_set_id, base_agent, status, k, cost_cap, cost_spent, as_of, created_at)
-		 VALUES (?, ?, ?, ?, ?, 0, ?, ?)`,
-		run.TaskSetID, run.BaseAgent, run.Status, run.K, run.CostCap, run.AsOf, run.CreatedAt)
+		`INSERT INTO eval_runs (task_set_id, base_agent, status, k, cost_cap, cost_spent, as_of, task_ids, created_at)
+		 VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?)`,
+		run.TaskSetID, run.BaseAgent, run.Status, run.K, run.CostCap, run.AsOf,
+		run.TaskIDs, run.CreatedAt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating run: %w", err)
+	}
+	run.TaskCount = len(run.TaskIDs)
+	if run.TaskCount == 0 {
+		if err := tx.GetContext(ctx, &run.TaskCount,
+			`SELECT COUNT(*) FROM eval_tasks WHERE set_id = ?`, run.TaskSetID); err != nil {
+			return nil, nil, fmt.Errorf("counting tasks of set %d: %w", run.TaskSetID, err)
+		}
 	}
 	run.ID, err = res.LastInsertId()
 	if err != nil {
@@ -770,24 +853,21 @@ func (s *Store) CreateRun(ctx context.Context, run Run, variants []Variant) (*Ru
 func (s *Store) GetRun(ctx context.Context, id int64) (*Run, error) {
 	var run Run
 	err := s.db.GetContext(ctx, &run,
-		`SELECT id, task_set_id, base_agent, status, k, cost_cap, cost_spent, as_of,
-		        error, created_at, finished_at
-		 FROM eval_runs WHERE id = ?`, id)
+		`SELECT `+runColumns+` FROM eval_runs WHERE id = ?`, id)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("run %d: %w", id, ErrNotFound)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getting run %d: %w", id, err)
 	}
+	run.resolveTaskCount()
 	return &run, nil
 }
 
 // ListRuns returns runs newest first, optionally filtered by task set id
 // (0 = any) and status ("" = any).
 func (s *Store) ListRuns(ctx context.Context, taskSetID int64, status string) ([]Run, error) {
-	q := `SELECT id, task_set_id, base_agent, status, k, cost_cap, cost_spent, as_of,
-	             error, created_at, finished_at
-	      FROM eval_runs WHERE 1 = 1`
+	q := `SELECT ` + runColumns + ` FROM eval_runs WHERE 1 = 1`
 	var args []any
 	if taskSetID > 0 {
 		q += ` AND task_set_id = ?`
@@ -803,7 +883,42 @@ func (s *Store) ListRuns(ctx context.Context, taskSetID int64, status string) ([
 	if err := s.db.SelectContext(ctx, &runs, q, args...); err != nil {
 		return nil, fmt.Errorf("listing runs: %w", err)
 	}
+	for i := range runs {
+		runs[i].resolveTaskCount()
+	}
 	return runs, nil
+}
+
+// RunTasks returns the tasks a run covers: its pinned list, or the whole set
+// when it has none. Every reader that needs "what does this run run" goes
+// through here — the runner, the progress figures and the summary's
+// samples_expected — so the three can never disagree about the denominator.
+//
+// A pinned task deleted after the run was created is skipped rather than
+// erroring: eval_tasks has no delete guard, the samples it already produced
+// stay readable, and an expected count that no longer matches what the runner
+// can dispatch would be the worse failure. Order is always creation order, the
+// order the baseline convention and the per-task deltas are read in, whatever
+// order the pin was written in.
+func (s *Store) RunTasks(ctx context.Context, run *Run) ([]Task, error) {
+	tasks, err := s.ListTasks(ctx, run.TaskSetID)
+	if err != nil {
+		return nil, err
+	}
+	if len(run.TaskIDs) == 0 {
+		return tasks, nil
+	}
+	pinned := make(map[int64]struct{}, len(run.TaskIDs))
+	for _, id := range run.TaskIDs {
+		pinned[id] = struct{}{}
+	}
+	out := make([]Task, 0, len(run.TaskIDs))
+	for _, t := range tasks {
+		if _, ok := pinned[t.ID]; ok {
+			out = append(out, t)
+		}
+	}
+	return out, nil
 }
 
 // ListVariants returns a run's variants in creation order. The first is the

--- a/internal/eval/summary.go
+++ b/internal/eval/summary.go
@@ -190,7 +190,7 @@ func (s *Store) loadSummary(ctx context.Context, runID int64) (verdictInput, *Ru
 	if in.variants, err = s.ListVariants(ctx, runID); err != nil {
 		return in, nil, nil, err
 	}
-	if in.tasks, err = s.ListTasks(ctx, run.TaskSetID); err != nil {
+	if in.tasks, err = s.RunTasks(ctx, run); err != nil {
 		return in, nil, nil, err
 	}
 	if in.samples, err = s.ListSamples(ctx, runID); err != nil {

--- a/internal/mcpserver/tools_eval.go
+++ b/internal/mcpserver/tools_eval.go
@@ -300,7 +300,7 @@ func buildEvalRunStatus(ctx context.Context, store *eval.Store, runID int64) (*e
 	if err != nil {
 		return nil, err
 	}
-	tasks, err := store.ListTasks(ctx, run.TaskSetID)
+	tasks, err := store.RunTasks(ctx, run)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Stage D0.1 of `design/eval-subsystem.md`: pin a run's task list at creation and let a run cover a stratified subset. This is what makes the "Quick check" preset (~10 sampled tasks, k=1) possible - today `POST /eval/runs` always runs the whole set.

## What changed

1. **`eval_runs.task_ids TEXT NULL`** - JSON array of task ids, NULL = the whole set. In the CREATE TABLE for fresh DBs and as the next `evalMigrations` entry. `TaskIDList` carries its own `sql.Scanner`/`driver.Valuer`, so NULL round-trips as a nil slice and callers never touch raw JSON. Empty stores NULL rather than `"[]"` - NULL is what every reader tests for, and an empty array would read as "run nothing".

2. **`sample_tasks` on `POST /eval/runs`** - 0 or at/above the set size runs everything (no pin). Otherwise the server draws: cycle the four categories in canonical order, one random unpicked task per pass, skip exhausted categories, stop at `sample_tasks`, so counts differ by at most one wherever the set allows. Drawn server-side because the ids are recorded on the run and every expected-sample figure counts them. Randomness goes through the package's existing `randIndex` (crypto/rand), no seed knob. Negative → 400.

3. **`Store.RunTasks(ctx, run)`** is the single "what does this run run" reader. Five call sites route through it - `Runner.prepare`, `handleGetEvalRun`'s `samples_total`, `Summarize`'s `SamplesExpected`, plus two the plan did not list: `loadPairingGrid` and the `eval_run_status` MCP tool. Both hold a run and would otherwise have disagreed with the runner about the grid.

4. **`task_ids` (omitempty) and `task_count` on run responses**, so D1 can render "10 of 37 tasks".

Also fixes the latent bug the plan calls out: a task added to a set after a run was created inflated `samples_expected` retroactively and could drag a finished run under the completeness floor. `TestSummarize_LaterTaskAddCannotFlipAFinishedRunToInconclusive` is the canary.

## Deleted pinned task

`eval_tasks` has no referenced-run delete guard today and this does not add one - deleting a task already had "samples already recorded are left alone" semantics. `RunTasks` therefore filters the pin against what still exists, so the runner's dispatch, `samples_total` and `SamplesExpected` shrink together and stay in agreement (`TestRunTasks_SkipsAPinnedTaskDeletedAfterTheRun`, `TestRunner_PinnedRunIsSampleComplete`). A pin whose tasks have *all* vanished fails the run with an error naming the pin rather than silently dispatching nothing.

`Run.TaskCount` is documented as a display figure (pinned count, else set size) and can lag by one in that edge; `len(RunTasks)` is authoritative wherever the number matters.

## Divergence to flag

**The retroactive-inflation fix applies to pinned runs only.** An unpinned run keeps NULL, which by definition means "the whole set, resolved at read time", so it still tracks a growing set. That follows the plan's explicit `task_ids stays NULL` contract for the whole-set case rather than always recording the pin. If you would rather close it everywhere, always pinning is a one-line change in `draftEvalRun` - happy to make it, but it puts a full task-id array on every run row.

## Test evidence

<details>
<summary><code>just hook</code> - all green</summary>

```
✓ fmt-check
✓ vet
✓ lint
✓ lint-ui
✓ test
✓ test-ui
✓ openapi-check
```

Plus `go test -tags=integration -race ./internal/integration/...` → ok (46s).
</details>

New tests: stratified draw balance and remainder-from-live-categories, `sample_tasks >= n` and 0 → whole set, ids ascending; `RunTasks` unpinned/pinned/pin-survives-a-later-add/deleted-pin; `Summarize` samples_expected over the pin and the inconclusive-flip canary; `CreatePairs` only pairs pinned tasks; runner dispatches only drawn tasks, is sample-complete, and fails on a fully vanished pin; API create carries `task_ids`/`task_count`, whole-set case leaves no pin, negative rejected, `samples_total` ignores later adds.

## Outside the slice

`internal/mcpserver/tools_eval.go` - one line, `ListTasks` → `RunTasks` in `buildEvalRunStatus`, for the same reason as the other readers.

`just openapi` regenerated: two `@Description` updates and the two new `eval.Run` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
