### PR TITLE
feat(eval): suggest test cases from history (Stage D3 backend)

### DIFF
--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -199,9 +199,10 @@ type SQLiteMemoryStore struct {
 
 // Compile-time interface checks.
 var (
-	_ MemoryStore        = (*SQLiteMemoryStore)(nil)
-	_ TelemetryStore     = (*SQLiteMemoryStore)(nil)
-	_ ActiveChannelStore = (*SQLiteMemoryStore)(nil)
+	_ MemoryStore          = (*SQLiteMemoryStore)(nil)
+	_ TelemetryStore       = (*SQLiteMemoryStore)(nil)
+	_ ActiveChannelStore   = (*SQLiteMemoryStore)(nil)
+	_ InterestingTurnStore = (*SQLiteMemoryStore)(nil)
 )
 
 const schema = `
@@ -1515,6 +1516,163 @@ func (s *SQLiteMemoryStore) TransitionSkillRevisions(ctx context.Context, agent,
 		return nil, fmt.Errorf("listing skill revisions for transition %q: %w", transitionID, err)
 	}
 	return revs, nil
+}
+
+// TurnMessage is one {role, content} pair of context preceding a turn. It is
+// the shape eval task pinned history is stored in.
+type TurnMessage struct {
+	Role    string `db:"role"    json:"role"`
+	Content string `db:"content" json:"content"`
+}
+
+// InterestingTurn is one past user turn with the facts that decide whether it
+// is worth offering as an eval test case. The facts are raw — which signals
+// count, and how they rank, is the caller's policy (internal/eval decides
+// both, since the cost decile is relative to the pool it asked for).
+type InterestingTurn struct {
+	MessageID      int64     `db:"message_id"`
+	ConversationID string    `db:"conversation_id"`
+	Content        string    `db:"content"`
+	CreatedAt      time.Time `db:"created_at"`
+	// ToolCalls, MaxRound, Faults and ReplyCost describe the assistant reply to
+	// this turn: the next assistant message in the conversation.
+	ToolCalls int     `db:"tool_calls"`
+	MaxRound  int     `db:"max_round"`
+	Faults    int     `db:"faults"`
+	ReplyCost float64 `db:"reply_cost"`
+	// CommandMatches counts skills that matched this turn via a command
+	// trigger (match_type 'command'), as opposed to ambient or scheduled.
+	CommandMatches int `db:"command_matches"`
+	// Preceding holds up to precedingTurns messages immediately before this
+	// one, oldest first, each capped at precedingContentMax runes.
+	Preceding []TurnMessage `db:"-"`
+}
+
+// InterestingTurnStore is the narrow telemetry surface behind the eval
+// "suggest test cases from history" endpoint. It is deliberately not folded
+// into MemoryStore or TelemetryStore: obtain one by type-asserting a
+// MemoryStore, the same way the API layer reaches TelemetryStore.
+type InterestingTurnStore interface {
+	ListInterestingTurns(ctx context.Context, agent string, since time.Time, limit int) ([]InterestingTurn, error)
+}
+
+const (
+	// precedingTurns is how many messages of context travel with a candidate,
+	// enough to pin a short history without turning a suggestion into a
+	// transcript.
+	precedingTurns = 4
+	// precedingContentMax caps each preceding message so one runaway tool dump
+	// cannot dominate the response.
+	precedingContentMax = 2000
+	// interestingTurnsMaxLimit bounds the candidate pool. Preceding context is
+	// fetched per turn, so the pool size is also the query count.
+	interestingTurnsMaxLimit = 500
+	// sqliteDatetimeLayout is what CURRENT_TIMESTAMP writes into a DATETIME
+	// column.
+	sqliteDatetimeLayout = "2006-01-02 15:04:05"
+)
+
+// interestingTurnsQuery pairs each user message with the assistant message
+// that answered it (the next assistant row in the conversation) and rolls up
+// that reply's tool calls. Agent scoping goes through conversation_stats,
+// LEFT-joined so an unfiltered call still sees turns whose stats row was
+// pruned.
+const interestingTurnsQuery = `
+SELECT
+    c.message_id,
+    c.conversation_id,
+    c.content,
+    c.created_at,
+    COALESCE(tc.tool_calls, 0)     AS tool_calls,
+    COALESCE(tc.max_round, 0)      AS max_round,
+    COALESCE(tc.faults, 0)         AS faults,
+    COALESCE(r.cost, 0)            AS reply_cost,
+    COALESCE(ms.command_matches, 0) AS command_matches
+FROM (
+    SELECT m.id AS message_id, m.conversation_id, m.content, m.created_at,
+           (SELECT a.id FROM messages a
+             WHERE a.conversation_id = m.conversation_id
+               AND a.role = 'assistant'
+               AND a.id > m.id
+             ORDER BY a.id LIMIT 1) AS reply_id
+    FROM messages m
+    LEFT JOIN conversation_stats cs ON cs.conversation_id = m.conversation_id
+    WHERE m.role = 'user'
+      AND m.created_at >= ?
+      AND (? = '' OR cs.agent = ?)
+) c
+JOIN messages r ON r.id = c.reply_id
+LEFT JOIN (
+    SELECT message_id,
+           COUNT(*) AS tool_calls,
+           MAX(round) AS max_round,
+           SUM(CASE WHEN outcome IN ('rejected', 'failed') THEN 1 ELSE 0 END) AS faults
+    FROM tool_calls GROUP BY message_id
+) tc ON tc.message_id = c.reply_id
+LEFT JOIN (
+    SELECT message_id,
+           SUM(CASE WHEN match_type = 'command' THEN 1 ELSE 0 END) AS command_matches
+    FROM message_skills GROUP BY message_id
+) ms ON ms.message_id = c.message_id
+ORDER BY c.created_at DESC, c.message_id DESC
+LIMIT ?`
+
+// ListInterestingTurns returns the most recent answered user turns since the
+// given time, newest first, with the reply telemetry a suggestion ranker needs.
+// An empty agent means every agent. The limit bounds the candidate pool, not
+// the number of suggestions.
+func (s *SQLiteMemoryStore) ListInterestingTurns(ctx context.Context, agent string, since time.Time, limit int) ([]InterestingTurn, error) {
+	if limit <= 0 || limit > interestingTurnsMaxLimit {
+		limit = interestingTurnsMaxLimit
+	}
+	var turns []InterestingTurn
+	// Bound as SQLite's own DATETIME text rather than a time.Time: created_at
+	// is stored by CURRENT_TIMESTAMP in that layout, and the comparison is a
+	// string comparison whichever way the driver renders the parameter.
+	sinceText := since.UTC().Format(sqliteDatetimeLayout)
+	if err := s.db.SelectContext(ctx, &turns, interestingTurnsQuery, sinceText, agent, agent, limit); err != nil {
+		return nil, fmt.Errorf("listing interesting turns: %w", err)
+	}
+	for i := range turns {
+		preceding, err := s.precedingMessages(ctx, turns[i].ConversationID, turns[i].MessageID)
+		if err != nil {
+			return nil, err
+		}
+		turns[i].Preceding = preceding
+	}
+	return turns, nil
+}
+
+// precedingMessages returns the messages immediately before msgID in its
+// conversation, oldest first.
+func (s *SQLiteMemoryStore) precedingMessages(ctx context.Context, convID string, msgID int64) ([]TurnMessage, error) {
+	var msgs []TurnMessage
+	err := s.db.SelectContext(ctx, &msgs,
+		`SELECT role, substr(content, 1, ?) AS content
+		 FROM messages
+		 WHERE conversation_id = ? AND id < ?
+		 ORDER BY id DESC LIMIT ?`,
+		precedingContentMax+1, convID, msgID, precedingTurns)
+	if err != nil {
+		return nil, fmt.Errorf("loading context before message %d: %w", msgID, err)
+	}
+	slices.Reverse(msgs)
+	for i := range msgs {
+		msgs[i].Content = truncateRunes(msgs[i].Content, precedingContentMax)
+	}
+	return msgs, nil
+}
+
+// truncateRunes cuts s to at most n runes, marking the cut with an ellipsis.
+func truncateRunes(s string, n int) string {
+	count := 0
+	for i := range s {
+		count++
+		if count > n {
+			return s[:i] + "…"
+		}
+	}
+	return s
 }
 
 // MessageSearchHit represents a single FTS5 search result.

--- a/internal/agent/memory_interesting_test.go
+++ b/internal/agent/memory_interesting_test.go
@@ -1,0 +1,282 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// seedTurn writes a user message, its assistant reply, and the reply's tool
+// calls, returning the user message id. It mirrors what Engine.persistTelemetry
+// does: tool calls hang off the assistant message, skill usages off the user's.
+func seedTurn(t *testing.T, store *SQLiteMemoryStore, convID, agent, prompt string, replyCost float64, calls []ToolCallRecord, skills []SkillUsageRecord) int64 {
+	t.Helper()
+	ctx := context.Background()
+
+	userID, err := store.AddMessage(ctx, convID, StoredMessage{Role: "user", Content: prompt})
+	if err != nil {
+		t.Fatalf("adding user message: %v", err)
+	}
+	reply := StoredMessage{Role: "assistant", Content: "reply to " + prompt, Cost: replyCost}
+	replyID, err := store.AddMessage(ctx, convID, reply)
+	if err != nil {
+		t.Fatalf("adding assistant message: %v", err)
+	}
+	if len(calls) > 0 {
+		if err := store.AddToolCalls(ctx, convID, replyID, calls); err != nil {
+			t.Fatalf("adding tool calls: %v", err)
+		}
+	}
+	if len(skills) > 0 {
+		if err := store.AddSkillUsages(ctx, convID, userID, skills); err != nil {
+			t.Fatalf("adding skill usages: %v", err)
+		}
+	}
+	if err := store.UpdateConversationStats(ctx, convID, agent, reply, len(calls), 0); err != nil {
+		t.Fatalf("updating conversation stats: %v", err)
+	}
+	return userID
+}
+
+func TestListInterestingTurns_CarriesReplyTelemetry(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	convID, _ := store.GetOrCreateConversation(ctx, "telegram", "1")
+	userID := seedTurn(t, store, convID, "pamela", "check the calendar", 0.42,
+		[]ToolCallRecord{
+			{ToolName: "kv_get", Round: 1, Success: true, Outcome: "ok"},
+			{ToolName: "web_fetch", Round: 2, Success: false, Outcome: "rejected"},
+			{ToolName: "web_fetch", Round: 3, Success: false, Outcome: "failed"},
+			{ToolName: "kv_set", Round: 3, Success: true, Outcome: "cached"},
+		},
+		[]SkillUsageRecord{{SkillName: "calendar", MatchType: "command"}})
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns = %d, want 1: %+v", len(turns), turns)
+	}
+	got := turns[0]
+	if got.MessageID != userID {
+		t.Errorf("MessageID = %d, want %d (the user turn, not the reply)", got.MessageID, userID)
+	}
+	if got.ConversationID != convID {
+		t.Errorf("ConversationID = %q, want %q", got.ConversationID, convID)
+	}
+	if got.Content != "check the calendar" {
+		t.Errorf("Content = %q, want the user prompt", got.Content)
+	}
+	if got.ToolCalls != 4 {
+		t.Errorf("ToolCalls = %d, want 4", got.ToolCalls)
+	}
+	if got.MaxRound != 3 {
+		t.Errorf("MaxRound = %d, want 3", got.MaxRound)
+	}
+	if got.Faults != 2 {
+		t.Errorf("Faults = %d, want 2 (rejected + failed, not cached)", got.Faults)
+	}
+	if got.ReplyCost != 0.42 {
+		t.Errorf("ReplyCost = %v, want 0.42", got.ReplyCost)
+	}
+	if got.CommandMatches != 1 {
+		t.Errorf("CommandMatches = %d, want 1", got.CommandMatches)
+	}
+}
+
+func TestListInterestingTurns_IgnoresAmbientAndScheduledMatches(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	convID, _ := store.GetOrCreateConversation(ctx, "telegram", "1")
+	seedTurn(t, store, convID, "pamela", "morning", 0.01, nil, []SkillUsageRecord{
+		{SkillName: "soul", MatchType: "always"},
+		{SkillName: "heartbeat", MatchType: "schedule"},
+	})
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns = %d, want 1", len(turns))
+	}
+	if turns[0].CommandMatches != 0 {
+		t.Errorf("CommandMatches = %d, want 0 — only match_type 'command' counts", turns[0].CommandMatches)
+	}
+}
+
+func TestListInterestingTurns_ScopesToAgent(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	mine, _ := store.GetOrCreateConversation(ctx, "telegram", "mine")
+	theirs, _ := store.GetOrCreateConversation(ctx, "telegram", "theirs")
+	seedTurn(t, store, mine, "pamela", "mine", 0.01, nil, nil)
+	seedTurn(t, store, theirs, "argus", "theirs", 0.01, nil, nil)
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns = %d, want 1", len(turns))
+	}
+	if turns[0].Content != "mine" {
+		t.Errorf("Content = %q, want %q — another agent's turns must never appear", turns[0].Content, "mine")
+	}
+
+	all, err := store.ListInterestingTurns(ctx, "", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns(all agents): %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("unfiltered turns = %d, want 2", len(all))
+	}
+}
+
+func TestListInterestingTurns_CarriesPrecedingContext(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	convID, _ := store.GetOrCreateConversation(ctx, "telegram", "1")
+	for _, p := range []string{"first", "second", "third"} {
+		seedTurn(t, store, convID, "pamela", p, 0.01, nil, nil)
+	}
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	if len(turns) != 3 {
+		t.Fatalf("turns = %d, want 3", len(turns))
+	}
+	// Newest first, so turns[0] is "third" and sees the two full turns before it.
+	latest := turns[0]
+	if latest.Content != "third" {
+		t.Fatalf("first turn = %q, want %q (newest first)", latest.Content, "third")
+	}
+	if len(latest.Preceding) != precedingTurns {
+		t.Fatalf("Preceding = %d messages, want %d: %+v", len(latest.Preceding), precedingTurns, latest.Preceding)
+	}
+	want := []TurnMessage{
+		{Role: "user", Content: "first"},
+		{Role: "assistant", Content: "reply to first"},
+		{Role: "user", Content: "second"},
+		{Role: "assistant", Content: "reply to second"},
+	}
+	for i, w := range want {
+		if latest.Preceding[i] != w {
+			t.Errorf("Preceding[%d] = %+v, want %+v (oldest first)", i, latest.Preceding[i], w)
+		}
+	}
+	// The oldest turn has nothing before it.
+	if len(turns[2].Preceding) != 0 {
+		t.Errorf("oldest turn Preceding = %+v, want none", turns[2].Preceding)
+	}
+}
+
+func TestListInterestingTurns_CapsPrecedingContent(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	convID, _ := store.GetOrCreateConversation(ctx, "telegram", "1")
+	huge := ""
+	for range precedingContentMax + 500 {
+		huge += "x"
+	}
+	seedTurn(t, store, convID, "pamela", huge, 0.01, nil, nil)
+	seedTurn(t, store, convID, "pamela", "next", 0.01, nil, nil)
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	latest := turns[0]
+	if len(latest.Preceding) == 0 {
+		t.Fatalf("expected preceding context")
+	}
+	if got := []rune(latest.Preceding[0].Content); len(got) != precedingContentMax+1 {
+		t.Errorf("preceding content = %d runes, want %d plus the ellipsis", len(got), precedingContentMax)
+	}
+	// The candidate's own prompt is never truncated — it becomes the test case.
+	if len([]rune(latest.Content)) != 4 {
+		t.Errorf("Content = %q, want the untruncated prompt", latest.Content)
+	}
+}
+
+func TestListInterestingTurns_SkipsUnansweredTurns(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	convID, _ := store.GetOrCreateConversation(ctx, "telegram", "1")
+	seedTurn(t, store, convID, "pamela", "answered", 0.01, nil, nil)
+	if _, err := store.AddMessage(ctx, convID, StoredMessage{Role: "user", Content: "still waiting"}); err != nil {
+		t.Fatalf("adding message: %v", err)
+	}
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns = %d, want 1 — a turn with no reply has no telemetry to judge", len(turns))
+	}
+	if turns[0].Content != "answered" {
+		t.Errorf("Content = %q, want %q", turns[0].Content, "answered")
+	}
+}
+
+func TestListInterestingTurns_HonoursSince(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	convID, _ := store.GetOrCreateConversation(ctx, "telegram", "1")
+	oldID := seedTurn(t, store, convID, "pamela", "ancient", 0.01, nil, nil)
+	seedTurn(t, store, convID, "pamela", "recent", 0.01, nil, nil)
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE messages SET created_at = datetime('now', '-120 days') WHERE id = ?`, oldID); err != nil {
+		t.Fatalf("backdating message: %v", err)
+	}
+
+	turns, err := store.ListInterestingTurns(ctx, "pamela", time.Now().Add(-90*24*time.Hour), 10)
+	if err != nil {
+		t.Fatalf("ListInterestingTurns: %v", err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("turns = %d, want 1", len(turns))
+	}
+	if turns[0].Content != "recent" {
+		t.Errorf("Content = %q, want %q", turns[0].Content, "recent")
+	}
+}

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -2863,6 +2863,87 @@
                 }
             }
         },
