### PR TITLE
feat(eval): unblinded pairs endpoint and rubric version on verdicts

### DIFF
--- a/.claude/skills/judge-eval/SKILL.md
+++ b/.claude/skills/judge-eval/SKILL.md
@@ -43,7 +43,7 @@ claude mcp add --transport http denkeeper https://your-denkeeper/api/v1/mcp --he
 | `eval_run_status` | Run status, progress, pairs produced, items still pending |
 | `eval_pending` | The queue. `run_id` scopes it; `sample_n` draws a random subset |
 | `eval_get_pair` | One blinded item: prompt, notes, pinned history, Response A and B with tool traces |
-| `eval_verdict` | Record `{item_id, winner, dimensions, notes}` |
+| `eval_verdict` | Record `{item_id, winner, dimensions, notes, rubric_version}` |
 | `eval_summary` | Unblinds: gate table, win-rate, per-category breakdown, verdict |
 
 Each pair of responses is queued **twice**, with the presentation order swapped.
@@ -127,12 +127,19 @@ eval_verdict:
   item_id: 41
   winner: "a"            # a, b, or tie
   dimensions: {"task_success":"a","tool_path":"tie","persona_fit":"a","length":"b"}
+  rubric_version: "v1"   # the "Rubric version" line at the top of this file
   notes: "A completed both halves of the request; B answered only the first.
           B's tool path was cleaner (2 rounds vs 4) and its reply was tighter,
           but persona.md line 'answer the whole question before offering more'
           is what A honoured and B did not."
 ```
 
+- `rubric_version` is **always** the version at the top of this file, on every
+  verdict including the operator's calibration marks. It is what lets the
+  results view name the policy a win-rate was produced under, and it is how a
+  queue worked across a rubric edit shows up as two versions rather than
+  silently averaging two different rubrics. Bump the line above when you change
+  the rubric below it.
 - `winner` is the overall call and is what the win-rate counts. It is **not** a
   majority vote of the dimensions — `task_success` can carry a pair on its own.
 - Use `tie` honestly. A forced preference between two equally good responses is

--- a/internal/api/docs/swagger.json
+++ b/internal/api/docs/swagger.json
@@ -2665,6 +2665,73 @@
                 }
             }
         },
+        "/eval/runs/{id}/pairs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the run's blinded-comparison pairs with the blinding lifted: which variant produced each side, every recorded verdict with the presented letter resolved back to a variant name, its per-dimension winners, notes and rubric version, and the pair's resolved outcome from the candidate's point of view. Outcomes follow the aggregation rules exactly — a pair is 'win' or 'loss' only when both presentation orders carry a judge verdict naming the same variant, orders that disagree are a 'tie' (the judge tracked position, not quality), and anything half-judged is 'pending'. The operator's calibration marks (judge_ident 'operator') are listed but never drive the outcome. This is the operator's results view and is deliberately not reachable from the judge's MCP tools.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "eval"
+                ],
+                "summary": "Get an eval run's judged pairs, unblinded",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Run id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Only return pairs for this task",
+                        "name": "task_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Unblinded pairs",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PairView"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad run id or task_id",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Run not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Eval subsystem not configured",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/eval/runs/{id}/samples": {
             "get": {
                 "security": [
@@ -8067,6 +8134,13 @@
                 "pairs": {
                     "type": "integer"
                 },
+                "rubric_versions": {
+                    "description": "RubricVersions is the distinct set of rubric revisions the judge verdicts\nbehind this tally were made under, sorted. A set rather than a single\nvalue because a queue worked across a rubric edit is a real thing to see:\ntwo versions here means the win-rate mixes two policies. Judges that did\nnot report a version contribute nothing.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "ties": {
                     "type": "integer"
                 },
@@ -8089,6 +8163,128 @@
                 },
                 "llm_provider": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.PairDetail": {
+            "type": "object",
+            "properties": {
+                "baseline": {
+                    "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PairSide"
+                },
+                "candidate": {
+                    "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PairSide"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PairItem"
+                    }
+                },
+                "k": {
+                    "description": "K is the pair's sample index within the task, so a k \u003e 1 run is readable.",
+                    "type": "integer"
+                },
+                "outcome": {
+                    "description": "Outcome is win/loss/tie/pending from the candidate's point of view.",
+                    "type": "string"
+                },
+                "pair_id": {
+                    "type": "integer"
+                },
+                "task_id": {
+                    "type": "integer"
+                },
+                "task_prompt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.PairItem": {
+            "type": "object",
+            "properties": {
+                "item_id": {
+                    "type": "integer"
+                },
+                "presentation_order": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "verdicts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PairVerdict"
+                    }
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.PairSide": {
+            "type": "object",
+            "properties": {
+                "sample_id": {
+                    "type": "integer"
+                },
+                "variant": {
+                    "type": "string"
+                },
+                "variant_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.PairVerdict": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "dimensions": {
+                    "description": "Dimensions is the stored per-dimension map, omitted when the judge\nrecorded none or the stored value will not decode.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "judge_ident": {
+                    "description": "JudgeIdent names who judged. JudgeOperator marks a calibration call: it\nis listed here but never drives the pair's outcome.",
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "string"
+                },
+                "rubric_version": {
+                    "type": "string"
+                },
+                "winner": {
+                    "description": "Winner is the presented letter the judge named — what it actually saw.",
+                    "type": "string"
+                },
+                "winner_variant": {
+                    "description": "WinnerVariant is that letter resolved through the item's presentation\norder and the pair's assignment. Empty on a tie.",
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Temikus_denkeeper_internal_eval.PairView": {
+            "type": "object",
+            "properties": {
+                "baseline_variant": {
+                    "description": "BaselineVariant names the incumbent every pair is measured against.",
+                    "type": "string"
+                },
+                "pairs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Temikus_denkeeper_internal_eval.PairDetail"
+                    }
+                },
+                "run_id": {
+                    "type": "integer"
                 }
             }
         },

--- a/internal/api/eval.go
+++ b/internal/api/eval.go
@@ -873,6 +873,45 @@ func (s *Server) handleEvalRunSummary(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, summary)
 }
 
+// handleEvalRunPairs godoc
+// @Summary Get an eval run's judged pairs, unblinded
+// @Description Returns the run's blinded-comparison pairs with the blinding lifted: which variant produced each side, every recorded verdict with the presented letter resolved back to a variant name, its per-dimension winners, notes and rubric version, and the pair's resolved outcome from the candidate's point of view. Outcomes follow the aggregation rules exactly — a pair is 'win' or 'loss' only when both presentation orders carry a judge verdict naming the same variant, orders that disagree are a 'tie' (the judge tracked position, not quality), and anything half-judged is 'pending'. The operator's calibration marks (judge_ident 'operator') are listed but never drive the outcome. This is the operator's results view and is deliberately not reachable from the judge's MCP tools.
+// @Tags eval
+// @Produce json
+// @Security BearerAuth
+// @Param id path int true "Run id"
+// @Param task_id query int false "Only return pairs for this task"
+// @Success 200 {object} eval.PairView "Unblinded pairs"
+// @Failure 400 {object} map[string]string "Bad run id or task_id"
+// @Failure 404 {object} map[string]string "Run not found"
+// @Failure 503 {object} map[string]string "Eval subsystem not configured"
+// @Router /eval/runs/{id}/pairs [get]
+func (s *Server) handleEvalRunPairs(w http.ResponseWriter, r *http.Request) {
+	if !s.evalRequired(w) {
+		return
+	}
+	id, ok := evalRunID(w, r)
+	if !ok {
+		return
+	}
+	var taskID int64
+	if raw := r.URL.Query().Get("task_id"); raw != "" {
+		parsed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || parsed <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error": "task_id must be a positive integer"})
+			return
+		}
+		taskID = parsed
+	}
+	view, err := s.deps.EvalStore.PairDetails(r.Context(), id, taskID)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, view)
+}
+
 // handleEvalRunSamples godoc
 // @Summary Get an eval run's per-sample transcripts
 // @Description Returns every sample the run produced, including its response and the full tool trace with arguments and results (trimmed to 8 KiB per field). Failed samples carry their error instead.

--- a/internal/api/eval_test.go
+++ b/internal/api/eval_test.go
@@ -652,6 +652,263 @@ func TestEvalRuns_SamplesUnknownRunIs404(t *testing.T) {
 	}
 }
 
+// --- Unblinded pairs ---
+
+// seedPairedRun builds a two-variant, one-task, k=1 run with both samples ok
+// and its pairs created — the state a finished run reaches on its own.
+func seedPairedRun(t *testing.T, store *eval.Store) (*eval.Run, []eval.Variant) {
+	t.Helper()
+	ctx := context.Background()
+	set, err := store.CreateTaskSet(ctx, "paired", "")
+	if err != nil {
+		t.Fatalf("CreateTaskSet: %v", err)
+	}
+	for _, prompt := range []string{"what is on today?", "summarise my week"} {
+		if _, err := store.AddTask(ctx, set.ID, eval.Task{
+			Prompt: prompt, Category: eval.CategoryChat,
+		}); err != nil {
+			t.Fatalf("AddTask: %v", err)
+		}
+	}
+	tasks, err := store.ListTasks(ctx, set.ID)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	run, variants, err := store.CreateRun(ctx, eval.Run{
+		TaskSetID: set.ID, BaseAgent: "default", K: 1, CostCap: 1, AsOf: time.Now(),
+	}, []eval.Variant{{Name: "incumbent"}, {Name: "candidate", Overlay: `{"llm_model":"kimi-k3"}`}})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for _, task := range tasks {
+		for _, v := range variants {
+			if _, err := store.AddSample(ctx, eval.Sample{
+				RunID: run.ID, VariantID: v.ID, TaskID: task.ID, KIndex: 0,
+				Status: eval.SampleOK, Response: "an answer", Rounds: 2, OutcomeOK: 5,
+			}); err != nil {
+				t.Fatalf("AddSample: %v", err)
+			}
+		}
+	}
+	if _, err := store.CreatePairs(ctx, run.ID); err != nil {
+		t.Fatalf("CreatePairs: %v", err)
+	}
+	return run, variants
+}
+
+// judgePairs records a verdict naming `variant` on the first `limit` items of a
+// run (limit <= 0 = all), resolving the presented letter per item.
+func judgePairs(t *testing.T, store *eval.Store, runID, variant int64, ident string, limit int) {
+	t.Helper()
+	ctx := context.Background()
+	pairs, err := store.ListPairs(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListPairs: %v", err)
+	}
+	assigns := make(map[int64]eval.Assignment, len(pairs))
+	for _, p := range pairs {
+		a, err := eval.DecodeAssignment(p.Assignment)
+		if err != nil {
+			t.Fatalf("DecodeAssignment: %v", err)
+		}
+		assigns[p.ID] = a
+	}
+	items, err := store.ListItems(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for i, it := range items {
+		if limit > 0 && i >= limit {
+			return
+		}
+		winner := eval.WinnerTie
+		for _, w := range []string{eval.WinnerA, eval.WinnerB} {
+			if eval.VariantFor(assigns[it.PairID], it.PresentationOrder, w) == variant {
+				winner = w
+			}
+		}
+		if _, err := store.RecordVerdict(ctx, eval.Verdict{
+			ItemID: it.ID, Winner: winner, JudgeIdent: ident, RubricVersion: "v1",
+		}); err != nil {
+			t.Fatalf("RecordVerdict: %v", err)
+		}
+	}
+}
+
+func getPairs(t *testing.T, srv *Server, runID int64, query, key string) eval.PairView {
+	t.Helper()
+	path := fmt.Sprintf("/api/v1/eval/runs/%d/pairs%s", runID, query)
+	rec := evalRequest(t, srv, http.MethodGet, path, "", key)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var view eval.PairView
+	if err := json.NewDecoder(rec.Body).Decode(&view); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return view
+}
+
+func TestEvalRuns_PairsUnblindAJudgedPair(t *testing.T) {
+	srv, store := evalTestServer(t)
+	run, variants := seedPairedRun(t, store)
+	judgePairs(t, store, run.ID, variants[1].ID, "claude-code", 0)
+
+	view := getPairs(t, srv, run.ID, "", "dk-test-key")
+	if view.RunID != run.ID || view.BaselineVariant != "incumbent" {
+		t.Fatalf("view = %+v, want the run id and the incumbent baseline", view)
+	}
+	if len(view.Pairs) != 2 {
+		t.Fatalf("got %d pairs, want one per task", len(view.Pairs))
+	}
+	for _, p := range view.Pairs {
+		if p.Outcome != eval.PairOutcomeWin {
+			t.Errorf("pair %d outcome = %q, want %q", p.PairID, p.Outcome, eval.PairOutcomeWin)
+		}
+		if p.Baseline.Variant != "incumbent" || p.Candidate.Variant != "candidate" {
+			t.Errorf("pair %d sides = %+v / %+v", p.PairID, p.Baseline, p.Candidate)
+		}
+		if p.Baseline.SampleID == 0 || p.Candidate.SampleID == 0 {
+			t.Errorf("pair %d is missing a sample id: %+v / %+v", p.PairID, p.Baseline, p.Candidate)
+		}
+		if p.TaskPrompt == "" || p.Category != eval.CategoryChat {
+			t.Errorf("pair %d lost its task context: %+v", p.PairID, p)
+		}
+		if len(p.Items) != 2 {
+			t.Fatalf("pair %d has %d items, want both presentation orders", p.PairID, len(p.Items))
+		}
+		for _, it := range p.Items {
+			if len(it.Verdicts) != 1 || it.Verdicts[0].WinnerVariant != "candidate" {
+				t.Errorf("pair %d order %s verdicts = %+v", p.PairID, it.PresentationOrder, it.Verdicts)
+			}
+			if it.Verdicts[0].RubricVersion != "v1" {
+				t.Errorf("pair %d order %s lost its rubric version", p.PairID, it.PresentationOrder)
+			}
+		}
+	}
+}
+
+func TestEvalRuns_PairsHalfJudgedIsPending(t *testing.T) {
+	srv, store := evalTestServer(t)
+	run, variants := seedPairedRun(t, store)
+	// One item only: the pair's other presentation order stays unjudged.
+	judgePairs(t, store, run.ID, variants[1].ID, "claude-code", 1)
+
+	view := getPairs(t, srv, run.ID, "", "dk-test-key")
+	for _, p := range view.Pairs {
+		if p.Outcome != eval.PairOutcomePending {
+			t.Errorf("pair %d outcome = %q, want %q while an order is unjudged",
+				p.PairID, p.Outcome, eval.PairOutcomePending)
+		}
+	}
+}
+
+// Both orders naming the same presented letter means the judge tracked
+// position. The endpoint must report the tie the tally records, not a win.
+func TestEvalRuns_PairsDisagreementIsATie(t *testing.T) {
+	srv, store := evalTestServer(t)
+	run, _ := seedPairedRun(t, store)
+	ctx := context.Background()
+	items, err := store.ListItems(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for _, it := range items {
+		if _, err := store.RecordVerdict(ctx, eval.Verdict{
+			ItemID: it.ID, Winner: eval.WinnerA, JudgeIdent: "claude-code",
+		}); err != nil {
+			t.Fatalf("RecordVerdict: %v", err)
+		}
+	}
+
+	view := getPairs(t, srv, run.ID, "", "dk-test-key")
+	for _, p := range view.Pairs {
+		if p.Outcome != eval.PairOutcomeTie {
+			t.Errorf("pair %d outcome = %q, want %q", p.PairID, p.Outcome, eval.PairOutcomeTie)
+		}
+	}
+}
+
+// The operator's calibration marks are shown next to the judge's — that is the
+// point of the calibration pass — but they are not judge work and must not
+// decide the pair.
+func TestEvalRuns_PairsOperatorVerdictIsListedButNotDeciding(t *testing.T) {
+	srv, store := evalTestServer(t)
+	run, variants := seedPairedRun(t, store)
+	judgePairs(t, store, run.ID, variants[0].ID, eval.JudgeOperator, 0)
+
+	view := getPairs(t, srv, run.ID, "", "dk-test-key")
+	var operatorRows int
+	for _, p := range view.Pairs {
+		if p.Outcome != eval.PairOutcomePending {
+			t.Errorf("pair %d outcome = %q, want %q — only the operator has marked it",
+				p.PairID, p.Outcome, eval.PairOutcomePending)
+		}
+		for _, it := range p.Items {
+			for _, v := range it.Verdicts {
+				if v.JudgeIdent == eval.JudgeOperator {
+					operatorRows++
+				}
+			}
+		}
+	}
+	if operatorRows != 4 {
+		t.Errorf("listed %d operator verdicts, want 4 (2 pairs × 2 orders)", operatorRows)
+	}
+}
+
+func TestEvalRuns_PairsFilterByTask(t *testing.T) {
+	srv, store := evalTestServer(t)
+	run, _ := seedPairedRun(t, store)
+
+	all := getPairs(t, srv, run.ID, "", "dk-test-key")
+	if len(all.Pairs) != 2 {
+		t.Fatalf("got %d pairs unfiltered, want 2", len(all.Pairs))
+	}
+	target := all.Pairs[1].TaskID
+	filtered := getPairs(t, srv, run.ID, fmt.Sprintf("?task_id=%d", target), "dk-test-key")
+	if len(filtered.Pairs) != 1 || filtered.Pairs[0].TaskID != target {
+		t.Errorf("filtered pairs = %+v, want only task %d", filtered.Pairs, target)
+	}
+}
+
+func TestEvalRuns_PairsUnknownRunIs404(t *testing.T) {
+	srv, _ := evalTestServer(t)
+
+	rec := evalRequest(t, srv, http.MethodGet, "/api/v1/eval/runs/999/pairs", "", "dk-test-key")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 via the ErrNotFound sentinel", rec.Code)
+	}
+}
+
+func TestEvalRuns_PairsBadTaskIDIs400(t *testing.T) {
+	srv, store := evalTestServer(t)
+	run, _ := seedPairedRun(t, store)
+
+	rec := evalRequest(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/v1/eval/runs/%d/pairs?task_id=nope", run.ID), "", "dk-test-key")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// The unblinded view is a read: eval:read must be enough, and a key without it
+// must not reach it at all.
+func TestEvalRuns_PairsAreReadableWithReadScopeOnly(t *testing.T) {
+	srv, store := evalTestServer(t, allScopesKey(), evalReadOnlyKey(), config.APIKeyConfig{
+		Name: "chat-only", Key: "dk-chat-only", Scopes: []string{"chat"},
+	})
+	run, _ := seedPairedRun(t, store)
+	path := fmt.Sprintf("/api/v1/eval/runs/%d/pairs", run.ID)
+
+	if rec := evalRequest(t, srv, http.MethodGet, path, "", "dk-eval-readonly"); rec.Code != http.StatusOK {
+		t.Errorf("status = %d for an eval:read key, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if rec := evalRequest(t, srv, http.MethodGet, path, "", "dk-chat-only"); rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d for a key without eval:read, want 403", rec.Code)
+	}
+}
+
 func TestEvalETA_ZeroWhenNothingLanded(t *testing.T) {
 	if got := evalETA(nil, 8, 2); got != 0 {
 		t.Errorf("eta = %d, want 0 before any sample lands", got)

--- a/internal/api/llmstxt.go
+++ b/internal/api/llmstxt.go
@@ -44,6 +44,7 @@ API keys are scoped. Required scopes are noted per endpoint below.
 - POST /api/v1/eval/task-sets/{name}/tasks (scope: eval:write)  Save a test case
 - POST /api/v1/eval/runs               (scope: eval:write)      Compare agent config variants on a test set
 - GET  /api/v1/eval/runs/{id}/summary  (scope: eval:read)       Scorecard, gate table and verdict for a run
+- GET  /api/v1/eval/runs/{id}/pairs    (scope: eval:read)       Judged pairs, unblinded: verdicts, dimensions and outcomes
 - POST /api/v1/eval/estimate           (scope: eval:read)       Cost range for a run before starting it
 - GET  /api/v1/eval/config             (scope: eval:read)       Eval defaults and verdict thresholds
 - POST /api/v1/panic                   (scope: admin)           Emergency stop all in-flight requests

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -288,6 +288,9 @@ func New(cfg config.APIConfig, deps Deps, logger *slog.Logger) *Server {
 	mux.HandleFunc("POST /api/v1/eval/runs/{id}/stop", s.RequireScope("eval:write", s.handleStopEvalRun))
 	mux.HandleFunc("GET /api/v1/eval/runs/{id}/summary", s.RequireScope("eval:read", s.handleEvalRunSummary))
 	mux.HandleFunc("GET /api/v1/eval/runs/{id}/samples", s.RequireScope("eval:read", s.handleEvalRunSamples))
+	// Unblinded, and deliberately REST-only: the judge's MCP surface must not
+	// be able to look up which variant produced which response.
+	mux.HandleFunc("GET /api/v1/eval/runs/{id}/pairs", s.RequireScope("eval:read", s.handleEvalRunPairs))
 	// Estimating, suggesting and reading the policy spend nothing, so all
 	// three are read-scoped.
 	mux.HandleFunc("POST /api/v1/eval/estimate", s.RequireScope("eval:read", s.handleEvalEstimate))

--- a/internal/eval/judging.go
+++ b/internal/eval/judging.go
@@ -265,12 +265,14 @@ func (s *Store) RecordVerdict(ctx context.Context, v Verdict) (*Verdict, error) 
 	defer func() { _ = tx.Rollback() }()
 
 	res, err := tx.ExecContext(ctx,
-		`INSERT INTO eval_verdicts (item_id, winner, dimensions, notes, judge_ident, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		`INSERT INTO eval_verdicts
+		   (item_id, winner, dimensions, notes, judge_ident, rubric_version, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT (item_id, judge_ident) DO UPDATE SET
 		     winner = excluded.winner, dimensions = excluded.dimensions,
-		     notes = excluded.notes, created_at = excluded.created_at`,
-		v.ItemID, v.Winner, v.Dimensions, v.Notes, v.JudgeIdent, v.CreatedAt)
+		     notes = excluded.notes, rubric_version = excluded.rubric_version,
+		     created_at = excluded.created_at`,
+		v.ItemID, v.Winner, v.Dimensions, v.Notes, v.JudgeIdent, v.RubricVersion, v.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("recording verdict for item %d: %w", v.ItemID, err)
 	}
@@ -293,7 +295,8 @@ func (s *Store) RecordVerdict(ctx context.Context, v Verdict) (*Verdict, error) 
 func (s *Store) ListVerdicts(ctx context.Context, runID int64) ([]Verdict, error) {
 	out := []Verdict{}
 	if err := s.db.SelectContext(ctx, &out,
-		`SELECT v.id, v.item_id, v.winner, v.dimensions, v.notes, v.judge_ident, v.created_at
+		`SELECT v.id, v.item_id, v.winner, v.dimensions, v.notes, v.judge_ident,
+		        v.rubric_version, v.created_at
 		 FROM eval_verdicts v
 		 JOIN eval_judgment_items i ON i.id = v.item_id
 		 JOIN eval_pairs p ON p.id = i.pair_id

--- a/internal/eval/pairview.go
+++ b/internal/eval/pairview.go
@@ -1,0 +1,251 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// The operator's unblinded view of a run's judging grid.
+//
+// This is the deliberate counterpart to GetBlindedItem: the judge sees two
+// responses with every identity hint stripped, and the operator reading the
+// results afterwards sees who won. It exists because the results view has to
+// render "judged pairs with the judge's dimension scores and notes"
+// (design/eval-subsystem.md §6 layer 3) and the only pair reader before it was
+// the blinded one.
+//
+// It is REST-only by design: nothing here may be advertised on the judge's MCP
+// surface, since a judge that can call it can unblind its own queue.
+
+// PairSide is one side of a pair once the assignment is applied.
+type PairSide struct {
+	VariantID int64  `json:"variant_id"`
+	Variant   string `json:"variant"`
+	SampleID  int64  `json:"sample_id"`
+}
+
+// PairVerdict is one recorded call on one item, unblinded.
+type PairVerdict struct {
+	// JudgeIdent names who judged. JudgeOperator marks a calibration call: it
+	// is listed here but never drives the pair's outcome.
+	JudgeIdent string `json:"judge_ident"`
+	// Winner is the presented letter the judge named — what it actually saw.
+	Winner string `json:"winner"`
+	// WinnerVariant is that letter resolved through the item's presentation
+	// order and the pair's assignment. Empty on a tie.
+	WinnerVariant string `json:"winner_variant,omitempty"`
+	// Dimensions is the stored per-dimension map, omitted when the judge
+	// recorded none or the stored value will not decode.
+	Dimensions    map[string]string `json:"dimensions,omitempty"`
+	Notes         string            `json:"notes,omitempty"`
+	RubricVersion string            `json:"rubric_version,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+}
+
+// PairItem is one presentation order of a pair with the verdicts against it.
+type PairItem struct {
+	ItemID            int64         `json:"item_id"`
+	PresentationOrder string        `json:"presentation_order"`
+	Status            string        `json:"status"`
+	Verdicts          []PairVerdict `json:"verdicts"`
+}
+
+// PairDetail is one pair, unblinded, with its resolved outcome.
+type PairDetail struct {
+	PairID     int64  `json:"pair_id"`
+	TaskID     int64  `json:"task_id"`
+	TaskPrompt string `json:"task_prompt"`
+	Category   string `json:"category"`
+	// K is the pair's sample index within the task, so a k > 1 run is readable.
+	K         int        `json:"k"`
+	Baseline  PairSide   `json:"baseline"`
+	Candidate PairSide   `json:"candidate"`
+	Items     []PairItem `json:"items"`
+	// Outcome is win/loss/tie/pending from the candidate's point of view.
+	Outcome string `json:"outcome"`
+}
+
+// PairView is a run's whole judging grid, unblinded.
+type PairView struct {
+	RunID int64 `json:"run_id"`
+	// BaselineVariant names the incumbent every pair is measured against.
+	BaselineVariant string       `json:"baseline_variant"`
+	Pairs           []PairDetail `json:"pairs"`
+}
+
+// PairDetails returns a run's pairs with their verdicts and resolved outcomes,
+// optionally narrowed to one task (taskID 0 = every task).
+//
+// Outcomes come from resolvePairs, the same resolver the win-rate is tallied
+// from, so a pair this view calls a tie is a tie in the verdict too. Deriving
+// the both-orders-must-agree rule a second time here is exactly how the two
+// views would drift apart.
+func (s *Store) PairDetails(ctx context.Context, runID, taskID int64) (*PairView, error) {
+	in, tasks, err := s.loadPairView(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	view := &PairView{RunID: runID, Pairs: []PairDetail{}}
+	if len(in.variants) < 2 {
+		return view, nil
+	}
+	baseline := in.variants[0]
+	view.BaselineVariant = baseline.Name
+
+	names := make(map[int64]string, len(in.variants))
+	for _, v := range in.variants {
+		names[v.ID] = v.Name
+	}
+	byTask := make(map[int64]Task, len(tasks))
+	for _, t := range tasks {
+		byTask[t.ID] = t
+	}
+	outcomes := make(map[int64]pairOutcome, len(in.pairs))
+	for _, po := range resolvePairs(in) {
+		outcomes[po.pairID] = po
+	}
+	itemsByPair := groupItems(in.items)
+	verdictsByPairItem := groupVerdicts(in.verdicts)
+
+	for _, p := range in.pairs {
+		if taskID > 0 && p.TaskID != taskID {
+			continue
+		}
+		po, ok := outcomes[p.ID]
+		if !ok {
+			// resolvePairs drops a pair whose assignment will not decode. It
+			// cannot be unblinded, so it is left out here too rather than shown
+			// with a guessed outcome.
+			continue
+		}
+		view.Pairs = append(view.Pairs, buildPairDetail(pairDetailInput{
+			pair:     p,
+			outcome:  po,
+			baseline: baseline.ID,
+			names:    names,
+			task:     byTask[p.TaskID],
+			items:    itemsByPair[p.ID],
+			verdicts: verdictsByPairItem,
+		}))
+	}
+	return view, nil
+}
+
+// loadPairView reads the grid in one place, so a pair's outcome and its listed
+// verdicts always come from the same snapshot. Samples are deliberately not
+// loaded: their traces are large, and the results view fetches them from
+// /samples when a row is expanded.
+func (s *Store) loadPairView(ctx context.Context, runID int64) (verdictInput, []Task, error) {
+	var in verdictInput
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		return in, nil, err
+	}
+	if in.variants, err = s.ListVariants(ctx, runID); err != nil {
+		return in, nil, err
+	}
+	if in.pairs, err = s.ListPairs(ctx, runID); err != nil {
+		return in, nil, err
+	}
+	if in.items, err = s.ListItems(ctx, runID); err != nil {
+		return in, nil, err
+	}
+	if in.verdicts, err = s.ListVerdicts(ctx, runID); err != nil {
+		return in, nil, err
+	}
+	// RunTasks, not ListTasks: a run's pairs only ever cover the task list
+	// pinned at creation, and every other reader resolves it through here.
+	tasks, err := s.RunTasks(ctx, run)
+	if err != nil {
+		return in, nil, err
+	}
+	return in, tasks, nil
+}
+
+// pairDetailInput bundles one pair's row-building inputs; they travel together
+// and a positional call would be seven arguments of the same two types.
+type pairDetailInput struct {
+	pair     Pair
+	outcome  pairOutcome
+	baseline int64
+	names    map[int64]string
+	task     Task
+	items    []JudgmentItem
+	verdicts map[int64][]Verdict
+}
+
+func buildPairDetail(in pairDetailInput) PairDetail {
+	p := in.pair
+	assign, _ := DecodeAssignment(p.Assignment)
+	detail := PairDetail{
+		PairID:     p.ID,
+		TaskID:     p.TaskID,
+		TaskPrompt: in.task.Prompt,
+		Category:   in.task.Category,
+		K:          p.KIndex,
+		Baseline:   pairSide(p, assign, in.baseline, in.names),
+		Candidate:  pairSide(p, assign, in.outcome.candidate, in.names),
+		Items:      []PairItem{},
+		Outcome:    in.outcome.outcome(in.baseline),
+	}
+	for _, it := range in.items {
+		detail.Items = append(detail.Items, PairItem{
+			ItemID:            it.ID,
+			PresentationOrder: it.PresentationOrder,
+			Status:            it.Status,
+			Verdicts:          pairVerdicts(assign, it, in.verdicts[it.ID], in.names),
+		})
+	}
+	return detail
+}
+
+// pairSide names one variant's side of a pair and the sample it produced.
+func pairSide(p Pair, a Assignment, variantID int64, names map[int64]string) PairSide {
+	side := PairSide{VariantID: variantID, Variant: names[variantID]}
+	switch variantID {
+	case a.A:
+		side.SampleID = p.SampleA
+	case a.B:
+		side.SampleID = p.SampleB
+	}
+	return side
+}
+
+func pairVerdicts(a Assignment, it JudgmentItem, rows []Verdict, names map[int64]string) []PairVerdict {
+	out := make([]PairVerdict, 0, len(rows))
+	for _, v := range rows {
+		pv := PairVerdict{
+			JudgeIdent:    v.JudgeIdent,
+			Winner:        v.Winner,
+			Notes:         v.Notes,
+			RubricVersion: v.RubricVersion,
+			CreatedAt:     v.CreatedAt,
+		}
+		if id := VariantFor(a, it.PresentationOrder, v.Winner); id != 0 {
+			pv.WinnerVariant = names[id]
+		}
+		var dims map[string]string
+		if err := json.Unmarshal([]byte(v.Dimensions), &dims); err == nil && len(dims) > 0 {
+			pv.Dimensions = dims
+		}
+		out = append(out, pv)
+	}
+	return out
+}
+
+func groupItems(items []JudgmentItem) map[int64][]JudgmentItem {
+	out := make(map[int64][]JudgmentItem, len(items))
+	for _, it := range items {
+		out[it.PairID] = append(out[it.PairID], it)
+	}
+	return out
+}
+
+func groupVerdicts(verdicts []Verdict) map[int64][]Verdict {
+	out := make(map[int64][]Verdict, len(verdicts))
+	for _, v := range verdicts {
+		out[v.ItemID] = append(out[v.ItemID], v)
+	}
+	return out
+}