+        "/eval/suggest": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Mines past turns for ones worth saving as test cases: any rejected or failed tool call, three or more tool rounds, a reply cost in the pool's top decile, or a command-triggered skill. Candidates are stratified across the four categories rather than ranked overall, since a set drawn purely by interestingness would be all failures and represent nothing the agent normally does. Turns already saved as a task are skipped, and a turn carrying no signal is never offered. Nothing is written — accepting a candidate is a separate call to the task create endpoint.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "eval"
+                ],
+                "summary": "Suggest eval test cases from history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Only turns handled by this agent",
+                        "name": "agent",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Candidates returned across all categories (default 20, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "RFC3339 lower bound on turn time (default 90 days ago)",
+                        "name": "since",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Stratified candidates",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api.evalSuggestResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad limit or since",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Store error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Telemetry not available",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Eval subsystem not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/eval/task-sets": {
             "get": {
                 "security": [
@@ -7807,6 +7888,38 @@
                 }
             }
         },
+        "github_com_Temikus_denkeeper_internal_eval.Candidate": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "conversation_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "message_id": {
+                    "type": "integer"
+                },
+                "preceding": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PrecedingMessage"
+                    }
+                },
+                "prompt": {
+                    "type": "string"
+                },
+                "signals": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "github_com_Temikus_denkeeper_internal_eval.CategoryResult": {
             "type": "object",
             "properties": {
@@ -7975,6 +8088,17 @@
                     "type": "string"
                 },
                 "llm_provider": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.PrecedingMessage": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "role": {
                     "type": "string"
                 }
             }
@@ -9137,6 +9261,17 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/internal_api.evalVariantInput"
+                    }
+                }
+            }
+        },
+        "internal_api.evalSuggestResult": {
+            "type": "object",
+            "properties": {
+                "candidates": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.Candidate"
                     }
                 }
             }

--- a/internal/api/eval.go
+++ b/internal/api/eval.go
@@ -89,6 +89,12 @@ type evalImportResult struct {
 	Imported int `json:"imported"`
 }
 
+// evalSuggestResult is the cold-start fill path's response: past turns worth
+// saving as test cases, stratified across the four categories.
+type evalSuggestResult struct {
+	Candidates []eval.Candidate `json:"candidates"`
+}
+
 // --- Guards and helpers ---
 
 // evalRequired writes a 503 when the eval subsystem is not wired.
@@ -897,4 +903,92 @@ func (s *Server) handleEvalRunSamples(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, samples)
+}
+
+// --- Suggestions ---
+
+const (
+	// suggestDefaultLimit is how many candidates a suggestion pass returns —
+	// enough to fill the four category columns without a wall of cards.
+	suggestDefaultLimit = 20
+	suggestMaxLimit     = 100
+	// suggestDefaultWindow is how far back the telemetry query looks.
+	suggestDefaultWindow = 90 * 24 * time.Hour
+	// suggestPoolFactor oversamples the candidate pool relative to the limit:
+	// stratification and the cost decile both need more turns to choose from
+	// than the pass returns.
+	suggestPoolFactor = 10
+	suggestMinPool    = 100
+)
+
+// suggestParams parses the query string, writing a 400 and reporting false on
+// a malformed one.
+func suggestParams(w http.ResponseWriter, r *http.Request) (agentName string, since time.Time, limit int, ok bool) {
+	agentName = r.URL.Query().Get("agent")
+	limit = suggestDefaultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "limit must be a positive integer"})
+			return "", time.Time{}, 0, false
+		}
+		limit = min(n, suggestMaxLimit)
+	}
+	since = time.Now().Add(-suggestDefaultWindow)
+	if raw := r.URL.Query().Get("since"); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "since must be an RFC3339 timestamp"})
+			return "", time.Time{}, 0, false
+		}
+		since = t
+	}
+	return agentName, since, limit, true
+}
+
+// handleEvalSuggest godoc
+// @Summary Suggest eval test cases from history
+// @Description Mines past turns for ones worth saving as test cases: any rejected or failed tool call, three or more tool rounds, a reply cost in the pool's top decile, or a command-triggered skill. Candidates are stratified across the four categories rather than ranked overall, since a set drawn purely by interestingness would be all failures and represent nothing the agent normally does. Turns already saved as a task are skipped, and a turn carrying no signal is never offered. Nothing is written — accepting a candidate is a separate call to the task create endpoint.
+// @Tags eval
+// @Produce json
+// @Security BearerAuth
+// @Param agent query string false "Only turns handled by this agent"
+// @Param limit query int false "Candidates returned across all categories (default 20, max 100)"
+// @Param since query string false "RFC3339 lower bound on turn time (default 90 days ago)"
+// @Success 200 {object} evalSuggestResult "Stratified candidates"
+// @Failure 400 {object} map[string]string "Bad limit or since"
+// @Failure 500 {object} map[string]string "Store error"
+// @Failure 501 {object} map[string]string "Telemetry not available"
+// @Failure 503 {object} map[string]string "Eval subsystem not configured"
+// @Router /eval/suggest [get]
+func (s *Server) handleEvalSuggest(w http.ResponseWriter, r *http.Request) {
+	if !s.evalRequired(w) {
+		return
+	}
+	store, ok := s.deps.Memory.(agent.InterestingTurnStore)
+	if !ok {
+		writeJSON(w, http.StatusNotImplemented, map[string]string{"error": "telemetry not available"})
+		return
+	}
+	agentName, since, limit, ok := suggestParams(w, r)
+	if !ok {
+		return
+	}
+
+	pool := max(limit*suggestPoolFactor, suggestMinPool)
+	turns, err := store.ListInterestingTurns(r.Context(), agentName, since, pool)
+	if err != nil {
+		s.logger.Error("listing interesting turns", "error", err, "agent", agentName)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	saved, err := s.deps.EvalStore.SavedTaskSources(r.Context())
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, evalSuggestResult{
+		Candidates: eval.Suggest(turns, eval.SuggestOpts{Limit: limit, Exclude: saved}),
+	})
 }