--- a/internal/eval/pairview_test.go
+++ b/internal/eval/pairview_test.go
@@ -1,0 +1,310 @@
+package eval
+
+import (
+	"context"
+	"testing"
+)
+
+// pairDetails runs the unblinded view over the fixture's run.
+func (f *pairFixture) pairDetails(t *testing.T, taskID int64) *PairView {
+	t.Helper()
+	view, err := f.store.PairDetails(context.Background(), f.run.ID, taskID)
+	if err != nil {
+		t.Fatalf("PairDetails: %v", err)
+	}
+	return view
+}
+
+// onlyPair asserts the view holds exactly one pair and returns it.
+func onlyPair(t *testing.T, view *PairView) PairDetail {
+	t.Helper()
+	if len(view.Pairs) != 1 {
+		t.Fatalf("got %d pairs, want 1", len(view.Pairs))
+	}
+	return view.Pairs[0]
+}
+
+// judgeItem records one judge verdict on one item, naming a variant.
+func (f *pairFixture) judgeItem(t *testing.T, it JudgmentItem, variant int64, ident string) {
+	t.Helper()
+	pair, err := f.store.GetPair(context.Background(), it.PairID)
+	if err != nil {
+		t.Fatalf("GetPair: %v", err)
+	}
+	assign, err := DecodeAssignment(pair.Assignment)
+	if err != nil {
+		t.Fatalf("DecodeAssignment: %v", err)
+	}
+	w := WinnerTie
+	if variant != 0 {
+		w = letterFor(assign, it.PresentationOrder, variant)
+	}
+	if _, err := f.store.RecordVerdict(context.Background(), Verdict{
+		ItemID: it.ID, Winner: w, JudgeIdent: ident, RubricVersion: "v1",
+	}); err != nil {
+		t.Fatalf("RecordVerdict: %v", err)
+	}
+}
+
+func (f *pairFixture) items(t *testing.T) []JudgmentItem {
+	t.Helper()
+	items, err := f.store.ListItems(context.Background(), f.run.ID)
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	return items
+}
+
+// Both presentation orders naming the candidate is the only shape that scores a
+// win, and the presented letters differ between the two orders — which is the
+// resolution doing its work rather than passing the letter through.
+func TestPairDetails_AgreeingOrdersResolveToTheCandidate(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+	cand := f.variants[1]
+	f.judgeRun(t, func(Pair) int64 { return cand.ID })
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	if pair.Outcome != PairOutcomeWin {
+		t.Fatalf("outcome = %q, want %q", pair.Outcome, PairOutcomeWin)
+	}
+	if len(pair.Items) != 2 {
+		t.Fatalf("got %d items, want both presentation orders", len(pair.Items))
+	}
+	for _, it := range pair.Items {
+		if len(it.Verdicts) != 1 {
+			t.Fatalf("item %d has %d verdicts, want 1", it.ItemID, len(it.Verdicts))
+		}
+		if got := it.Verdicts[0].WinnerVariant; got != cand.Name {
+			t.Errorf("winner_variant = %q on order %s, want %q", got, it.PresentationOrder, cand.Name)
+		}
+	}
+	if pair.Items[0].Verdicts[0].Winner == pair.Items[1].Verdicts[0].Winner {
+		t.Error("both orders carry the same presented letter — the swap did not happen")
+	}
+}
+
+func TestPairDetails_AgreeingOnTheBaselineIsALoss(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+	base := f.variants[0]
+	f.judgeRun(t, func(Pair) int64 { return base.ID })
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	if pair.Outcome != PairOutcomeLoss {
+		t.Fatalf("outcome = %q, want %q", pair.Outcome, PairOutcomeLoss)
+	}
+	for _, it := range pair.Items {
+		if got := it.Verdicts[0].WinnerVariant; got != base.Name {
+			t.Errorf("winner_variant = %q, want the baseline %q", got, base.Name)
+		}
+	}
+}
+
+// Naming the same *presented* letter in both orders means the judge tracked
+// position, not quality. The view must say tie, exactly as the tally does.
+func TestPairDetails_DisagreementBetweenOrdersIsATie(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	ctx := context.Background()
+	f.cleanRun(t)
+	f.createPairs(t)
+
+	for _, it := range f.items(t) {
+		if _, err := f.store.RecordVerdict(ctx, Verdict{
+			ItemID: it.ID, Winner: WinnerA, JudgeIdent: "claude-code",
+		}); err != nil {
+			t.Fatalf("RecordVerdict: %v", err)
+		}
+	}
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	if pair.Outcome != PairOutcomeTie {
+		t.Fatalf("outcome = %q, want %q when the two orders disagree", pair.Outcome, PairOutcomeTie)
+	}
+}
+
+func TestPairDetails_HalfJudgedPairIsPending(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+	items := f.items(t)
+	f.judgeItem(t, items[0], f.variants[1].ID, "claude-code")
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	if pair.Outcome != PairOutcomePending {
+		t.Fatalf("outcome = %q, want %q with one order unjudged", pair.Outcome, PairOutcomePending)
+	}
+	var judged int
+	for _, it := range pair.Items {
+		judged += len(it.Verdicts)
+	}
+	if judged != 1 {
+		t.Errorf("listed %d verdicts, want the single one recorded", judged)
+	}
+}
+
+// The operator's calibration marks are ordinary verdict rows. They belong in
+// the view — the operator wants to see their own call next to the judge's — but
+// they must never move the outcome.
+func TestPairDetails_OperatorVerdictIsListedButDoesNotDecide(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+	items := f.items(t)
+	base, cand := f.variants[0], f.variants[1]
+
+	// The judge works only one order; the operator marks both, disagreeing.
+	f.judgeItem(t, items[0], cand.ID, "claude-code")
+	for _, it := range items {
+		f.judgeItem(t, it, base.ID, JudgeOperator)
+	}
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	if pair.Outcome != PairOutcomePending {
+		t.Fatalf("outcome = %q, want %q — an operator mark is not judge work",
+			pair.Outcome, PairOutcomePending)
+	}
+	var operatorRows int
+	for _, it := range pair.Items {
+		for _, v := range it.Verdicts {
+			if v.JudgeIdent == JudgeOperator {
+				operatorRows++
+				if v.WinnerVariant != base.Name {
+					t.Errorf("operator winner_variant = %q, want %q", v.WinnerVariant, base.Name)
+				}
+			}
+		}
+	}
+	if operatorRows != 2 {
+		t.Errorf("listed %d operator verdicts, want 2", operatorRows)
+	}
+}
+
+// Each side must name the variant that produced it and the sample it produced,
+// so the results view can fetch the two transcripts.
+func TestPairDetails_SidesNameTheirVariantAndSample(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	byVariant := make(map[int64]int64, len(f.variants))
+	for _, v := range f.variants {
+		smp := f.addSample(t, Sample{
+			VariantID: v.ID, TaskID: f.tasks[0].ID, KIndex: 0,
+			Response: "an answer", Rounds: 2, Cost: 0.1, OutcomeOK: 5,
+		})
+		byVariant[v.ID] = smp.ID
+	}
+	f.createPairs(t)
+
+	view := f.pairDetails(t, 0)
+	if view.BaselineVariant != f.variants[0].Name {
+		t.Errorf("baseline_variant = %q, want %q", view.BaselineVariant, f.variants[0].Name)
+	}
+	pair := onlyPair(t, view)
+	if pair.Baseline.VariantID != f.variants[0].ID || pair.Candidate.VariantID != f.variants[1].ID {
+		t.Fatalf("sides = %+v / %+v, want baseline then candidate", pair.Baseline, pair.Candidate)
+	}
+	if pair.Baseline.SampleID != byVariant[f.variants[0].ID] {
+		t.Errorf("baseline sample = %d, want %d", pair.Baseline.SampleID, byVariant[f.variants[0].ID])
+	}
+	if pair.Candidate.SampleID != byVariant[f.variants[1].ID] {
+		t.Errorf("candidate sample = %d, want %d", pair.Candidate.SampleID, byVariant[f.variants[1].ID])
+	}
+	if pair.TaskPrompt != f.tasks[0].Prompt || pair.Category != f.tasks[0].Category {
+		t.Errorf("task = %q/%q, want %q/%q", pair.TaskPrompt, pair.Category,
+			f.tasks[0].Prompt, f.tasks[0].Category)
+	}
+}
+
+func TestPairDetails_TaskFilterNarrowsToOneTask(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat, CategoryToolHeavy})
+	f.cleanRun(t)
+	f.createPairs(t)
+
+	if got := len(f.pairDetails(t, 0).Pairs); got != 2 {
+		t.Fatalf("unfiltered pairs = %d, want 2", got)
+	}
+	view := f.pairDetails(t, f.tasks[1].ID)
+	pair := onlyPair(t, view)
+	if pair.TaskID != f.tasks[1].ID {
+		t.Errorf("task_id = %d, want %d", pair.TaskID, f.tasks[1].ID)
+	}
+}
+
+func TestPairDetails_UnjudgedRunListsEveryPairAsPending(t *testing.T) {
+	f := newPairFixture(t, 2, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+
+	view := f.pairDetails(t, 0)
+	if len(view.Pairs) != 2 {
+		t.Fatalf("got %d pairs, want one per k", len(view.Pairs))
+	}
+	for _, p := range view.Pairs {
+		if p.Outcome != PairOutcomePending {
+			t.Errorf("pair %d outcome = %q, want %q", p.PairID, p.Outcome, PairOutcomePending)
+		}
+		if p.Items == nil {
+			t.Errorf("pair %d items is null, want an empty array the UI can iterate", p.PairID)
+		}
+	}
+	if view.Pairs[0].K == view.Pairs[1].K {
+		t.Error("both pairs report the same k, want one per sample index")
+	}
+}
+
+func TestPairDetails_UnknownRunIsNotFound(t *testing.T) {
+	store := newTestStore(t)
+
+	if _, err := store.PairDetails(context.Background(), 9999, 0); err == nil {
+		t.Fatal("PairDetails on an unknown run returned no error")
+	}
+}
+
+func TestPairDetails_VerdictCarriesDimensionsAndRubricVersion(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	ctx := context.Background()
+	f.cleanRun(t)
+	f.createPairs(t)
+	items := f.items(t)
+
+	if _, err := f.store.RecordVerdict(ctx, Verdict{
+		ItemID: items[0].ID, Winner: WinnerA, JudgeIdent: "claude-code",
+		Dimensions:    `{"task_success":"a","length":"b"}`,
+		Notes:         "A answered the whole question",
+		RubricVersion: "v1",
+	}); err != nil {
+		t.Fatalf("RecordVerdict: %v", err)
+	}
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	v := pair.Items[0].Verdicts[0]
+	if v.RubricVersion != "v1" {
+		t.Errorf("rubric_version = %q, want v1", v.RubricVersion)
+	}
+	if v.Dimensions["task_success"] != "a" || v.Dimensions["length"] != "b" {
+		t.Errorf("dimensions = %v, want the recorded pair", v.Dimensions)
+	}
+	if v.Notes != "A answered the whole question" {
+		t.Errorf("notes = %q, want the recorded text", v.Notes)
+	}
+}
+
+// A tie names no variant: an empty winner_variant is the honest rendering, not
+// a guess at whichever side sorted first.
+func TestPairDetails_TieVerdictNamesNoVariant(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+	f.judgeRun(t, func(Pair) int64 { return 0 })
+
+	pair := onlyPair(t, f.pairDetails(t, 0))
+	if pair.Outcome != PairOutcomeTie {
+		t.Fatalf("outcome = %q, want %q", pair.Outcome, PairOutcomeTie)
+	}
+	for _, it := range pair.Items {
+		if it.Verdicts[0].Winner != WinnerTie || it.Verdicts[0].WinnerVariant != "" {
+			t.Errorf("tie verdict = %+v, want winner tie and no variant", it.Verdicts[0])
+		}
+	}
+}

--- a/internal/eval/store.go
+++ b/internal/eval/store.go
@@ -231,13 +231,14 @@ CREATE TABLE IF NOT EXISTS eval_judgment_items (
 );
 
 CREATE TABLE IF NOT EXISTS eval_verdicts (
-    id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    item_id     INTEGER NOT NULL REFERENCES eval_judgment_items(id),
-    winner      TEXT    NOT NULL,
-    dimensions  TEXT    NOT NULL DEFAULT '{}',
-    notes       TEXT    NOT NULL DEFAULT '',
-    judge_ident TEXT    NOT NULL DEFAULT '',
-    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id        INTEGER NOT NULL REFERENCES eval_judgment_items(id),
+    winner         TEXT    NOT NULL,
+    dimensions     TEXT    NOT NULL DEFAULT '{}',
+    notes          TEXT    NOT NULL DEFAULT '',
+    judge_ident    TEXT    NOT NULL DEFAULT '',
+    rubric_version TEXT    NOT NULL DEFAULT '',
+    created_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_eval_tasks_set      ON eval_tasks (set_id);
@@ -267,6 +268,9 @@ var evalMigrations = []string{
 	// task_ids: the run's task list, pinned at creation. NULL means the whole
 	// set, resolved at read time.
 	`ALTER TABLE eval_runs ADD COLUMN task_ids TEXT`,
+	// rubric_version: which revision of the judging rubric produced the verdict.
+	// Empty on every pre-migration row, and on any judge that does not say.
+	`ALTER TABLE eval_verdicts ADD COLUMN rubric_version TEXT NOT NULL DEFAULT ''`,
 }
 
 // TaskSet is a named collection of eval tasks.
@@ -464,8 +468,13 @@ type Verdict struct {
 	Notes      string `db:"notes"      json:"notes"`
 	// JudgeIdent names who judged — an API key name, or JudgeOperator for the
 	// operator's calibration marks.
-	JudgeIdent string    `db:"judge_ident" json:"judge_ident"`
-	CreatedAt  time.Time `db:"created_at"  json:"created_at"`
+	JudgeIdent string `db:"judge_ident" json:"judge_ident"`
+	// RubricVersion is the judging rubric revision this call was made under, as
+	// the judge reported it (the `Rubric version:` line of the judge-eval
+	// skill). Empty when the judge did not say, which is why the results view
+	// reports the distinct set rather than assuming one.
+	RubricVersion string    `db:"rubric_version" json:"rubric_version,omitempty"`
+	CreatedAt     time.Time `db:"created_at"     json:"created_at"`
 }
 
 // Store persists eval task sets, runs and samples. It owns its own handle on

--- a/internal/eval/verdict.go
+++ b/internal/eval/verdict.go
@@ -1,6 +1,9 @@
 package eval
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Decision-rule outcomes.
 //
@@ -61,6 +64,12 @@ type Judgment struct {
 	WinThreshold float64 `json:"win_threshold"`
 	// OperatorAgreement is nil until the operator marks a calibration item.
 	OperatorAgreement *Agreement `json:"operator_agreement,omitempty"`
+	// RubricVersions is the distinct set of rubric revisions the judge verdicts
+	// behind this tally were made under, sorted. A set rather than a single
+	// value because a queue worked across a rubric edit is a real thing to see:
+	// two versions here means the win-rate mixes two policies. Judges that did
+	// not report a version contribute nothing.
+	RubricVersions []string `json:"rubric_versions,omitempty"`
 }
 
 // CategoryResult breaks a candidate's performance down by task category. A
@@ -207,6 +216,7 @@ func gateLabel(name string) string {
 
 // pairOutcome is one pair collapsed to a single winner.
 type pairOutcome struct {
+	pairID    int64
 	taskID    int64
 	candidate int64
 	// winner is the variant id that took the pair, 0 for a tie.
@@ -215,6 +225,33 @@ type pairOutcome struct {
 	decided bool
 	// agreement counts the operator's calibration marks on this pair's items.
 	agreeItems, agreed int
+	// rubrics are the non-empty rubric versions the judge verdicts on this
+	// pair's items reported.
+	rubrics []string
+}
+
+// Pair outcomes, from the candidate's point of view. They follow the
+// aggregation rules exactly: a pair is only decided once both presentation
+// orders carry a judge verdict, and orders that disagree are a tie.
+const (
+	PairOutcomeWin     = "win"
+	PairOutcomeLoss    = "loss"
+	PairOutcomeTie     = "tie"
+	PairOutcomePending = "pending"
+)
+
+// outcome names a resolved pair from the candidate's point of view.
+func (po pairOutcome) outcome(baselineID int64) string {
+	switch {
+	case !po.decided:
+		return PairOutcomePending
+	case po.winner == po.candidate:
+		return PairOutcomeWin
+	case po.winner == baselineID:
+		return PairOutcomeLoss
+	default:
+		return PairOutcomeTie
+	}
 }
 
 // resolvePairs collapses each pair's two presentation orders into one outcome.
@@ -236,9 +273,10 @@ func resolvePairs(in verdictInput) []pairOutcome {
 		if err != nil {
 			continue
 		}
-		po := pairOutcome{taskID: p.TaskID, candidate: candidateOf(assign, in.variants[0].ID)}
+		po := pairOutcome{pairID: p.ID, taskID: p.TaskID, candidate: candidateOf(assign, in.variants[0].ID)}
 		po.decided, po.winner = resolveOutcome(itemsByPair[p.ID], judge, assign)
 		po.agreeItems, po.agreed = countAgreement(itemsByPair[p.ID], judge, operator)
+		po.rubrics = pairRubrics(itemsByPair[p.ID], judge)
 		out = append(out, po)
 	}
 	return out
@@ -289,6 +327,20 @@ func countAgreement(items []JudgmentItem, judge, operator map[int64]Verdict) (in
 	return total, agreed
 }
 
+// pairRubrics collects the rubric versions the judge reported on one pair's
+// items. Only the judge's own calls count: the operator's calibration mark is
+// excluded from the win rate, so it does not describe the rubric the tally was
+// produced under.
+func pairRubrics(items []JudgmentItem, judge map[int64]Verdict) []string {
+	var out []string
+	for _, it := range items {
+		if v, ok := judge[it.ID]; ok && v.RubricVersion != "" {
+			out = append(out, v.RubricVersion)
+		}
+	}
+	return out
+}
+
 // verdictsByItem splits stored verdicts into the judge's and the operator's,
 // keeping the newest of each per item.
 func verdictsByItem(verdicts []Verdict) (judge, operator map[int64]Verdict) {
@@ -318,6 +370,7 @@ func candidateOf(assign Assignment, baselineID int64) int64 {
 func tallyJudgment(opts SummaryOpts, outcomes []pairOutcome, baselineID, candID int64) Judgment {
 	j := Judgment{WinThreshold: opts.WinThreshold}
 	var agreeItems, agreed int
+	rubrics := make(map[string]struct{})
 	for _, po := range outcomes {
 		if po.candidate != candID {
 			continue
@@ -325,6 +378,9 @@ func tallyJudgment(opts SummaryOpts, outcomes []pairOutcome, baselineID, candID 
 		j.Pairs++
 		agreeItems += po.agreeItems
 		agreed += po.agreed
+		for _, rv := range po.rubrics {
+			rubrics[rv] = struct{}{}
+		}
 		if !po.decided {
 			continue
 		}
@@ -347,7 +403,22 @@ func tallyJudgment(opts SummaryOpts, outcomes []pairOutcome, baselineID, candID 
 			Rate: float64(agreed) / float64(agreeItems),
 		}
 	}
+	j.RubricVersions = sortedKeys(rubrics)
 	return j
+}
+
+// sortedKeys returns a map's keys in a stable order; a map walk would reshuffle
+// the rubric list on every request.
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // --- Per-category breakdown ---

--- a/internal/eval/verdict_test.go
+++ b/internal/eval/verdict_test.go
@@ -423,3 +423,92 @@ func TestSummaryOpts_ZeroValueUsesShippedDefaults(t *testing.T) {
 		t.Errorf("verdict = %q (%s), want %q", vv.Verdict, vv.Reason, VerdictNoRegressions)
 	}
 }
+
+// A queue worked across a rubric edit must show both versions rather than
+// silently averaging two different policies into one win-rate.
+func TestJudgment_RubricVersionsAreDistinctAndSorted(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat, CategoryToolHeavy})
+	ctx := context.Background()
+	f.cleanRun(t)
+	f.createPairs(t)
+
+	// Two rubric versions across the queue, recorded newest-first so the sort
+	// is doing the ordering rather than insertion order.
+	versions := []string{"v2", "v1", "v2", "v1"}
+	for i, it := range f.items(t) {
+		if _, err := f.store.RecordVerdict(ctx, Verdict{
+			ItemID: it.ID, Winner: WinnerA, JudgeIdent: "claude-code",
+			RubricVersion: versions[i%len(versions)],
+		}); err != nil {
+			t.Fatalf("RecordVerdict: %v", err)
+		}
+	}
+
+	got := f.onlyVerdict(t, f.summarizeWith(t, testOpts())).Judgment.RubricVersions
+	if len(got) != 2 || got[0] != "v1" || got[1] != "v2" {
+		t.Errorf("rubric_versions = %v, want [v1 v2]", got)
+	}
+}
+
+// A judge that does not report a version contributes nothing, and the field
+// stays absent rather than carrying an empty string.
+func TestJudgment_RubricVersionsEmptyWhenUnreported(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	f.cleanRun(t)
+	f.createPairs(t)
+	f.judgeRun(t, func(Pair) int64 { return f.variants[1].ID })
+
+	if got := f.onlyVerdict(t, f.summarizeWith(t, testOpts())).Judgment.RubricVersions; got != nil {
+		t.Errorf("rubric_versions = %v, want nil when no judge reported one", got)
+	}
+}
+
+// The operator's calibration mark is excluded from the win rate, so it must not
+// describe the rubric the win rate was produced under either.
+func TestJudgment_RubricVersionsIgnoreOperatorMarks(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	ctx := context.Background()
+	f.cleanRun(t)
+	f.createPairs(t)
+
+	for _, it := range f.items(t) {
+		if _, err := f.store.RecordVerdict(ctx, Verdict{
+			ItemID: it.ID, Winner: WinnerA, JudgeIdent: JudgeOperator, RubricVersion: "operator-notes",
+		}); err != nil {
+			t.Fatalf("RecordVerdict: %v", err)
+		}
+	}
+
+	if got := f.onlyVerdict(t, f.summarizeWith(t, testOpts())).Judgment.RubricVersions; got != nil {
+		t.Errorf("rubric_versions = %v, want nil — only judge verdicts count", got)
+	}
+}
+
+// The verdict upsert must carry the rubric version through a re-judge rather
+// than blanking it, since a retrying headless judge overwrites its own row.
+func TestRecordVerdict_UpsertPreservesRubricVersion(t *testing.T) {
+	f := newPairFixture(t, 1, []string{CategoryChat})
+	ctx := context.Background()
+	f.cleanRun(t)
+	f.createPairs(t)
+	item := f.items(t)[0]
+
+	for _, w := range []string{WinnerA, WinnerB} {
+		if _, err := f.store.RecordVerdict(ctx, Verdict{
+			ItemID: item.ID, Winner: w, JudgeIdent: "claude-code", RubricVersion: "v1",
+		}); err != nil {
+			t.Fatalf("RecordVerdict: %v", err)
+		}
+	}
+
+	rows, err := f.store.ListVerdicts(ctx, f.run.ID)
+	if err != nil {
+		t.Fatalf("ListVerdicts: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d verdict rows, want 1 after a re-judge", len(rows))
+	}
+	if rows[0].Winner != WinnerB || rows[0].RubricVersion != "v1" {
+		t.Errorf("verdict = %+v, want the second winner and rubric v1", rows[0])
+	}
+}

--- a/internal/mcpserver/tools_eval.go
+++ b/internal/mcpserver/tools_eval.go
@@ -36,6 +36,9 @@ type evalVerdictInput struct {
 	Notes      string `json:"notes,omitempty" jsonschema:"Short rationale; cite the persona or skill clause behind any persona_fit or task_success deduction"`
 	Dimensions string `json:"dimensions,omitempty" jsonschema:"JSON object of dimension to winner, e.g. {\"task_success\":\"a\",\"tool_path\":\"tie\",\"persona_fit\":\"a\",\"length\":\"b\"}"`
 	JudgeIdent string `json:"judge_ident,omitempty" jsonschema:"Who is judging; defaults to the API key name. Pass \"operator\" to record a human calibration mark alongside the judge's verdict rather than replacing it"`
+	// RubricVersion is stored verbatim: the rubric is a skill file the operator
+	// edits, so the server has no list of valid versions to check against.
+	RubricVersion string `json:"rubric_version,omitempty" jsonschema:"The judging rubric revision this call was made under, e.g. \"v1\" — copy the 'Rubric version' line of the judging skill so the results view can name what the win-rate was judged against"`
 }
 
 type evalRunInput struct {
@@ -66,8 +69,8 @@ func (s *Server) registerEvalTools() {
 		Name: "eval_verdict",
 		Description: "Record a verdict on one judgment item: which response won (a, b, or tie), " +
 			"optional per-dimension winners (task_success, tool_path, persona_fit, length), " +
-			"and notes. Re-judging the same item overwrites your own earlier verdict. " +
-			"Requires 'eval:write' scope.",
+			"notes, and the rubric version it was judged under. Re-judging the same item " +
+			"overwrites your own earlier verdict. Requires 'eval:write' scope.",
 	}, s.handleEvalVerdict)
 
 	mcp.AddTool(s.mcpServer, &mcp.Tool{
@@ -160,11 +163,12 @@ func (s *Server) handleEvalVerdict(ctx context.Context, _ *mcp.CallToolRequest, 
 	}
 
 	verdict, err := store.RecordVerdict(ctx, eval.Verdict{
-		ItemID:     input.ItemID,
-		Winner:     winner,
-		Dimensions: dims,
-		Notes:      input.Notes,
-		JudgeIdent: judgeIdent(ctx, input.JudgeIdent),
+		ItemID:        input.ItemID,
+		Winner:        winner,
+		Dimensions:    dims,
+		Notes:         input.Notes,
+		JudgeIdent:    judgeIdent(ctx, input.JudgeIdent),
+		RubricVersion: strings.TrimSpace(input.RubricVersion),
 	})
 	if err != nil {
 		return toolError("recording verdict: " + err.Error()), nil, nil

--- a/internal/mcpserver/tools_eval_test.go
+++ b/internal/mcpserver/tools_eval_test.go
@@ -3,11 +3,13 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Temikus/denkeeper/internal/eval"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func evalReadCtx() context.Context {
@@ -163,6 +165,93 @@ func TestEvalVerdict_RecordsAndDefaultsJudgeToTheKeyName(t *testing.T) {
 	}
 	if item.Status != eval.ItemJudged {
 		t.Errorf("item status = %q, want %q", item.Status, eval.ItemJudged)
+	}
+}
+
+// The rubric version has to survive the whole path — MCP input, store row,
+// aggregation — or the results view cannot name the policy a win-rate was
+// produced under.
+func TestEvalVerdict_RubricVersionReachesTheSummary(t *testing.T) {
+	s, store, runID := evalServer(t)
+	ctx := context.Background()
+	items, err := store.ListItems(ctx, runID)
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+
+	for _, it := range items {
+		res, _, _ := s.handleEvalVerdict(evalWriteCtx(), nil, evalVerdictInput{
+			ItemID: it.ID, Winner: "a", RubricVersion: "  v1  ",
+		})
+		if res.IsError {
+			t.Fatalf("eval_verdict: %s", toolResultText(res))
+		}
+	}
+
+	res, _, _ := s.handleEvalSummary(evalReadCtx(), nil, evalRunInput{RunID: runID})
+	if res.IsError {
+		t.Fatalf("eval_summary: %s", toolResultText(res))
+	}
+	var sum eval.Summary
+	if err := json.Unmarshal([]byte(toolResultText(res)), &sum); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(sum.Verdicts) != 1 {
+		t.Fatalf("got %d verdicts, want 1", len(sum.Verdicts))
+	}
+	got := sum.Verdicts[0].Judgment.RubricVersions
+	if len(got) != 1 || got[0] != "v1" {
+		t.Errorf("rubric_versions = %v, want [v1] with the padding trimmed", got)
+	}
+}
+
+// listEvalToolNames connects an in-process client and returns what the judge
+// surface advertises.
+func listEvalToolNames(t *testing.T) []string {
+	t.Helper()
+	s := &Server{deps: Deps{Logger: testLogger()}}
+	s.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "denkeeper", Version: "test"}, nil)
+	s.registerEvalTools()
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := s.mcpServer.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "tool-list-test", Version: "test"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	names := make([]string, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// The judge surface is exactly five tools, and none of them unblinds a pair.
+// The unblinded view (GET /eval/runs/{id}/pairs) is REST-only on purpose: a
+// judge that can look up which variant produced which response can unblind its
+// own queue, and every position-bias control downstream stops meaning anything.
+func TestEvalTools_JudgeSurfaceCannotUnblindAPair(t *testing.T) {
+	want := []string{"eval_get_pair", "eval_pending", "eval_run_status", "eval_summary", "eval_verdict"}
+	got := listEvalToolNames(t)
+
+	if len(got) != len(want) {
+		t.Fatalf("judge tools = %v, want exactly %v", got, want)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Fatalf("judge tools = %v, want exactly %v", got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Stage D0.4 and D0.5 of the eval subsystem — the two judging-side backend gaps the results view (D2) cannot be honest without. Backend only; no UI in this PR.

## D0.4 — `GET /api/v1/eval/runs/{id}/pairs` (`eval:read`)

The operator's **unblinded** view of a run's judging grid. Until now the only pair reader was the blinded MCP `eval_get_pair`, so "judged pairs with the judge's dimension scores and notes" had nothing to call.

Per pair: task prompt/category/k, both sides' variant name and sample id, the two presentation-order items with every verdict (judge ident, presented letter, the letter resolved to a variant via `VariantFor`, dimensions, notes, rubric version), and the pair's outcome from the candidate's point of view. Optional `?task_id=` filter. Read-only — no new store writes.

Two things worth a reviewer's attention:

1. **Outcomes reuse `resolvePairs`/`resolveOutcome`** rather than re-deriving the both-orders-must-agree rule. `pairOutcome` gained a `pairID` so the view can index it; the win/loss/tie/pending mapping is a one-line method on that struct. A second derivation is exactly how this view and the win-rate would drift apart.
2. **REST-only, deliberately.** It is not on the MCP judge surface: a judge that can unblind its own queue makes every position-bias control downstream meaningless. `TestEvalTools_JudgeSurfaceCannotUnblindAPair` pins the judge tool set at exactly five names so this cannot regress by accident.

## D0.5 — rubric version on verdicts

`eval_verdicts.rubric_version TEXT NOT NULL DEFAULT ''` (new `evalMigrations` entry), optional `rubric_version` on the `eval_verdict` MCP tool, carried through the upsert, and the distinct set surfaced as `Judgment.RubricVersions` (sorted; judge verdicts only, operator marks excluded). `.claude/skills/judge-eval/SKILL.md` now passes it on every verdict, matching its own `Rubric version: v1` line.

A set rather than a single value because a queue worked across a rubric edit should show two versions rather than silently averaging two policies into one win-rate.

## Response shape

```json
{
  "run_id": 7,
  "baseline_variant": "incumbent",
  "pairs": [{
    "pair_id": 12, "task_id": 3, "task_prompt": "what is on today?",
    "category": "chat", "k": 0,
    "baseline":  {"variant_id": 1, "variant": "incumbent", "sample_id": 40},
    "candidate": {"variant_id": 2, "variant": "candidate", "sample_id": 41},
    "items": [{
      "item_id": 23, "presentation_order": "ab", "status": "judged",
      "verdicts": [{"judge_ident": "claude-code", "winner": "a",
                    "winner_variant": "candidate",
                    "dimensions": {"task_success": "a", "length": "b"},
                    "notes": "...", "rubric_version": "v1",
                    "created_at": "2026-08-19T08:12:44Z"}]
    }],
    "outcome": "win"
  }]
}
```

`outcome` is `win|loss|tie|pending`. `winner_variant` is omitted on a tie. Operator rows appear with `judge_ident: "operator"` and never move the outcome.

<details>
<summary>Test evidence</summary>

`JUST_HOOK_FORCE=1 just hook` green after rebase onto `origin/main` (18e363e): fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check.

New tests:
- `internal/eval/pairview_test.go` (11) — agreeing orders resolve to the candidate (and the two presented letters differ, so the resolution is doing work), agreeing on the baseline is a loss, disagreement is a tie, half-judged is pending, operator verdict listed but not deciding, sides name their variant and sample, task filter, unjudged run, unknown run, dimensions/rubric round-trip, tie names no variant.
- `internal/eval/verdict_test.go` (4) — `rubric_versions` distinct and sorted, absent when unreported, ignores operator marks, upsert preserves it across a re-judge.
- `internal/mcpserver/tools_eval_test.go` (2) — rubric version MCP to store to summary (with whitespace trimmed), and the five-tool judge surface pin.
- `internal/api/eval_test.go` (7) — full unblinded shape, pending, tie, operator, task filter, 404, 400 on a bad `task_id`, and scope gating (an `eval:read` key reads it, a `chat` key gets 403).

`TestGetBlindedItem_LeaksNoIdentity` untouched and green; `BlindedItem` is unchanged.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