--- a/internal/api/eval_suggest_test.go
+++ b/internal/api/eval_suggest_test.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Temikus/denkeeper/internal/agent"
+	"github.com/Temikus/denkeeper/internal/config"
+	"github.com/Temikus/denkeeper/internal/eval"
+)
+
+// noEvalKey carries chat but neither eval scope.
+func noEvalKey() config.APIKeyConfig {
+	return config.APIKeyConfig{Name: "chat-only", Key: "dk-chat-only", Scopes: []string{"chat"}}
+}
+
+// seedSuggestTurn writes a real user turn, its assistant reply, and the reply's
+// telemetry into the server's memory store, returning the user message id.
+func seedSuggestTurn(t *testing.T, srv *Server, convID, agentName, prompt string, replyCost float64, calls []agent.ToolCallRecord, skills []agent.SkillUsageRecord) int64 {
+	t.Helper()
+	ctx := context.Background()
+	mem := srv.deps.Memory
+	tel, ok := mem.(agent.TelemetryStore)
+	if !ok {
+		t.Fatalf("memory store is not a TelemetryStore")
+	}
+	if err := mem.GetOrCreateConversationByID(ctx, convID, "test", convID); err != nil {
+		t.Fatalf("creating conversation: %v", err)
+	}
+	userID, err := mem.AddMessage(ctx, convID, agent.StoredMessage{Role: "user", Content: prompt})
+	if err != nil {
+		t.Fatalf("adding user message: %v", err)
+	}
+	reply := agent.StoredMessage{Role: "assistant", Content: "ack", Cost: replyCost}
+	replyID, err := mem.AddMessage(ctx, convID, reply)
+	if err != nil {
+		t.Fatalf("adding assistant message: %v", err)
+	}
+	if len(calls) > 0 {
+		if err := tel.AddToolCalls(ctx, convID, replyID, calls); err != nil {
+			t.Fatalf("adding tool calls: %v", err)
+		}
+	}
+	if len(skills) > 0 {
+		if err := tel.AddSkillUsages(ctx, convID, userID, skills); err != nil {
+			t.Fatalf("adding skill usages: %v", err)
+		}
+	}
+	if err := tel.UpdateConversationStats(ctx, convID, agentName, reply, len(calls), 0); err != nil {
+		t.Fatalf("updating conversation stats: %v", err)
+	}
+	return userID
+}
+
+// seedOneTurnPerCategory writes four candidate turns — one per category — plus
+// an unremarkable one that carries no signal at all. Returns the message ids
+// keyed by the category each turn should land in.
+func seedOneTurnPerCategory(t *testing.T, srv *Server, convID, agentName string) map[string]int64 {
+	t.Helper()
+	ids := map[string]int64{}
+	ids[eval.CategorySkillCommand] = seedSuggestTurn(t, srv, convID, agentName, "/report weekly", 0, nil,
+		[]agent.SkillUsageRecord{{SkillName: "report", MatchType: "command"}})
+	ids[eval.CategoryScheduled] = seedSuggestTurn(t, srv, convID, agentName,
+		"[Scheduled: heartbeat | 2026-08-01T10:00:00Z UTC | 2026-W31]", 0,
+		[]agent.ToolCallRecord{{ToolName: "kv_get", Round: 1, Outcome: "failed"}}, nil)
+	ids[eval.CategoryToolHeavy] = seedSuggestTurn(t, srv, convID, agentName, "dig through the logs", 0,
+		[]agent.ToolCallRecord{
+			{ToolName: "web_fetch", Round: 1, Success: true, Outcome: "ok"},
+			{ToolName: "web_fetch", Round: 2, Success: true, Outcome: "ok"},
+			{ToolName: "kv_get", Round: 3, Success: true, Outcome: "ok"},
+			{ToolName: "kv_set", Round: 4, Success: true, Outcome: "ok"},
+		}, nil)
+	// The priciest reply in the pool, so this one earns the cost signal alone.
+	ids[eval.CategoryChat] = seedSuggestTurn(t, srv, convID, agentName, "write me a limerick", 5.0, nil, nil)
+	// Unremarkable: no tools, no skills, no cost.
+	seedSuggestTurn(t, srv, convID, agentName, "thanks", 0, nil, nil)
+	return ids
+}
+
+func decodeSuggestions(t *testing.T, body []byte) evalSuggestResult {
+	t.Helper()
+	var got evalSuggestResult
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decoding response: %v (%s)", err, body)
+	}
+	return got
+}
+
+func TestEvalSuggest_ReturnsOnePerCategoryAndSkipsTheBoringTurn(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey())
+	ids := seedOneTurnPerCategory(t, srv, "chan:main", "default")
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest", "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	got := decodeSuggestions(t, rec.Body.Bytes())
+	if len(got.Candidates) != 4 {
+		t.Fatalf("candidates = %d, want 4 (one per category, the boring turn excluded): %+v",
+			len(got.Candidates), got.Candidates)
+	}
+	seen := map[string]int64{}
+	for _, c := range got.Candidates {
+		if _, dup := seen[c.Category]; dup {
+			t.Errorf("category %q appeared twice", c.Category)
+		}
+		seen[c.Category] = c.MessageID
+		if len(c.Signals) == 0 {
+			t.Errorf("candidate %d has no signals; it should not have been offered", c.MessageID)
+		}
+		if c.ConversationID != "chan:main" {
+			t.Errorf("ConversationID = %q, want %q", c.ConversationID, "chan:main")
+		}
+		if c.Prompt == "" || c.CreatedAt.IsZero() {
+			t.Errorf("candidate %d is missing prompt or created_at: %+v", c.MessageID, c)
+		}
+	}
+	for cat, wantID := range ids {
+		if seen[cat] != wantID {
+			t.Errorf("category %q resolved to message %d, want %d", cat, seen[cat], wantID)
+		}
+	}
+}
+
+func TestEvalSuggest_ExcludesTurnsAlreadySavedAsTasks(t *testing.T) {
+	srv, store := evalTestServer(t, allScopesKey())
+	ids := seedOneTurnPerCategory(t, srv, "chan:main", "default")
+
+	set, err := store.CreateTaskSet(context.Background(), "golden", "")
+	if err != nil {
+		t.Fatalf("CreateTaskSet: %v", err)
+	}
+	saved := ids[eval.CategoryToolHeavy]
+	if _, err := store.AddTask(context.Background(), set.ID, eval.Task{
+		Prompt:               "dig through the logs",
+		Category:             eval.CategoryToolHeavy,
+		SourceConversationID: "chan:main",
+		SourceMessageID:      &saved,
+	}); err != nil {
+		t.Fatalf("AddTask: %v", err)
+	}
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest", "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	got := decodeSuggestions(t, rec.Body.Bytes())
+	if len(got.Candidates) != 3 {
+		t.Fatalf("candidates = %d, want 3 — an accepted suggestion must not resurface: %+v",
+			len(got.Candidates), got.Candidates)
+	}
+	for _, c := range got.Candidates {
+		if c.MessageID == saved {
+			t.Errorf("message %d is already saved as a task but was suggested again", saved)
+		}
+	}
+}
+
+func TestEvalSuggest_ScopesToAgent(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey())
+	seedOneTurnPerCategory(t, srv, "chan:main", "default")
+	seedSuggestTurn(t, srv, "chan:other", "argus", "not mine", 0, nil,
+		[]agent.SkillUsageRecord{{SkillName: "report", MatchType: "command"}})
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest?agent=default", "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	got := decodeSuggestions(t, rec.Body.Bytes())
+	if len(got.Candidates) != 4 {
+		t.Fatalf("candidates = %d, want 4: %+v", len(got.Candidates), got.Candidates)
+	}
+	for _, c := range got.Candidates {
+		if c.ConversationID == "chan:other" {
+			t.Errorf("another agent's turn leaked into the suggestions: %+v", c)
+		}
+	}
+}
+
+func TestEvalSuggest_DefaultLimitCapsTheResponse(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey())
+	for i := 0; i < suggestDefaultLimit+8; i++ {
+		seedSuggestTurn(t, srv, "chan:main", "default", "/report", 0, nil,
+			[]agent.SkillUsageRecord{{SkillName: "report", MatchType: "command"}})
+	}
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest", "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	got := decodeSuggestions(t, rec.Body.Bytes())
+	if len(got.Candidates) != suggestDefaultLimit {
+		t.Fatalf("candidates = %d, want the default limit of %d", len(got.Candidates), suggestDefaultLimit)
+	}
+
+	rec = evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest?limit=3", "", "dk-test-key")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if got := decodeSuggestions(t, rec.Body.Bytes()); len(got.Candidates) != 3 {
+		t.Errorf("candidates = %d, want 3", len(got.Candidates))
+	}
+}
+
+func TestEvalSuggest_RejectsMalformedParams(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey())
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest?limit=0", "", "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("limit=0 status = %d, want 400", rec.Code)
+	}
+	rec = evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest?since=yesterday", "", "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("since=yesterday status = %d, want 400", rec.Code)
+	}
+}
+
+func TestEvalSuggest_NeedsEvalReadScope(t *testing.T) {
+	srv, _ := evalTestServer(t, allScopesKey(), evalReadOnlyKey(), noEvalKey())
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest", "", "dk-chat-only")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 without eval:read", rec.Code)
+	}
+	rec = evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest", "", "dk-eval-readonly")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with eval:read — suggesting writes nothing", rec.Code)
+	}
+}
+
+func TestEvalSuggest_UnwiredStoreReturns503(t *testing.T) {
+	srv := New(testConfig(allScopesKey()), testDeps(), testLogger())
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/suggest", "", "dk-test-key")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 when the eval subsystem is not wired", rec.Code)
+	}
+}

--- a/internal/api/llmstxt.go
+++ b/internal/api/llmstxt.go
@@ -40,6 +40,7 @@ API keys are scoped. Required scopes are noted per endpoint below.
 - POST /api/v1/approvals/{id}/approve  (scope: approvals:write) Approve a pending tool call
 - POST /api/v1/schedules/{name}/dry-run (scope: schedules:write) Preview a schedule; writes suppressed, nothing persisted
 - GET  /api/v1/eval/task-sets          (scope: eval:read)       Saved eval test sets
+- GET  /api/v1/eval/suggest            (scope: eval:read)       Suggest test cases from past turns, stratified by category
 - POST /api/v1/eval/task-sets/{name}/tasks (scope: eval:write)  Save a test case
 - POST /api/v1/eval/runs               (scope: eval:write)      Compare agent config variants on a test set
 - GET  /api/v1/eval/runs/{id}/summary  (scope: eval:read)       Scorecard, gate table and verdict for a run

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -288,9 +288,11 @@ func New(cfg config.APIConfig, deps Deps, logger *slog.Logger) *Server {
 	mux.HandleFunc("POST /api/v1/eval/runs/{id}/stop", s.RequireScope("eval:write", s.handleStopEvalRun))
 	mux.HandleFunc("GET /api/v1/eval/runs/{id}/summary", s.RequireScope("eval:read", s.handleEvalRunSummary))
 	mux.HandleFunc("GET /api/v1/eval/runs/{id}/samples", s.RequireScope("eval:read", s.handleEvalRunSamples))
-	// Estimating and reading the policy spend nothing, so both are read-scoped.
+	// Estimating, suggesting and reading the policy spend nothing, so all
+	// three are read-scoped.
 	mux.HandleFunc("POST /api/v1/eval/estimate", s.RequireScope("eval:read", s.handleEvalEstimate))
 	mux.HandleFunc("GET /api/v1/eval/config", s.RequireScope("eval:read", s.handleEvalConfig))
+	mux.HandleFunc("GET /api/v1/eval/suggest", s.RequireScope("eval:read", s.handleEvalSuggest))
 
 	// Browser profile and session endpoints.
 	mux.HandleFunc("GET /api/v1/browser/profiles", s.RequireScope("browser:read", s.handleListBrowserProfiles))

--- a/internal/eval/store.go
+++ b/internal/eval/store.go
@@ -703,6 +703,29 @@ func (s *Store) ListTasks(ctx context.Context, setID int64) ([]Task, error) {
 	return tasks, nil
 }
 
+// SavedTaskSources returns the SourceKey of every turn already saved as a
+// task, across all sets. The suggestion endpoint subtracts it so an accepted
+// candidate does not come back next time. Tasks with no source message (hand
+// written, imported) contribute nothing — there is no turn to suppress.
+func (s *Store) SavedTaskSources(ctx context.Context) (map[string]struct{}, error) {
+	var rows []struct {
+		ConversationID string `db:"source_conversation_id"`
+		MessageID      int64  `db:"source_message_id"`
+	}
+	err := s.db.SelectContext(ctx, &rows,
+		`SELECT DISTINCT source_conversation_id, source_message_id
+		 FROM eval_tasks
+		 WHERE source_message_id IS NOT NULL AND source_conversation_id != ''`)
+	if err != nil {
+		return nil, fmt.Errorf("listing saved task sources: %w", err)
+	}
+	saved := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		saved[SourceKey(r.ConversationID, r.MessageID)] = struct{}{}
+	}
+	return saved, nil
+}
+
 // GetTask returns one task by id, scoped to a set so a caller cannot address
 // another set's task through a set-scoped route.
 func (s *Store) GetTask(ctx context.Context, setID, taskID int64) (*Task, error) {

--- a/internal/eval/suggest.go
+++ b/internal/eval/suggest.go
@@ -1,0 +1,228 @@
+package eval
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Temikus/denkeeper/internal/agent"
+)
+
+// Signals a past turn can carry. A turn with none of them is not offered at
+// all — "interesting" is the whole point, and an unremarkable turn teaches the
+// eval set nothing.
+const (
+	// SignalToolFault: the reply had a rejected (bad args) or failed
+	// (transport) tool call. The sharpest model-fault signal we record.
+	SignalToolFault = "tool_fault"
+	// SignalManyRounds: the reply took three or more tool rounds.
+	SignalManyRounds = "many_rounds"
+	// SignalHighCost: the reply's cost is in the candidate pool's top decile.
+	SignalHighCost = "high_cost"
+	// SignalCommandSkill: a command-triggered skill drove the turn.
+	SignalCommandSkill = "command_skill"
+)
+
+// roundsThreshold is the round count at which a turn reads as tool-heavy,
+// matching the toolCallsThreshold below: both are "the model had to work".
+const roundsThreshold = 3
+
+// toolCallsThreshold is the call count at which a turn reads as tool-heavy.
+const toolCallsThreshold = 3
+
+// scheduledPrefix is what scheduler.FormatScheduledText opens with, for both
+// its labels ("[Scheduled: <skill>" and "[Scheduled trigger: <name>"). Matched
+// as a prefix rather than parsed — the category only needs to know a schedule
+// fired this turn.
+const scheduledPrefix = "[Scheduled"
+
+// PrecedingMessage is one {role, content} pair of context preceding a
+// suggested turn, ready to be pinned as a task's history.
+type PrecedingMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// Candidate is one past turn offered as a test case.
+type Candidate struct {
+	Prompt         string             `json:"prompt"`
+	Category       string             `json:"category"`
+	ConversationID string             `json:"conversation_id"`
+	MessageID      int64              `json:"message_id"`
+	CreatedAt      time.Time          `json:"created_at"`
+	Signals        []string           `json:"signals"`
+	Preceding      []PrecedingMessage `json:"preceding"`
+}
+
+// SuggestOpts bounds a suggestion pass.
+type SuggestOpts struct {
+	// Limit is the total number of candidates returned across all categories.
+	Limit int
+	// Exclude holds SourceKey values for turns already saved as tasks, so an
+	// accepted suggestion does not resurface.
+	Exclude map[string]struct{}
+}
+
+// SourceKey identifies a turn by its source conversation and message, the pair
+// eval_tasks records when a suggestion is accepted.
+func SourceKey(convID string, messageID int64) string {
+	return fmt.Sprintf("%s:%d", convID, messageID)
+}
+
+// scored pairs a candidate with the signal count that ranks it.
+type scored struct {
+	candidate Candidate
+	score     int
+}
+
+// Suggest turns a pool of past turns into stratified test-case candidates:
+// top-N per category rather than top-N overall, because a set drawn purely by
+// interestingness is all failures and represents nothing the agent normally
+// does. Turns with no signal, and turns already saved as tasks, are dropped.
+func Suggest(turns []agent.InterestingTurn, opts SuggestOpts) []Candidate {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	threshold := topDecileCost(turns)
+	byCategory := make(map[string][]scored, len(Categories()))
+	for _, t := range turns {
+		if _, seen := opts.Exclude[SourceKey(t.ConversationID, t.MessageID)]; seen {
+			continue
+		}
+		signals := signalsFor(t, threshold)
+		if len(signals) == 0 {
+			continue
+		}
+		category := categoryFor(t)
+		byCategory[category] = append(byCategory[category], scored{
+			candidate: Candidate{
+				Prompt:         t.Content,
+				Category:       category,
+				ConversationID: t.ConversationID,
+				MessageID:      t.MessageID,
+				CreatedAt:      t.CreatedAt,
+				Signals:        signals,
+				Preceding:      precedingOf(t),
+			},
+			score: len(signals),
+		})
+	}
+
+	for cat := range byCategory {
+		group := byCategory[cat]
+		sort.SliceStable(group, func(i, j int) bool {
+			if group[i].score != group[j].score {
+				return group[i].score > group[j].score
+			}
+			return group[i].candidate.CreatedAt.After(group[j].candidate.CreatedAt)
+		})
+	}
+	return stratify(byCategory, limit)
+}
+
+// stratify draws limit/len(Categories()) from each category, then hands the
+// leftover slots round-robin to whichever categories still have surplus, so a
+// thin category costs the total nothing.
+func stratify(byCategory map[string][]scored, limit int) []Candidate {
+	cats := Categories()
+	share := limit / len(cats)
+	taken := make(map[string]int, len(cats))
+	out := make([]Candidate, 0, limit)
+
+	for _, cat := range cats {
+		n := min(share, len(byCategory[cat]))
+		for i := 0; i < n; i++ {
+			out = append(out, byCategory[cat][i].candidate)
+		}
+		taken[cat] = n
+	}
+
+	// Round-robin the remainder so no single category can eat every spare slot.
+	for len(out) < limit {
+		progressed := false
+		for _, cat := range cats {
+			if len(out) >= limit {
+				break
+			}
+			if taken[cat] >= len(byCategory[cat]) {
+				continue
+			}
+			out = append(out, byCategory[cat][taken[cat]].candidate)
+			taken[cat]++
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
+	}
+	return out
+}
+
+// signalsFor lists the reasons this turn is worth saving, most diagnostic
+// first.
+func signalsFor(t agent.InterestingTurn, costThreshold float64) []string {
+	var signals []string
+	if t.Faults > 0 {
+		signals = append(signals, SignalToolFault)
+	}
+	if t.MaxRound >= roundsThreshold {
+		signals = append(signals, SignalManyRounds)
+	}
+	if costThreshold > 0 && t.ReplyCost >= costThreshold {
+		signals = append(signals, SignalHighCost)
+	}
+	if t.CommandMatches > 0 {
+		signals = append(signals, SignalCommandSkill)
+	}
+	return signals
+}
+
+// categoryFor infers which of the four curation categories a turn belongs to.
+// The order is the discriminating one: a command match is what the turn *was*,
+// while tool weight is only how it went.
+func categoryFor(t agent.InterestingTurn) string {
+	switch {
+	case t.CommandMatches > 0:
+		return CategorySkillCommand
+	case strings.HasPrefix(t.Content, scheduledPrefix):
+		return CategoryScheduled
+	case t.ToolCalls >= toolCallsThreshold || t.MaxRound >= roundsThreshold:
+		return CategoryToolHeavy
+	default:
+		return CategoryChat
+	}
+}
+
+// topDecileCost returns the cost a reply must reach to count as expensive
+// within this pool: the cost of the ceil(n/10)-th priciest reply. Zero when
+// nothing in the pool cost anything, which disables the signal rather than
+// handing it to every free turn.
+func topDecileCost(turns []agent.InterestingTurn) float64 {
+	costs := make([]float64, 0, len(turns))
+	for _, t := range turns {
+		if t.ReplyCost > 0 {
+			costs = append(costs, t.ReplyCost)
+		}
+	}
+	if len(costs) == 0 {
+		return 0
+	}
+	sort.Sort(sort.Reverse(sort.Float64Slice(costs)))
+	decile := len(costs) / 10
+	if decile < 1 {
+		decile = 1
+	}
+	return costs[decile-1]
+}
+
+// precedingOf converts the store's context window into the response shape.
+func precedingOf(t agent.InterestingTurn) []PrecedingMessage {
+	out := make([]PrecedingMessage, 0, len(t.Preceding))
+	for _, m := range t.Preceding {
+		out = append(out, PrecedingMessage{Role: m.Role, Content: m.Content})
+	}
+	return out
+}

--- a/internal/eval/suggest_test.go
+++ b/internal/eval/suggest_test.go
@@ -1,0 +1,271 @@
+package eval
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Temikus/denkeeper/internal/agent"
+)
+
+func TestSavedTaskSources_OnlyTurnsWithASourceMessage(t *testing.T) {
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	ctx := context.Background()
+
+	set, err := store.CreateTaskSet(ctx, "golden", "")
+	if err != nil {
+		t.Fatalf("CreateTaskSet: %v", err)
+	}
+	msgID := int64(77)
+	for _, task := range []Task{
+		{Prompt: "from a turn", Category: CategoryChat, SourceConversationID: "chan:main", SourceMessageID: &msgID},
+		{Prompt: "hand written", Category: CategoryChat},
+	} {
+		if _, err := store.AddTask(ctx, set.ID, task); err != nil {
+			t.Fatalf("AddTask: %v", err)
+		}
+	}
+
+	saved, err := store.SavedTaskSources(ctx)
+	if err != nil {
+		t.Fatalf("SavedTaskSources: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("saved = %v, want exactly the one task with a source turn", saved)
+	}
+	if _, ok := saved[SourceKey("chan:main", msgID)]; !ok {
+		t.Errorf("saved = %v, want key %q", saved, SourceKey("chan:main", msgID))
+	}
+}
+
+// turn builds an InterestingTurn with sane defaults; the callers set only the
+// facts the case is about.
+func turn(id int64, content string, mutate func(*agent.InterestingTurn)) agent.InterestingTurn {
+	t := agent.InterestingTurn{
+		MessageID:      id,
+		ConversationID: "chan:main",
+		Content:        content,
+		CreatedAt:      time.Date(2026, 8, 1, 0, 0, int(id), 0, time.UTC),
+	}
+	if mutate != nil {
+		mutate(&t)
+	}
+	return t
+}
+
+func candidateCategories(candidates []Candidate) map[string]int {
+	counts := map[string]int{}
+	for _, c := range candidates {
+		counts[c.Category]++
+	}
+	return counts
+}
+
+func TestSuggest_DropsTurnsWithNoSignal(t *testing.T) {
+	turns := []agent.InterestingTurn{
+		turn(1, "how are you", nil),
+		turn(2, "fix it", func(x *agent.InterestingTurn) { x.Faults = 1 }),
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 20})
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1 — an unremarkable turn teaches the set nothing: %+v", len(got), got)
+	}
+	if got[0].MessageID != 2 {
+		t.Errorf("MessageID = %d, want 2", got[0].MessageID)
+	}
+	if !slices.Contains(got[0].Signals, SignalToolFault) {
+		t.Errorf("Signals = %v, want %s", got[0].Signals, SignalToolFault)
+	}
+}
+
+func TestSuggest_CategorisesEachKind(t *testing.T) {
+	turns := []agent.InterestingTurn{
+		turn(1, "run the report", func(x *agent.InterestingTurn) { x.CommandMatches = 1 }),
+		turn(2, "[Scheduled: heartbeat | 2026-08-01T10:00:00Z UTC | 2026-W31]", func(x *agent.InterestingTurn) {
+			x.Faults = 1
+		}),
+		turn(3, "dig through the logs", func(x *agent.InterestingTurn) { x.ToolCalls = 5; x.MaxRound = 4 }),
+		turn(4, "write me a poem", func(x *agent.InterestingTurn) { x.ReplyCost = 1.5 }),
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 20})
+	if len(got) != 4 {
+		t.Fatalf("candidates = %d, want 4: %+v", len(got), got)
+	}
+	want := map[int64]string{
+		1: CategorySkillCommand,
+		2: CategoryScheduled,
+		3: CategoryToolHeavy,
+		4: CategoryChat,
+	}
+	for _, c := range got {
+		if want[c.MessageID] != c.Category {
+			t.Errorf("message %d category = %q, want %q", c.MessageID, c.Category, want[c.MessageID])
+		}
+	}
+}
+
+func TestSuggest_CommandMatchBeatsToolWeight(t *testing.T) {
+	// A command-driven turn that also ran many tools is a skill_command case:
+	// the command is what the turn *was*, tool weight is only how it went.
+	turns := []agent.InterestingTurn{
+		turn(1, "/report", func(x *agent.InterestingTurn) { x.CommandMatches = 1; x.ToolCalls = 9; x.MaxRound = 5 }),
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 4})
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(got))
+	}
+	if got[0].Category != CategorySkillCommand {
+		t.Errorf("Category = %q, want %q", got[0].Category, CategorySkillCommand)
+	}
+	want := []string{SignalManyRounds, SignalCommandSkill}
+	if !slices.Equal(got[0].Signals, want) {
+		t.Errorf("Signals = %v, want %v", got[0].Signals, want)
+	}
+}
+
+func TestSuggest_StratifiesRatherThanRankingOverall(t *testing.T) {
+	// Eight tool-heavy failures and one of each other kind. Ranked overall the
+	// failures would take every slot; stratified they cannot.
+	var turns []agent.InterestingTurn
+	for i := int64(1); i <= 8; i++ {
+		turns = append(turns, turn(i, "flaily", func(x *agent.InterestingTurn) {
+			x.Faults = 2
+			x.MaxRound = 5
+			x.ToolCalls = 6
+			x.ReplyCost = 9
+		}))
+	}
+	turns = append(turns,
+		turn(20, "/report", func(x *agent.InterestingTurn) { x.CommandMatches = 1 }),
+		turn(21, "[Scheduled: heartbeat | x | y]", func(x *agent.InterestingTurn) { x.Faults = 1 }),
+		turn(22, "just chatting", func(x *agent.InterestingTurn) { x.ReplyCost = 20 }),
+	)
+
+	got := Suggest(turns, SuggestOpts{Limit: 4})
+	if len(got) != 4 {
+		t.Fatalf("candidates = %d, want 4", len(got))
+	}
+	counts := candidateCategories(got)
+	for _, cat := range Categories() {
+		if counts[cat] != 1 {
+			t.Errorf("category %q = %d candidates, want 1 (stratified, not top-4 overall): %v", cat, counts[cat], counts)
+		}
+	}
+}
+
+func TestSuggest_LeftoverSlotsGoToCategoriesWithSurplus(t *testing.T) {
+	// Only two categories have anything; a thin category must not cost the
+	// total its slots.
+	turns := []agent.InterestingTurn{
+		turn(1, "a", func(x *agent.InterestingTurn) { x.Faults = 1; x.MaxRound = 4 }),
+		turn(2, "b", func(x *agent.InterestingTurn) { x.Faults = 1; x.MaxRound = 4 }),
+		turn(3, "c", func(x *agent.InterestingTurn) { x.Faults = 1; x.MaxRound = 4 }),
+		turn(4, "/one", func(x *agent.InterestingTurn) { x.CommandMatches = 1 }),
+		turn(5, "/two", func(x *agent.InterestingTurn) { x.CommandMatches = 1 }),
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 4})
+	if len(got) != 4 {
+		t.Fatalf("candidates = %d, want 4 — spare slots should be redistributed: %+v", len(got), got)
+	}
+	counts := candidateCategories(got)
+	if counts[CategoryToolHeavy] != 2 || counts[CategorySkillCommand] != 2 {
+		t.Errorf("counts = %v, want 2 tool_heavy and 2 skill_command", counts)
+	}
+}
+
+func TestSuggest_RanksBySignalCountThenRecency(t *testing.T) {
+	turns := []agent.InterestingTurn{
+		turn(1, "one signal", func(x *agent.InterestingTurn) { x.MaxRound = 3 }),
+		turn(2, "two signals", func(x *agent.InterestingTurn) { x.MaxRound = 3; x.Faults = 1 }),
+		turn(3, "one signal, newer", func(x *agent.InterestingTurn) { x.MaxRound = 3 }),
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 8})
+	if len(got) != 3 {
+		t.Fatalf("candidates = %d, want 3", len(got))
+	}
+	order := []int64{got[0].MessageID, got[1].MessageID, got[2].MessageID}
+	want := []int64{2, 3, 1}
+	if !slices.Equal(order, want) {
+		t.Errorf("order = %v, want %v (score desc, then newest first)", order, want)
+	}
+}
+
+func TestSuggest_TopDecileCostIsRelativeToThePool(t *testing.T) {
+	// Twenty turns, costs 1..20. The top decile is the two priciest.
+	var turns []agent.InterestingTurn
+	for i := int64(1); i <= 20; i++ {
+		cost := float64(i)
+		turns = append(turns, turn(i, "chat", func(x *agent.InterestingTurn) { x.ReplyCost = cost }))
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 20})
+	if len(got) != 2 {
+		t.Fatalf("candidates = %d, want 2 — only the top decile carries a signal here: %+v", len(got), got)
+	}
+	for _, c := range got {
+		if c.MessageID != 19 && c.MessageID != 20 {
+			t.Errorf("message %d in the top decile, want only 19 and 20", c.MessageID)
+		}
+	}
+}
+
+func TestSuggest_FreePoolNeverEarnsTheCostSignal(t *testing.T) {
+	turns := []agent.InterestingTurn{
+		turn(1, "a", nil),
+		turn(2, "b", nil),
+	}
+
+	if got := Suggest(turns, SuggestOpts{Limit: 20}); len(got) != 0 {
+		t.Errorf("candidates = %+v, want none — a zero-cost pool has no expensive reply", got)
+	}
+}
+
+func TestSuggest_SkipsTurnsAlreadySavedAsTasks(t *testing.T) {
+	turns := []agent.InterestingTurn{
+		turn(1, "already saved", func(x *agent.InterestingTurn) { x.Faults = 1 }),
+		turn(2, "still open", func(x *agent.InterestingTurn) { x.Faults = 1 }),
+	}
+	exclude := map[string]struct{}{SourceKey("chan:main", 1): {}}
+
+	got := Suggest(turns, SuggestOpts{Limit: 20, Exclude: exclude})
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1 — an accepted suggestion must not resurface: %+v", len(got), got)
+	}
+	if got[0].MessageID != 2 {
+		t.Errorf("MessageID = %d, want 2", got[0].MessageID)
+	}
+}
+
+func TestSuggest_CarriesPrecedingContext(t *testing.T) {
+	turns := []agent.InterestingTurn{
+		turn(1, "and then?", func(x *agent.InterestingTurn) {
+			x.Faults = 1
+			x.Preceding = []agent.TurnMessage{
+				{Role: "user", Content: "what did I ask"},
+				{Role: "assistant", Content: "you asked about X"},
+			}
+		}),
+	}
+
+	got := Suggest(turns, SuggestOpts{Limit: 20})
+	if len(got) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(got))
+	}
+	want := []PrecedingMessage{
+		{Role: "user", Content: "what did I ask"},
+		{Role: "assistant", Content: "you asked about X"},
+	}
+	if !slices.Equal(got[0].Preceding, want) {
+		t.Errorf("Preceding = %+v, want %+v", got[0].Preceding, want)
+	}
+}


### PR DESCRIPTION
Stage D3 backend: the telemetry query and endpoint behind "Suggest test cases from history". No UI in this PR.

The Evals page has no in-page fill path - a new user lands on an empty task set whose only sources live on other screens. This is the cold-start fix.

## What changed

**`agent.ListInterestingTurns(ctx, agent, since, limit)`** pairs each user message with the assistant reply that answered it (next assistant row in the conversation) and rolls up that reply's `tool_calls` - count, max round, rejected/failed - plus the turn's `message_skills` command matches, scoped by `conversation_stats.agent`. It also carries the last 4 preceding messages for pinned history, each capped at 2000 runes.

It sits on a new narrow `InterestingTurnStore` interface, type-asserted from `MemoryStore` the way the API layer already reaches `TelemetryStore` - rather than widening `MemoryStore` and every hand-written mock.

**`eval.Suggest`** scores each turn by signal count and stratifies:

- Signals: `tool_fault` (any rejected/failed outcome), `many_rounds` (max round >= 3), `high_cost` (reply cost in the pool's top decile), `command_skill`.
- Category: command match -> `skill_command`; content opening with the `[Scheduled` header -> `scheduled`; >= 3 tool calls or rounds -> `tool_heavy`; else `chat`.
- **Stratified, never top-N overall**: `limit/4` per category, spare slots redistributed round-robin. A set drawn purely by interestingness is all failures and represents nothing the agent normally does.
- A turn with zero signals is never offered, and `Store.SavedTaskSources` subtracts turns already saved as a task (`source_conversation_id` + `source_message_id`), so an accepted suggestion does not resurface.

**`GET /api/v1/eval/suggest?agent=&limit=&since=`** (scope `eval:read`, default limit 20 / max 100, default window 90 days). It writes nothing - accepting a candidate is a separate call to the task create endpoint. `llms.txt` lists it; spec regenerated.

Response shape (the D3 UI slice builds cards against this):

```json
{
  "candidates": [
    {
      "prompt": "dig through the logs",
      "category": "tool_heavy",
      "conversation_id": "chan:main",
      "message_id": 4211,
      "created_at": "2026-08-14T09:12:33Z",
      "signals": ["tool_fault", "many_rounds"],
      "preceding": [{ "role": "user", "content": "..." }]
    }
  ]
}
```

## Notes for the reviewer

- The `since` bound is formatted to SQLite's own `DATETIME` text rather than bound as a `time.Time`. `created_at` is written by `CURRENT_TIMESTAMP` in that layout and the comparison is a string comparison whichever way the driver renders the parameter - binding a `time.Time` returned zero rows.
- Preceding context is fetched per candidate, so the pool size is also the query count. Hence the 500 clamp in the store and the `limit * 10` (min 100) pool in the handler.
- Only `match_type = 'command'` counts toward the command signal; ambient and scheduled matches deliberately do not.

## Test evidence

`just hook` green (fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check), before and after `git rebase origin/main`.

New tests, all `-race`:

- `internal/agent/memory_interesting_test.go` - reply telemetry roll-up (cached calls excluded from faults), ambient/scheduled matches ignored, agent scoping, preceding context oldest-first, the content cap, unanswered turns skipped, the `since` bound.
- `internal/eval/suggest_test.go` - zero-signal drop, all four categories, command beats tool weight, stratification against 8 failures + one of each other kind, leftover-slot redistribution, score-then-recency ordering, top-decile relative to the pool, exclusion, and `SavedTaskSources`.
- `internal/api/eval_suggest_test.go` - seeded against the real in-memory SQLite store (no canned candidates): one interesting turn per category plus a boring one returns exactly four, one per category; an already-saved turn is excluded; agent scoping; default and explicit limit; malformed params 400; scope gating (403 without `eval:read`, 200 with it); 503 unwired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
