### PR TITLE
feat(web): add the Evals page — launcher and run status

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -26,6 +26,7 @@
   import Settings from './pages/Settings.svelte'
   import AuditLog from './pages/AuditLog.svelte'
   import Channels from './pages/Channels.svelte'
+  import Evals from './pages/Evals.svelte'
   import MoreMenu from './pages/MoreMenu.svelte'
   import './shared.css'
 
@@ -110,6 +111,8 @@
         <Channels />
       {:else if route === 'audit'}
         <AuditLog />
+      {:else if route === 'evals'}
+        <Evals />
       {:else if route === 'settings'}
         <Settings />
       {:else if route === 'more'}

--- a/web/src/__tests__/pages/Evals.test.js
+++ b/web/src/__tests__/pages/Evals.test.js
@@ -204,10 +204,41 @@ describe('Evals page — launcher', () => {
     })
   })
 
-  test('Start stays disabled until a candidate is named', async () => {
+  test('Start stays disabled until a candidate is named, and says why', async () => {
     render(Evals)
     await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
     expect(screen.getByTestId('start-run')).toBeDisabled()
+    expect(screen.getByTestId('start-blocker')).toHaveTextContent('Pick a candidate model')
+  })
+
+  test('a hand-typed candidate drops the provider captured for another model', async () => {
+    let body = null
+    server.use(
+      http.post('/api/v1/eval/runs', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ id: 3, task_set_id: 1, status: 'pending', k: 1, cost_cap: 2, cost_spent: 0, variants: [], samples_done: 0, samples_total: 0, active: true }, { status: 201 })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    // Pick from the list, which captures the model's provider...
+    const input = document.querySelector('.model-selector input')
+    await fireEvent.focus(input)
+    // The selector only lists models once a provider is chosen.
+    await waitFor(() => expect(document.querySelector('.provider-select')).toBeInTheDocument())
+    await fireEvent.change(document.querySelector('.provider-select'), { target: { value: 'openrouter' } })
+    await waitFor(() => expect(screen.getByText('OpenAI: GPT-4o')).toBeInTheDocument())
+    await fireEvent.mouseDown(screen.getByText('OpenAI: GPT-4o'))
+
+    // ...then hand-edit the field to a model that provider was never read for.
+    await fireEvent.input(input, { target: { value: 'anthropic/claude-3-opus' } })
+    await waitFor(() => expect(screen.getByTestId('start-run')).not.toBeDisabled())
+    await fireEvent.click(screen.getByTestId('start-run'))
+
+    await waitFor(() => expect(body).not.toBeNull())
+    expect(body.variants[1].llm_model).toBe('anthropic/claude-3-opus')
+    expect(body.variants[1].llm_provider).toBeUndefined()
   })
 
   test('a rejected run surfaces the error inline', async () => {
@@ -230,8 +261,9 @@ describe('Evals page — runs list', () => {
     render(Evals)
     await waitFor(() => expect(screen.getByTestId('run-1')).toBeInTheDocument())
 
+    // Statuses render as operator words, not the API's own ("capped" especially).
     expect(screen.getByTestId('run-status-1')).toHaveTextContent('running')
-    expect(screen.getByTestId('run-status-2')).toHaveTextContent('done')
+    expect(screen.getByTestId('run-status-2')).toHaveTextContent('finished')
     expect(screen.getByTestId('progress-1')).toHaveTextContent('8 / 20')
     expect(screen.getByTestId('run-1')).toHaveTextContent('$0.31 of $2.00')
     expect(screen.getByTestId('run-1')).toHaveTextContent('golden-set')
@@ -275,6 +307,22 @@ describe('Evals page — runs list', () => {
     await waitFor(() => expect(stopped).toBe(1))
   })
 
+  test('a failed Stop keeps the dialog open and reports inside it', async () => {
+    server.use(
+      http.post('/api/v1/eval/runs/:id/stop', () =>
+        HttpResponse.json({ error: 'run 1 is done and cannot be stopped' }, { status: 409 })),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('stop-1')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByTestId('stop-1'))
+    await fireEvent.click(screen.getByRole('button', { name: 'Stop run' }))
+
+    await waitFor(() => expect(screen.getByTestId('stop-error')).toHaveTextContent('cannot be stopped'))
+    // The run card may be screens away, so closing on failure would read as success.
+    expect(screen.getByTestId('stop-confirm')).toBeInTheDocument()
+  })
+
   test('cancelling the confirm leaves the run alone', async () => {
     let stopped = 0
     server.use(
@@ -313,7 +361,7 @@ describe('Evals page — runs list', () => {
 
     // The mount hydrate is read 1; the poll interval supplies the rest.
     await waitFor(() => expect(screen.getByTestId('progress-1')).toHaveTextContent('12 / 20'), { timeout: 3000 })
-    await waitFor(() => expect(screen.getByTestId('run-status-1')).toHaveTextContent('done'), { timeout: 15000 })
+    await waitFor(() => expect(screen.getByTestId('run-status-1')).toHaveTextContent('finished'), { timeout: 15000 })
 
     const settled = detailReads
     await new Promise(r => setTimeout(r, 5000))

--- a/web/src/__tests__/pages/Evals.test.js
+++ b/web/src/__tests__/pages/Evals.test.js
@@ -1,0 +1,351 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/server.js'
+import { token, authMode } from '../../store.js'
+import { evalProgress } from '../../wsStore.js'
+import Evals from '../../pages/Evals.svelte'
+
+const AGENTS = [
+  { name: 'default', model: 'kimi-k2.6', provider: 'openrouter', permission_tier: 'autonomous', skill_count: 2, has_tools: true },
+  { name: 'helper', model: 'gpt-4o', provider: 'openrouter', permission_tier: 'supervised', skill_count: 0, has_tools: false },
+]
+
+/** Strips every eval read down to empty, which is what a fresh install looks like. */
+function emptyInstance() {
+  server.use(
+    http.get('/api/v1/eval/task-sets', () => HttpResponse.json([])),
+    http.get('/api/v1/eval/runs', () => HttpResponse.json([])),
+  )
+}
+
+beforeEach(() => {
+  token.set('test-key')
+  authMode.set('token')
+  evalProgress.set(new Map())
+  server.use(http.get('/api/v1/agents', () => HttpResponse.json(AGENTS)))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('Evals page — empty state', () => {
+  test('teaches the loop and offers Chat and import, but not suggest', async () => {
+    emptyInstance()
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('evals-empty')).toBeInTheDocument())
+    expect(
+      screen.getByText(/Save real conversations as test cases, then compare your current model against a candidate on them/)
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('empty-chat-cta')).toBeInTheDocument()
+    expect(screen.getByTestId('empty-import-cta')).toBeInTheDocument()
+    // "Suggest from history" ships in a later slice — absent, not disabled.
+    expect(screen.queryByText(/Suggest/i)).not.toBeInTheDocument()
+  })
+
+  test('hides the launcher and runs list until something exists', async () => {
+    emptyInstance()
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('evals-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('launcher')).not.toBeInTheDocument()
+  })
+
+  test('import creates the set on the fly and reports what landed', async () => {
+    emptyInstance()
+    let createdName = ''
+    let importedInto = ''
+    server.use(
+      http.post('/api/v1/eval/task-sets', async ({ request }) => {
+        createdName = (await request.json()).name
+        return HttpResponse.json({ id: 9, name: createdName, task_count: 0 }, { status: 201 })
+      }),
+      http.post('/api/v1/eval/task-sets/:name/import', ({ params }) => {
+        importedInto = params.name
+        return HttpResponse.json({ imported: 4 })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('evals-empty')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByTestId('empty-import-cta'))
+
+    const file = new File(['{"prompt":"hi","category":"chat"}\n'], 'golden-set.jsonl', { type: 'text/plain' })
+    const picker = document.querySelector('input[type="file"]')
+    Object.defineProperty(picker, 'files', { value: [file] })
+    await fireEvent.change(picker)
+
+    await waitFor(() => expect(screen.getByText('Import')).not.toBeDisabled())
+    await fireEvent.click(screen.getByText('Import'))
+
+    await waitFor(() => expect(screen.getByText(/Imported 4 test cases into "golden-set"/)).toBeInTheDocument())
+    expect(createdName).toBe('golden-set')
+    expect(importedInto).toBe('golden-set')
+  })
+})
+
+describe('Evals page — launcher', () => {
+  test('Quick check posts a sampled subset at k=1', async () => {
+    let body = null
+    server.use(
+      http.post('/api/v1/eval/runs', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ id: 3, task_set_id: 1, status: 'pending', k: body.k, cost_cap: 2, cost_spent: 0, variants: [], samples_done: 0, samples_total: 0, active: true }, { status: 201 })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+    await fireEvent.click(screen.getByTestId('preset-quick'))
+    await waitFor(() => expect(screen.getByTestId('start-run')).not.toBeDisabled())
+    await fireEvent.click(screen.getByTestId('start-run'))
+
+    await waitFor(() => expect(body).not.toBeNull())
+    expect(body.sample_tasks).toBe(10)
+    expect(body.k).toBe(1)
+  })
+
+  test('Full eval runs the whole set at the configured default_k', async () => {
+    let body = null
+    server.use(
+      http.post('/api/v1/eval/runs', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ id: 3, task_set_id: 1, status: 'pending', k: body.k, cost_cap: 2, cost_spent: 0, variants: [], samples_done: 0, samples_total: 0, active: true }, { status: 201 })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+    await fireEvent.click(screen.getByTestId('preset-full'))
+    await waitFor(() => expect(screen.getByTestId('start-run')).not.toBeDisabled())
+    await fireEvent.click(screen.getByTestId('start-run'))
+
+    await waitFor(() => expect(body).not.toBeNull())
+    expect(body.sample_tasks).toBeUndefined()
+    // default_k from GET /eval/config.
+    expect(body.k).toBe(3)
+  })
+
+  test('Start posts the incumbent first, as an empty overlay', async () => {
+    let body = null
+    server.use(
+      http.post('/api/v1/eval/runs', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ id: 3, task_set_id: 1, status: 'pending', k: 1, cost_cap: 2, cost_spent: 0, variants: [], samples_done: 0, samples_total: 0, active: true }, { status: 201 })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+    await waitFor(() => expect(screen.getByTestId('start-run')).not.toBeDisabled())
+    await fireEvent.click(screen.getByTestId('start-run'))
+
+    await waitFor(() => expect(body).not.toBeNull())
+    expect(body.variants[0]).toEqual({ name: 'current' })
+    expect(body.variants[0].llm_model).toBeUndefined()
+    expect(body.variants[1].name).toBe('openai/gpt-4o')
+    expect(body.variants[1].llm_model).toBe('openai/gpt-4o')
+    expect(body.base_agent).toBe('default')
+    expect(body.task_set).toBe('golden-set')
+  })
+
+  test('shows the estimate range with its basis, and any note', async () => {
+    server.use(
+      http.post('/api/v1/eval/estimate', () => HttpResponse.json({
+        low: 0.12, high: 0.4, currency: 'USD', basis: 'history', tasks: 10, k: 1,
+        per_variant: [], note: 'Two candidate tasks had no cost history.',
+      })),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('estimate')).toHaveTextContent('$0.12')
+      expect(screen.getByTestId('estimate')).toHaveTextContent('$0.40')
+      expect(screen.getByTestId('estimate')).toHaveTextContent('from history')
+    })
+    expect(screen.getByTestId('estimate-note')).toHaveTextContent('Two candidate tasks had no cost history.')
+  })
+
+  test('list_price basis is labelled as such', async () => {
+    server.use(
+      http.post('/api/v1/eval/estimate', () => HttpResponse.json({
+        low: 0.5, high: 1.2, currency: 'USD', basis: 'list_price', tasks: 10, k: 1, per_variant: [],
+      })),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+
+    await waitFor(() => expect(screen.getByTestId('estimate')).toHaveTextContent('list price'))
+  })
+
+  test('an unknown basis invents no number — the cap stands alone', async () => {
+    server.use(
+      http.post('/api/v1/eval/estimate', () => HttpResponse.json({
+        low: 0, high: 0, currency: 'USD', basis: 'unknown', tasks: 10, k: 1, per_variant: [],
+      })),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+
+    await waitFor(() => expect(screen.getByTestId('cost-cap')).toHaveValue(2))
+    await waitFor(() => {
+      expect(screen.getByTestId('estimate')).not.toHaveTextContent('~$')
+      expect(screen.getByTestId('estimate')).toHaveTextContent('stops cleanly at the cap')
+    })
+  })
+
+  test('Start stays disabled until a candidate is named', async () => {
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+    expect(screen.getByTestId('start-run')).toBeDisabled()
+  })
+
+  test('a rejected run surfaces the error inline', async () => {
+    server.use(
+      http.post('/api/v1/eval/runs', () =>
+        HttpResponse.json({ error: 'task set is empty' }, { status: 400 })),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+    await fireEvent.input(document.querySelector('.model-selector input'), { target: { value: 'openai/gpt-4o' } })
+    await waitFor(() => expect(screen.getByTestId('start-run')).not.toBeDisabled())
+    await fireEvent.click(screen.getByTestId('start-run'))
+
+    await waitFor(() => expect(screen.getByText('task set is empty')).toBeInTheDocument())
+  })
+})
+
+describe('Evals page — runs list', () => {
+  test('renders status, progress, spend and the test set for each run', async () => {
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('run-1')).toBeInTheDocument())
+
+    expect(screen.getByTestId('run-status-1')).toHaveTextContent('running')
+    expect(screen.getByTestId('run-status-2')).toHaveTextContent('done')
+    expect(screen.getByTestId('progress-1')).toHaveTextContent('8 / 20')
+    expect(screen.getByTestId('run-1')).toHaveTextContent('$0.31 of $2.00')
+    expect(screen.getByTestId('run-1')).toHaveTextContent('golden-set')
+    expect(screen.getByTestId('run-1')).toHaveTextContent('current vs openai/gpt-4o')
+  })
+
+  test('names the subset when fewer than the whole set ran', async () => {
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('run-1')).toBeInTheDocument())
+    // Run 1 drew 10 of the set's 37 cases; run 2 used all of them.
+    expect(screen.getByTestId('subset-1')).toHaveTextContent('10 of 37 test cases')
+    expect(screen.queryByTestId('subset-2')).not.toBeInTheDocument()
+  })
+
+  test('a terminal run expands to the results mount point', async () => {
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
+    // An active run offers Stop instead.
+    expect(screen.queryByTestId('results-1')).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByTestId('results-2'))
+    expect(screen.getByTestId('results-panel-2')).toBeInTheDocument()
+  })
+
+  test('Stop confirms before cancelling', async () => {
+    let stopped = 0
+    server.use(
+      http.post('/api/v1/eval/runs/:id/stop', () => {
+        stopped++
+        return HttpResponse.json({ status: 'stopping' })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('stop-1')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByTestId('stop-1'))
+    expect(screen.getByTestId('stop-confirm')).toBeInTheDocument()
+    expect(stopped).toBe(0)
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Stop run' }))
+    await waitFor(() => expect(stopped).toBe(1))
+  })
+
+  test('cancelling the confirm leaves the run alone', async () => {
+    let stopped = 0
+    server.use(
+      http.post('/api/v1/eval/runs/:id/stop', () => {
+        stopped++
+        return HttpResponse.json({ status: 'stopping' })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('stop-1')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByTestId('stop-1'))
+    await fireEvent.click(screen.getByText('Cancel'))
+
+    await waitFor(() => expect(screen.queryByTestId('stop-confirm')).not.toBeInTheDocument())
+    expect(stopped).toBe(0)
+  })
+
+  test('polls the active run and stops once nothing is live', async () => {
+    let detailReads = 0
+    server.use(
+      http.get('/api/v1/eval/runs/:id', ({ params }) => {
+        if (params.id !== '1') return new HttpResponse(null, { status: 404 })
+        detailReads++
+        // Third read reports the run finished, which should end the polling.
+        const done = detailReads >= 3
+        return HttpResponse.json({
+          id: 1, task_set_id: 1, base_agent: 'default', status: done ? 'done' : 'running',
+          k: 1, cost_cap: 2, cost_spent: 0.5, created_at: '2026-08-18T09:00:00Z', task_count: 10,
+          variants: [{ id: 1, run_id: 1, name: 'current', overlay: '{}' }],
+          samples_done: done ? 20 : 12, samples_total: 20, active: !done,
+        })
+      }),
+    )
+    render(Evals)
+
+    // The mount hydrate is read 1; the poll interval supplies the rest.
+    await waitFor(() => expect(screen.getByTestId('progress-1')).toHaveTextContent('12 / 20'), { timeout: 3000 })
+    await waitFor(() => expect(screen.getByTestId('run-status-1')).toHaveTextContent('done'), { timeout: 15000 })
+
+    const settled = detailReads
+    await new Promise(r => setTimeout(r, 5000))
+    expect(detailReads).toBe(settled)
+  }, 25000)
+
+  test('an eval_progress frame wakes an immediate re-read', async () => {
+    let detailReads = 0
+    server.use(
+      http.get('/api/v1/eval/runs/:id', ({ params }) => {
+        if (params.id !== '1') return new HttpResponse(null, { status: 404 })
+        detailReads++
+        return HttpResponse.json({
+          id: 1, task_set_id: 1, base_agent: 'default', status: 'running',
+          k: 1, cost_cap: 2, cost_spent: 0.9, created_at: '2026-08-18T09:00:00Z', task_count: 10,
+          variants: [{ id: 1, run_id: 1, name: 'current', overlay: '{}' }],
+          samples_done: 17, samples_total: 20, active: true,
+        })
+      }),
+    )
+    render(Evals)
+    await waitFor(() => expect(detailReads).toBeGreaterThan(0))
+    const before = detailReads
+
+    // The frame is a wake-up, not truth: the page re-reads the run rather than
+    // rendering the frame's own numbers.
+    evalProgress.set(new Map([[1, {
+      type: 'eval_progress', run_id: 1, status: 'running',
+      samples_done: 15, samples_total: 20, cost_spent: 0.8, cost_cap: 2, eta_seconds: 30,
+    }]]))
+
+    await waitFor(() => expect(detailReads).toBeGreaterThan(before))
+    await waitFor(() => expect(screen.getByTestId('progress-1')).toHaveTextContent('17 / 20'))
+  })
+})

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -402,16 +402,76 @@ export const api = {
       body: JSON.stringify(body),
     }),
 
-  // Evals — saved test cases. Stage B exposes only the acquisition half here;
-  // runs are API-only until the Evals page lands.
+  // Evals — saved test cases and comparison runs.
   evalTaskSets: () => apiFetch('/api/v1/eval/task-sets'),
+  evalTaskSet: (name) => apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}`),
   createEvalTaskSet: (body) =>
     apiFetch('/api/v1/eval/task-sets', { method: 'POST', body: JSON.stringify(body) }),
+  updateEvalTaskSet: (name, body) =>
+    apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+  deleteEvalTaskSet: (name) =>
+    apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}`, { method: 'DELETE' }),
   addEvalTask: (name, body) =>
     apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}/tasks`, {
       method: 'POST',
       body: JSON.stringify(body),
     }),
+  updateEvalTask: (name, id, body) =>
+    apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}/tasks/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+  deleteEvalTask: (name, id) =>
+    apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}/tasks/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    }),
+  // Export streams JSONL, not JSON, so it bypasses apiFetch's parse.
+  exportEvalTaskSet: async (name) => {
+    const res = await fetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}/export`, {
+      headers: authHeaders(),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error(body.error || `HTTP ${res.status}`)
+    }
+    return res.text()
+  },
+  // The import body is the JSONL itself, one task per line.
+  importEvalTaskSet: (name, jsonl) =>
+    apiFetch(`/api/v1/eval/task-sets/${encodeURIComponent(name)}/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: jsonl,
+    }),
+
+  createEvalRun: (body) =>
+    apiFetch('/api/v1/eval/runs', { method: 'POST', body: JSON.stringify(body) }),
+  evalRuns: (opts = {}) => {
+    const params = new URLSearchParams()
+    if (opts.taskSet) params.set('task_set', opts.taskSet)
+    if (opts.status) params.set('status', opts.status)
+    const qs = params.toString()
+    return apiFetch(`/api/v1/eval/runs${qs ? `?${qs}` : ''}`)
+  },
+  evalRun: (id) => apiFetch(`/api/v1/eval/runs/${encodeURIComponent(id)}`),
+  stopEvalRun: (id) =>
+    apiFetch(`/api/v1/eval/runs/${encodeURIComponent(id)}/stop`, { method: 'POST' }),
+  evalRunSummary: (id) => apiFetch(`/api/v1/eval/runs/${encodeURIComponent(id)}/summary`),
+  evalRunSamples: (id) => apiFetch(`/api/v1/eval/runs/${encodeURIComponent(id)}/samples`),
+  evalRunPairs: (id) => apiFetch(`/api/v1/eval/runs/${encodeURIComponent(id)}/pairs`),
+  evalEstimate: (body) =>
+    apiFetch('/api/v1/eval/estimate', { method: 'POST', body: JSON.stringify(body) }),
+  evalConfig: () => apiFetch('/api/v1/eval/config'),
+  evalSuggest: (opts = {}) => {
+    const params = new URLSearchParams()
+    if (opts.agent) params.set('agent', opts.agent)
+    if (opts.limit) params.set('limit', String(opts.limit))
+    const qs = params.toString()
+    return apiFetch(`/api/v1/eval/suggest${qs ? `?${qs}` : ''}`)
+  },
 
   // Safety — stop/panic/resume.
   stopSession: (id) => apiFetch(`/api/v1/sessions/${encodeURIComponent(id)}/stop`, { method: 'POST' }),

--- a/web/src/components/Nav.svelte
+++ b/web/src/components/Nav.svelte
@@ -69,6 +69,7 @@
         { id: 'server',    label: 'Server' },
         { id: 'providers', label: 'Providers' },
         { id: 'costs',     label: 'Costs' },
+        { id: 'evals',     label: 'Evals' },
         { id: 'keys',      label: 'API Keys' },
         { id: 'settings',  label: 'Settings' },
       ],

--- a/web/src/components/__tests__/Nav.test.js
+++ b/web/src/components/__tests__/Nav.test.js
@@ -13,8 +13,8 @@ describe('Nav', () => {
   test('renders all navigation links', () => {
     const { container } = render(Nav, { props: { active: 'overview' } })
     const links = container.querySelectorAll('.nav-item')
-    // 2 top links (overview, chat) + 6 agents section + 4 platform section + 5 admin section = 17
-    expect(links).toHaveLength(17)
+    // 2 top links (overview, chat) + 6 agents section + 4 platform section + 6 admin section = 18
+    expect(links).toHaveLength(18)
   })
 
   test('has a theme toggle button', () => {

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -6,6 +6,7 @@
   import { evalProgress } from '../wsStore.js'
   import { relativeTime } from '../relativeTime.js'
   import ErrorBanner from '../components/ErrorBanner.svelte'
+  import FilterChips from '../components/FilterChips.svelte'
   import ModelSelector from '../components/ModelSelector.svelte'
 
   // Quick check draws this many test cases; Full eval runs the whole set.
@@ -29,6 +30,10 @@
   let baseAgent = $state('')
   let candidate = $state('')
   let candidateProvider = $state('')
+  // The model id the provider was captured for. The candidate field is also
+  // free text, so a hand-edit after picking from the list must not keep the
+  // old provider — that would measure a model/provider pair nobody chose.
+  let providerFor = $state('')
   let taskSetName = $state('')
   let preset = $state('quick')
   let costCap = $state('')
@@ -49,6 +54,10 @@
   let expandedRun = $state(null)
   let confirmStop = $state(null)
   let stopping = $state(false)
+  let stopError = $state('')
+  // Runs whose status reads have failed repeatedly, so the card can say the
+  // progress it shows is stale instead of silently freezing.
+  let staleRuns = $state(new Set())
 
   let currentAgent = $derived(agents.find(a => a.name === baseAgent) || null)
   let selectedSet = $derived(taskSets.find(t => t.name === taskSetName) || null)
@@ -56,6 +65,29 @@
   let sampleTasks = $derived(preset === 'quick' ? QUICK_TASKS : 0)
   let isEmpty = $derived(!loading && taskSets.length === 0 && runs.length === 0)
   let canStart = $derived(!!baseAgent && !!candidate.trim() && !!taskSetName && !starting)
+
+  /** Names the input still missing, so a disabled Start says why. */
+  let startBlocker = $derived.by(() => {
+    if (!baseAgent) return 'No agent to compare on.'
+    if (!taskSetName) return 'Import a test set first.'
+    if (!candidate.trim()) return 'Pick a candidate model to compare.'
+    return ''
+  })
+
+  // Operator-facing names for the run statuses. "capped" especially: the API
+  // word does not say what happened to the money.
+  const STATUS_LABEL = {
+    pending: 'queued',
+    running: 'running',
+    done: 'finished',
+    capped: 'stopped at cost cap',
+    stopped: 'stopped',
+    failed: 'failed',
+  }
+
+  function statusLabel(status) {
+    return STATUS_LABEL[status] || status
+  }
 
   function setName(id) {
     return taskSets.find(t => t.id === id)?.name || `#${id}`
@@ -139,15 +171,21 @@
       cfg = null
     }
     if (!costCap) costCap = String(cfg?.max_cost_per_run ?? FALLBACK_CAP)
-    for (const r of runs.filter(isActive)) refreshRun(r.id)
+    // Hydrate every run, not just the live ones: the list endpoint carries the
+    // bare run row, while the variants a run compared and its turn counts live
+    // on the detail. Without this a finished run renders nameless.
+    await Promise.all(runs.map(r => refreshRun(r.id)))
   })
 
   // --- Estimating -----------------------------------------------------------
 
   let estimateTimer = null
+  // Set once the endpoint answers 404, so a server without it is asked once
+  // rather than on every keystroke for the life of the page.
+  let estimateUnavailable = $state(false)
 
   async function fetchEstimate() {
-    if (!baseAgent || !taskSetName || !candidate.trim()) {
+    if (estimateUnavailable || !baseAgent || !taskSetName || !candidate.trim()) {
       estimate = null
       return
     }
@@ -160,9 +198,10 @@
         k,
         ...(sampleTasks ? { sample_tasks: sampleTasks } : {}),
       })
-    } catch {
+    } catch (e) {
       // No estimate is a supported state — the cap stands on its own.
       estimate = null
+      if (/404/.test(e.message)) estimateUnavailable = true
     } finally {
       estimating = false
     }
@@ -184,8 +223,10 @@
    * blinded pairing both baseline against the first variant by creation order.
    */
   function buildVariants() {
-    const cand = { name: candidate.trim(), llm_model: candidate.trim() }
-    if (candidateProvider) cand.llm_provider = candidateProvider
+    const model = candidate.trim()
+    const cand = { name: model, llm_model: model }
+    // Only send the provider the operator actually picked this model from.
+    if (candidateProvider && providerFor === model) cand.llm_provider = candidateProvider
     return [{ name: 'current' }, cand]
   }
 
@@ -220,6 +261,8 @@
     importOk = ''
   }
 
+  let fileEl = $state(null)
+
   function pickFile(e) {
     importFile = e.target.files?.[0] || null
     // A file named work-set.jsonl is almost always the set's name.
@@ -239,16 +282,18 @@
     importOk = ''
     try {
       const text = await importFile.text()
-      try {
+      // Importing into an existing set is the normal second import. Ask the
+      // list we already hold rather than matching the server's error prose.
+      if (!taskSets.some(t => t.name === name)) {
         await api.createEvalTaskSet({ name })
-      } catch (e) {
-        // Importing into an existing set is the normal second import.
-        if (!/exists|taken|already/i.test(e.message)) throw e
       }
       const res = await api.importEvalTaskSet(name, text)
       const n = res?.imported ?? 0
       importOk = `Imported ${n} test case${n === 1 ? '' : 's'} into "${name}"`
+      // Clear the control too, not just the state — a picker still showing a
+      // filename beside a disabled Import button reads as a broken button.
       importFile = null
+      if (fileEl) fileEl.value = ''
       await loadTaskSets()
       taskSetName = name
     } catch (e) {
@@ -260,12 +305,26 @@
 
   // --- Run status -----------------------------------------------------------
 
+  // Consecutive failed status reads per run. One blip is nothing; a card that
+  // silently freezes while polling every few seconds is a lie.
+  const STALE_AFTER = 3
+  let readFailures = new Map()
+
   async function refreshRun(id) {
     try {
       const detail = await api.evalRun(id)
       runs = runs.map(r => (r.id === detail.id ? { ...r, ...detail } : r))
+      readFailures.delete(id)
+      if (staleRuns.has(id)) {
+        staleRuns = new Set([...staleRuns].filter(x => x !== id))
+      }
     } catch {
-      // A transient read failure leaves the last known progress on screen.
+      const n = (readFailures.get(id) || 0) + 1
+      readFailures.set(id, n)
+      // The last known progress stays on screen, but stops claiming to be live.
+      if (n >= STALE_AFTER && !staleRuns.has(id)) {
+        staleRuns = new Set(staleRuns).add(id)
+      }
     }
   }
 
@@ -305,21 +364,33 @@
 
   async function doStop() {
     stopping = true
+    stopError = ''
     try {
       const id = confirmStop
       await api.stopEvalRun(id)
       confirmStop = null
       await refreshRun(id)
     } catch (e) {
-      error = e.message
-      confirmStop = null
+      // Reported inside the dialog and the dialog stays open: the run card may
+      // be screens away, so closing on failure would look like it worked.
+      stopError = e.message
     } finally {
       stopping = false
     }
   }
 
+  function askStop(id) {
+    stopError = ''
+    confirmStop = id
+  }
+
   function toggleResults(id) {
     expandedRun = expandedRun === id ? null : id
+  }
+
+  /** Focuses the confirm dialog so its Escape handler and SR focus work. */
+  function focusOnMount(node) {
+    node.focus()
   }
 </script>
 
@@ -364,7 +435,8 @@
         </label>
         <label>
           JSONL file
-          <input type="file" accept=".jsonl,.json,text/plain" onchange={pickFile} disabled={importing} />
+          <input type="file" accept=".jsonl,.json,text/plain" onchange={pickFile}
+            disabled={importing} bind:this={fileEl} />
           <span class="hint">One test case per line.</span>
         </label>
       </div>
@@ -401,7 +473,7 @@
       <label class="field">
         <span class="field-label">Candidate</span>
         <ModelSelector bind:value={candidate}
-          onchange={(id, provider) => { candidate = id; candidateProvider = provider || '' }} />
+          onchange={(id, provider) => { candidate = id; candidateProvider = provider || ''; providerFor = id }} />
         <span class="hint">The model to test against the one running now.</span>
       </label>
 
@@ -418,26 +490,29 @@
     <div class="launch-row">
       <div class="field">
         <span class="field-label">Depth</span>
-        <div class="filter-chips filter-chips-sm" role="radiogroup" aria-label="Run depth">
-          <button class="chip" class:active={preset === 'quick'} role="radio"
-            aria-checked={preset === 'quick'} onclick={() => preset = 'quick'}
-            data-testid="preset-quick">Quick check</button>
-          <button class="chip" class:active={preset === 'full'} role="radio"
-            aria-checked={preset === 'full'} onclick={() => preset = 'full'}
-            data-testid="preset-full">Full eval</button>
-        </div>
+        <FilterChips
+          items={[
+            { value: 'quick', label: 'Quick check', testid: 'preset-quick' },
+            { value: 'full', label: 'Full eval', testid: 'preset-full' },
+          ]}
+          value={preset}
+          label="Run depth"
+          size="sm"
+          onselect={(v) => preset = v} />
         <span class="hint" data-testid="preset-hint">
           {#if preset === 'quick'}
             {QUICK_TASKS} cases, 1 run each — a cheap first signal.
-          {:else}
+          {:else if cfg}
             All {selectedSet?.task_count ?? 0} cases, {k} runs each.
+          {:else}
+            All {selectedSet?.task_count ?? 0} cases, at the configured number of runs each.
           {/if}
         </span>
       </div>
 
       <label class="field cap-field">
-        <span class="field-label">Cost cap</span>
-        <input type="number" min="0" step="0.5" bind:value={costCap} disabled={starting}
+        <span class="field-label">Cost cap (USD)</span>
+        <input type="number" min="0.01" step="0.5" bind:value={costCap} disabled={starting}
           data-testid="cost-cap" aria-label="Cost cap in USD" />
         <span class="hint" data-testid="estimate">
           {#if estimating}
@@ -457,6 +532,9 @@
         <button class="btn-primary" onclick={start} disabled={!canStart} data-testid="start-run">
           {starting ? 'Starting…' : 'Start'}
         </button>
+        {#if startBlocker && !starting}
+          <span class="hint" data-testid="start-blocker">{startBlocker}</span>
+        {/if}
       </div>
     </div>
   </section>
@@ -472,19 +550,22 @@
       {@const setCases = setTotal(run.task_set_id)}
       <article class="run-card" data-testid="run-{run.id}">
         <header class="run-head">
-          <span class="status-chip {run.status}" data-testid="run-status-{run.id}">{run.status}</span>
-          <span class="run-title">{variantLabel(run) || 'comparison'}</span>
+          <span class="status-chip {run.status}" data-testid="run-status-{run.id}">{statusLabel(run.status)}</span>
+          {#if variantLabel(run)}
+            <span class="run-title">{variantLabel(run)}</span>
+          {/if}
           <span class="run-sub">on {setName(run.task_set_id)}</span>
           <span class="spacer"></span>
           {#if run.created_at}
             <span class="run-when">{relativeTime(run.created_at)}</span>
           {/if}
           {#if isActive(run)}
-            <button class="btn-sm danger" onclick={() => confirmStop = run.id}
+            <button class="btn-sm danger" onclick={() => askStop(run.id)}
               data-testid="stop-{run.id}">Stop</button>
           {:else}
             <button class="btn-sm" onclick={() => toggleResults(run.id)}
               aria-expanded={expandedRun === run.id}
+              aria-controls="results-panel-{run.id}"
               data-testid="results-{run.id}">
               {expandedRun === run.id ? 'Hide results' : 'Results'}
             </button>
@@ -493,13 +574,15 @@
 
         {#if total > 0}
           <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax={total}
-            aria-valuenow={done} aria-label="Run progress">
+            aria-valuenow={done} aria-valuetext="{done} of {total} turns" aria-label="Run progress">
             <div class="progress-fill" style:width={`${Math.min(100, (done / total) * 100)}%`}></div>
           </div>
         {/if}
 
         <div class="run-meta">
-          <span data-testid="progress-{run.id}">{done} / {total || '?'} turns</span>
+          {#if total > 0}
+            <span data-testid="progress-{run.id}">{done} / {total} turns</span>
+          {/if}
           <span>{fmtUSD(run.cost_spent)} of {fmtUSD(run.cost_cap)}</span>
           {#if run.task_count != null && setCases != null && run.task_count < setCases}
             <span data-testid="subset-{run.id}">{run.task_count} of {setCases} test cases</span>
@@ -507,18 +590,18 @@
           {#if isActive(run) && fmtETA(run.eta_seconds)}
             <span>{fmtETA(run.eta_seconds)}</span>
           {/if}
+          {#if staleRuns.has(run.id)}
+            <span class="run-stale" data-testid="stale-{run.id}">Progress unavailable — showing the last reading</span>
+          {/if}
           {#if run.error}
             <span class="run-error">{run.error}</span>
           {/if}
         </div>
 
         {#if expandedRun === run.id}
-          <div class="results-panel" data-testid="results-panel-{run.id}">
+          <div class="results-panel" id="results-panel-{run.id}" data-testid="results-panel-{run.id}">
             <!-- D2: EvalResults mounts here -->
-            <p class="muted">
-              The scorecard and judged pairs land in the next slice. Until then read
-              <code>GET /api/v1/eval/runs/{run.id}/summary</code>.
-            </p>
+            <p class="muted">The scorecard and judged pairs land in the next update.</p>
           </div>
         {/if}
       </article>
@@ -527,16 +610,20 @@
 {/if}
 
 {#if confirmStop != null}
-  <!-- svelte-ignore a11y_click_events_have_key_events a11y_interactive_supports_focus -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div class="overlay" onclick={(e) => { if (e.target === e.currentTarget) confirmStop = null }}
     onkeydown={(e) => { if (e.key === 'Escape') confirmStop = null }}
-    role="dialog" aria-modal="true" tabindex="-1">
+    role="dialog" aria-modal="true" aria-labelledby="stop-run-title"
+    tabindex="-1" use:focusOnMount>
     <div class="confirm-modal" data-testid="stop-confirm">
-      <h2>Stop run</h2>
+      <h2 id="stop-run-title">Stop run</h2>
       <p>
         Stop this run? Work already finished is kept and stays readable, but the remaining
         comparisons never start.
       </p>
+      {#if stopError}
+        <div class="inline-error" role="alert" data-testid="stop-error">{stopError}</div>
+      {/if}
       <div class="modal-actions">
         <button class="btn-danger" onclick={doStop} disabled={stopping}>
           {stopping ? 'Stopping…' : 'Stop run'}
@@ -548,6 +635,14 @@
 {/if}
 
 <style>
+  /* Matches the local declaration every other inline form on the dashboard
+     carries (Schedules, Skills, Providers). */
+  .form-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 16px;
+  }
+
   .section-title {
     font-size: 11px;
     font-weight: 500;
@@ -642,7 +737,15 @@
     gap: 8px;
   }
   .spacer { flex: 1; }
-  .run-title { font-size: 13px; font-weight: 600; font-family: monospace; }
+  /* Model ids are long unbreakable tokens; without this the card scrolls
+     sideways at 320px. */
+  .run-title {
+    font-size: 13px;
+    font-weight: 600;
+    font-family: monospace;
+    overflow-wrap: anywhere;
+    min-width: 0;
+  }
   .run-sub { font-size: 12px; color: var(--text-muted); }
   .run-when { font-size: 11px; color: var(--text-muted); }
 
@@ -681,7 +784,8 @@
     font-size: 12px;
     color: var(--text-muted);
   }
-  .run-error { color: var(--danger); }
+  .run-error { color: var(--danger); overflow-wrap: anywhere; min-width: 0; }
+  .run-stale { color: var(--warn); }
 
   .results-panel {
     margin-top: 12px;
@@ -689,14 +793,6 @@
     border-top: 1px solid var(--border);
     font-size: 12px;
   }
-  code {
-    font-family: monospace;
-    font-size: 11px;
-    background: var(--hover-overlay);
-    padding: 1px 5px;
-    border-radius: 3px;
-  }
-
   @media (max-width: 520px) {
     .launch-row { flex-direction: column; align-items: stretch; }
     .cap-field { width: 100%; }

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -1,0 +1,705 @@
+<script>
+  import { onMount, onDestroy } from 'svelte'
+  import { api } from '../api.js'
+  import { navigate } from '../router.js'
+  import { inert } from '../inert.js'
+  import { evalProgress } from '../wsStore.js'
+  import { relativeTime } from '../relativeTime.js'
+  import ErrorBanner from '../components/ErrorBanner.svelte'
+  import ModelSelector from '../components/ModelSelector.svelte'
+
+  // Quick check draws this many test cases; Full eval runs the whole set.
+  const QUICK_TASKS = 10
+  // Fallbacks for when GET /eval/config is unavailable. They mirror the
+  // shipped [eval] defaults.
+  const FALLBACK_K = 3
+  const FALLBACK_CAP = 2
+  const POLL_MS = 4000
+  const ESTIMATE_DEBOUNCE_MS = 400
+
+  let loading = $state(true)
+  let error = $state('')
+
+  let taskSets = $state([])
+  let runs = $state([])
+  let agents = $state([])
+  let cfg = $state(null)
+
+  // --- Launcher ---
+  let baseAgent = $state('')
+  let candidate = $state('')
+  let candidateProvider = $state('')
+  let taskSetName = $state('')
+  let preset = $state('quick')
+  let costCap = $state('')
+  let estimate = $state(null)
+  let estimating = $state(false)
+  let starting = $state(false)
+  let launchError = $state('')
+
+  // --- Import ---
+  let showImport = $state(false)
+  let importName = $state('')
+  let importFile = $state(null)
+  let importing = $state(false)
+  let importError = $state('')
+  let importOk = $state('')
+
+  // --- Runs ---
+  let expandedRun = $state(null)
+  let confirmStop = $state(null)
+  let stopping = $state(false)
+
+  let currentAgent = $derived(agents.find(a => a.name === baseAgent) || null)
+  let selectedSet = $derived(taskSets.find(t => t.name === taskSetName) || null)
+  let k = $derived(preset === 'quick' ? 1 : (cfg?.default_k || FALLBACK_K))
+  let sampleTasks = $derived(preset === 'quick' ? QUICK_TASKS : 0)
+  let isEmpty = $derived(!loading && taskSets.length === 0 && runs.length === 0)
+  let canStart = $derived(!!baseAgent && !!candidate.trim() && !!taskSetName && !starting)
+
+  function setName(id) {
+    return taskSets.find(t => t.id === id)?.name || `#${id}`
+  }
+
+  /** Total cases in the run's set, when that set is still around to ask. */
+  function setTotal(id) {
+    return taskSets.find(t => t.id === id)?.task_count ?? null
+  }
+
+  /** A run is live while the server says so, or while its status is non-terminal. */
+  function isActive(run) {
+    if (typeof run.active === 'boolean') return run.active
+    return run.status === 'pending' || run.status === 'running'
+  }
+
+  function fmtUSD(v) {
+    if (v == null) return '—'
+    if (v > 0 && v < 0.01) return '$' + v.toFixed(4)
+    return '$' + v.toFixed(2)
+  }
+
+  function fmtETA(secs) {
+    if (!secs || secs <= 0) return ''
+    if (secs < 60) return `${secs}s left`
+    const m = Math.round(secs / 60)
+    if (m < 60) return `${m}m left`
+    return `${Math.round(m / 6) / 10}h left`
+  }
+
+  function variantLabel(run) {
+    const names = (run.variants || []).map(v => v.name)
+    if (names.length === 0) return ''
+    return names.join(' vs ')
+  }
+
+  const BASIS_LABEL = {
+    history: 'from history',
+    list_price: 'list price',
+  }
+
+  /**
+   * The estimate line, or '' when there is nothing honest to say. An unknown
+   * basis shows the cap alone rather than a number nobody can stand behind.
+   */
+  let estimateLabel = $derived.by(() => {
+    if (!estimate) return ''
+    const basis = BASIS_LABEL[estimate.basis]
+    if (!basis) return ''
+    if (estimate.low == null || estimate.high == null) return ''
+    return `~${fmtUSD(estimate.low)}–${fmtUSD(estimate.high)}, ${basis}`
+  })
+
+  async function loadTaskSets() {
+    taskSets = (await api.evalTaskSets()) || []
+    if (!taskSetName && taskSets.length) taskSetName = taskSets[0].name
+  }
+
+  onMount(async () => {
+    try {
+      const [sets, runList, agentList] = await Promise.all([
+        api.evalTaskSets(),
+        api.evalRuns(),
+        api.agents().catch(() => []),
+      ])
+      taskSets = sets || []
+      runs = runList || []
+      agents = agentList || []
+      if (taskSets.length) taskSetName = taskSets[0].name
+      if (agents.length) baseAgent = agents[0].name
+    } catch (e) {
+      error = e.message
+    } finally {
+      loading = false
+    }
+    // The config endpoint only supplies defaults, so a failure downgrades to
+    // the shipped ones rather than failing the page.
+    try {
+      cfg = await api.evalConfig()
+    } catch {
+      cfg = null
+    }
+    if (!costCap) costCap = String(cfg?.max_cost_per_run ?? FALLBACK_CAP)
+    for (const r of runs.filter(isActive)) refreshRun(r.id)
+  })
+
+  // --- Estimating -----------------------------------------------------------
+
+  let estimateTimer = null
+
+  async function fetchEstimate() {
+    if (!baseAgent || !taskSetName || !candidate.trim()) {
+      estimate = null
+      return
+    }
+    estimating = true
+    try {
+      estimate = await api.evalEstimate({
+        task_set: taskSetName,
+        base_agent: baseAgent,
+        variants: buildVariants(),
+        k,
+        ...(sampleTasks ? { sample_tasks: sampleTasks } : {}),
+      })
+    } catch {
+      // No estimate is a supported state — the cap stands on its own.
+      estimate = null
+    } finally {
+      estimating = false
+    }
+  }
+
+  // Every launcher input that changes the price re-asks, debounced so typing a
+  // model id does not fire a request per keystroke.
+  $effect(() => {
+    void baseAgent; void taskSetName; void candidate; void preset; void k; void sampleTasks
+    clearTimeout(estimateTimer)
+    estimateTimer = setTimeout(fetchEstimate, ESTIMATE_DEBOUNCE_MS)
+    return () => clearTimeout(estimateTimer)
+  })
+
+  // --- Launching ------------------------------------------------------------
+
+  /**
+   * The incumbent is the empty overlay and MUST come first: per-task deltas and
+   * blinded pairing both baseline against the first variant by creation order.
+   */
+  function buildVariants() {
+    const cand = { name: candidate.trim(), llm_model: candidate.trim() }
+    if (candidateProvider) cand.llm_provider = candidateProvider
+    return [{ name: 'current' }, cand]
+  }
+
+  async function start() {
+    launchError = ''
+    starting = true
+    try {
+      const body = {
+        task_set: taskSetName,
+        base_agent: baseAgent,
+        variants: buildVariants(),
+        k,
+      }
+      if (sampleTasks) body.sample_tasks = sampleTasks
+      const cap = parseFloat(costCap)
+      if (!Number.isNaN(cap) && cap > 0) body.cost_cap = cap
+      const run = await api.createEvalRun(body)
+      runs = [run, ...runs]
+      refreshRun(run.id)
+    } catch (e) {
+      launchError = e.message
+    } finally {
+      starting = false
+    }
+  }
+
+  // --- Import ---------------------------------------------------------------
+
+  function toggleImport() {
+    showImport = !showImport
+    importError = ''
+    importOk = ''
+  }
+
+  function pickFile(e) {
+    importFile = e.target.files?.[0] || null
+    // A file named work-set.jsonl is almost always the set's name.
+    if (importFile && !importName.trim()) {
+      importName = importFile.name.replace(/\.jsonl?$/i, '')
+    }
+  }
+
+  async function doImport() {
+    const name = importName.trim()
+    if (!name || !importFile) {
+      importError = 'Pick a file and name the test set'
+      return
+    }
+    importing = true
+    importError = ''
+    importOk = ''
+    try {
+      const text = await importFile.text()
+      try {
+        await api.createEvalTaskSet({ name })
+      } catch (e) {
+        // Importing into an existing set is the normal second import.
+        if (!/exists|taken|already/i.test(e.message)) throw e
+      }
+      const res = await api.importEvalTaskSet(name, text)
+      const n = res?.imported ?? 0
+      importOk = `Imported ${n} test case${n === 1 ? '' : 's'} into "${name}"`
+      importFile = null
+      await loadTaskSets()
+      taskSetName = name
+    } catch (e) {
+      importError = e.message
+    } finally {
+      importing = false
+    }
+  }
+
+  // --- Run status -----------------------------------------------------------
+
+  async function refreshRun(id) {
+    try {
+      const detail = await api.evalRun(id)
+      runs = runs.map(r => (r.id === detail.id ? { ...r, ...detail } : r))
+    } catch {
+      // A transient read failure leaves the last known progress on screen.
+    }
+  }
+
+  function refreshActive() {
+    for (const r of runs.filter(isActive)) refreshRun(r.id)
+  }
+
+  let pollTimer = null
+
+  // Poll only while something is live, so an idle page makes no requests.
+  $effect(() => {
+    const active = runs.some(isActive)
+    if (active && !pollTimer) {
+      pollTimer = setInterval(refreshActive, POLL_MS)
+    } else if (!active && pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+  })
+
+  // A progress frame is a wake-up, not truth: it triggers an immediate re-read
+  // of the authoritative GET /eval/runs/{id}.
+  let seenProgress = new Map()
+  $effect(() => {
+    for (const [id, frame] of $evalProgress) {
+      const sig = `${frame.status}:${frame.samples_done}:${frame.cost_spent}`
+      if (seenProgress.get(id) === sig) continue
+      seenProgress.set(id, sig)
+      refreshRun(id)
+    }
+  })
+
+  onDestroy(() => {
+    clearInterval(pollTimer)
+    clearTimeout(estimateTimer)
+  })
+
+  async function doStop() {
+    stopping = true
+    try {
+      const id = confirmStop
+      await api.stopEvalRun(id)
+      confirmStop = null
+      await refreshRun(id)
+    } catch (e) {
+      error = e.message
+      confirmStop = null
+    } finally {
+      stopping = false
+    }
+  }
+
+  function toggleResults(id) {
+    expandedRun = expandedRun === id ? null : id
+  }
+</script>
+
+<div class="page-header">
+  <h1 class="page-title">Evals</h1>
+  {#if !isEmpty}
+    <button class="btn-ghost btn-sm" onclick={toggleImport}
+      aria-expanded={showImport} aria-controls="eval-import-panel"
+      data-testid="import-toggle">Import JSONL</button>
+  {/if}
+</div>
+
+<ErrorBanner message={error} />
+
+{#if loading}
+  <p class="muted">Loading…</p>
+{:else if isEmpty}
+  <div class="empty-state" data-testid="evals-empty">
+    <p class="empty-lead">
+      Save real conversations as test cases, then compare your current model against a
+      candidate on them.
+    </p>
+    <div class="empty-actions">
+      <button class="btn-primary" onclick={() => navigate('chat')} data-testid="empty-chat-cta">Go to Chat</button>
+      <button class="btn-ghost" onclick={toggleImport} data-testid="empty-import-cta"
+        aria-expanded={showImport} aria-controls="eval-import-panel">Import JSONL</button>
+    </div>
+  </div>
+{/if}
+
+<div class="inline-panel" id="eval-import-panel" class:open={showImport} use:inert={!showImport}>
+  <div class="inline-panel-inner">
+    <div class="inline-form" data-testid="import-form">
+      <h2 class="form-title">Import test cases</h2>
+      {#if importError}<div class="inline-error" role="alert">{importError}</div>{/if}
+      {#if importOk}<div class="save-ok" role="status">{importOk}</div>{/if}
+      <div class="row">
+        <label>
+          Test set name
+          <input type="text" bind:value={importName} disabled={importing} placeholder="e.g. golden-set" />
+          <span class="hint">Created if it does not exist yet.</span>
+        </label>
+        <label>
+          JSONL file
+          <input type="file" accept=".jsonl,.json,text/plain" onchange={pickFile} disabled={importing} />
+          <span class="hint">One test case per line.</span>
+        </label>
+      </div>
+      <div class="form-actions">
+        <button class="btn-primary" onclick={doImport} disabled={importing || !importName.trim() || !importFile}>
+          {importing ? 'Importing…' : 'Import'}
+        </button>
+        <button class="btn-ghost" onclick={toggleImport} disabled={importing}>Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+{#if !loading && !isEmpty}
+  <section class="launcher" data-testid="launcher">
+    <h2 class="section-title">Compare current vs candidate</h2>
+    {#if launchError}<div class="inline-error" role="alert">{launchError}</div>{/if}
+
+    <div class="launch-grid">
+      <label class="field">
+        <span class="field-label">Agent</span>
+        <select bind:value={baseAgent} disabled={starting} data-testid="agent-select">
+          {#each agents as a}
+            <option value={a.name}>{a.name}</option>
+          {/each}
+        </select>
+        {#if currentAgent}
+          <span class="hint">
+            Current: {currentAgent.model || 'default model'}{currentAgent.provider ? ` · ${currentAgent.provider}` : ''}
+          </span>
+        {/if}
+      </label>
+
+      <label class="field">
+        <span class="field-label">Candidate</span>
+        <ModelSelector bind:value={candidate}
+          onchange={(id, provider) => { candidate = id; candidateProvider = provider || '' }} />
+        <span class="hint">The model to test against the one running now.</span>
+      </label>
+
+      <label class="field">
+        <span class="field-label">Test set</span>
+        <select bind:value={taskSetName} disabled={starting} data-testid="task-set-select">
+          {#each taskSets as t}
+            <option value={t.name}>{t.name} ({t.task_count} case{t.task_count === 1 ? '' : 's'})</option>
+          {/each}
+        </select>
+      </label>
+    </div>
+
+    <div class="launch-row">
+      <div class="field">
+        <span class="field-label">Depth</span>
+        <div class="filter-chips filter-chips-sm" role="radiogroup" aria-label="Run depth">
+          <button class="chip" class:active={preset === 'quick'} role="radio"
+            aria-checked={preset === 'quick'} onclick={() => preset = 'quick'}
+            data-testid="preset-quick">Quick check</button>
+          <button class="chip" class:active={preset === 'full'} role="radio"
+            aria-checked={preset === 'full'} onclick={() => preset = 'full'}
+            data-testid="preset-full">Full eval</button>
+        </div>
+        <span class="hint" data-testid="preset-hint">
+          {#if preset === 'quick'}
+            {QUICK_TASKS} cases, 1 run each — a cheap first signal.
+          {:else}
+            All {selectedSet?.task_count ?? 0} cases, {k} runs each.
+          {/if}
+        </span>
+      </div>
+
+      <label class="field cap-field">
+        <span class="field-label">Cost cap</span>
+        <input type="number" min="0" step="0.5" bind:value={costCap} disabled={starting}
+          data-testid="cost-cap" aria-label="Cost cap in USD" />
+        <span class="hint" data-testid="estimate">
+          {#if estimating}
+            Estimating…
+          {:else if estimateLabel}
+            Estimated {estimateLabel}
+          {:else}
+            The run stops cleanly at the cap and keeps what it produced.
+          {/if}
+        </span>
+        {#if !estimating && estimate?.note}
+          <span class="hint" data-testid="estimate-note">{estimate.note}</span>
+        {/if}
+      </label>
+
+      <div class="field start-field">
+        <button class="btn-primary" onclick={start} disabled={!canStart} data-testid="start-run">
+          {starting ? 'Starting…' : 'Start'}
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <section class="runs">
+    <h2 class="section-title">Runs</h2>
+    {#if runs.length === 0}
+      <p class="muted" data-testid="no-runs">No runs yet. Pick a candidate above to compare it against your current model.</p>
+    {/if}
+    {#each runs as run (run.id)}
+      {@const total = run.samples_total ?? 0}
+      {@const done = run.samples_done ?? 0}
+      {@const setCases = setTotal(run.task_set_id)}
+      <article class="run-card" data-testid="run-{run.id}">
+        <header class="run-head">
+          <span class="status-chip {run.status}" data-testid="run-status-{run.id}">{run.status}</span>
+          <span class="run-title">{variantLabel(run) || 'comparison'}</span>
+          <span class="run-sub">on {setName(run.task_set_id)}</span>
+          <span class="spacer"></span>
+          {#if run.created_at}
+            <span class="run-when">{relativeTime(run.created_at)}</span>
+          {/if}
+          {#if isActive(run)}
+            <button class="btn-sm danger" onclick={() => confirmStop = run.id}
+              data-testid="stop-{run.id}">Stop</button>
+          {:else}
+            <button class="btn-sm" onclick={() => toggleResults(run.id)}
+              aria-expanded={expandedRun === run.id}
+              data-testid="results-{run.id}">
+              {expandedRun === run.id ? 'Hide results' : 'Results'}
+            </button>
+          {/if}
+        </header>
+
+        {#if total > 0}
+          <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax={total}
+            aria-valuenow={done} aria-label="Run progress">
+            <div class="progress-fill" style:width={`${Math.min(100, (done / total) * 100)}%`}></div>
+          </div>
+        {/if}
+
+        <div class="run-meta">
+          <span data-testid="progress-{run.id}">{done} / {total || '?'} turns</span>
+          <span>{fmtUSD(run.cost_spent)} of {fmtUSD(run.cost_cap)}</span>
+          {#if run.task_count != null && setCases != null && run.task_count < setCases}
+            <span data-testid="subset-{run.id}">{run.task_count} of {setCases} test cases</span>
+          {/if}
+          {#if isActive(run) && fmtETA(run.eta_seconds)}
+            <span>{fmtETA(run.eta_seconds)}</span>
+          {/if}
+          {#if run.error}
+            <span class="run-error">{run.error}</span>
+          {/if}
+        </div>
+
+        {#if expandedRun === run.id}
+          <div class="results-panel" data-testid="results-panel-{run.id}">
+            <!-- D2: EvalResults mounts here -->
+            <p class="muted">
+              The scorecard and judged pairs land in the next slice. Until then read
+              <code>GET /api/v1/eval/runs/{run.id}/summary</code>.
+            </p>
+          </div>
+        {/if}
+      </article>
+    {/each}
+  </section>
+{/if}
+
+{#if confirmStop != null}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_interactive_supports_focus -->
+  <div class="overlay" onclick={(e) => { if (e.target === e.currentTarget) confirmStop = null }}
+    onkeydown={(e) => { if (e.key === 'Escape') confirmStop = null }}
+    role="dialog" aria-modal="true" tabindex="-1">
+    <div class="confirm-modal" data-testid="stop-confirm">
+      <h2>Stop run</h2>
+      <p>
+        Stop this run? Work already finished is kept and stays readable, but the remaining
+        comparisons never start.
+      </p>
+      <div class="modal-actions">
+        <button class="btn-danger" onclick={doStop} disabled={stopping}>
+          {stopping ? 'Stopping…' : 'Stop run'}
+        </button>
+        <button class="btn-ghost" onclick={() => confirmStop = null} disabled={stopping}>Cancel</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .section-title {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    margin: 0 0 12px;
+  }
+
+  /* Empty state */
+  .empty-state {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    max-width: 620px;
+  }
+  .empty-lead {
+    font-size: 14px;
+    color: var(--text);
+    margin-bottom: 16px;
+    line-height: 1.6;
+  }
+  .empty-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  /* Launcher */
+  .launcher {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px;
+    margin-bottom: 24px;
+  }
+  .launch-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .launch-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 16px;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+  .cap-field { width: 160px; }
+  .start-field { justify-content: flex-end; padding-top: 20px; }
+  .field-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+  .field select,
+  .field input[type="number"] {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    padding: 6px 10px;
+    font-size: 13px;
+    width: 100%;
+  }
+  .field select:focus,
+  .field input:focus { outline: none; border-color: var(--accent); }
+
+  .inline-error { color: var(--danger); font-size: 12px; margin-bottom: 10px; }
+
+  /* Runs */
+  .run-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 14px;
+    margin-bottom: 10px;
+  }
+  .run-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+  .spacer { flex: 1; }
+  .run-title { font-size: 13px; font-weight: 600; font-family: monospace; }
+  .run-sub { font-size: 12px; color: var(--text-muted); }
+  .run-when { font-size: 11px; color: var(--text-muted); }
+
+  .status-chip {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    text-transform: lowercase;
+  }
+  .status-chip.running,
+  .status-chip.pending { border-color: var(--accent); color: var(--accent); }
+  .status-chip.done { border-color: var(--success); color: var(--success); }
+  .status-chip.failed { border-color: var(--danger); color: var(--danger); }
+  .status-chip.capped,
+  .status-chip.stopped { border-color: var(--warn); color: var(--warn); }
+
+  .progress {
+    height: 6px;
+    background: var(--border);
+    border-radius: 999px;
+    overflow: hidden;
+    margin: 10px 0 6px;
+  }
+  .progress-fill {
+    height: 100%;
+    background: var(--accent);
+    transition: width 0.3s ease;
+  }
+
+  .run-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .run-error { color: var(--danger); }
+
+  .results-panel {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+  }
+  code {
+    font-family: monospace;
+    font-size: 11px;
+    background: var(--hover-overlay);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+
+  @media (max-width: 520px) {
+    .launch-row { flex-direction: column; align-items: stretch; }
+    .cap-field { width: 100%; }
+    .start-field { padding-top: 0; }
+  }
+</style>

--- a/web/src/pages/MoreMenu.svelte
+++ b/web/src/pages/MoreMenu.svelte
@@ -32,6 +32,7 @@
         { id: 'server',    label: 'Server' },
         { id: 'providers', label: 'Providers' },
         { id: 'costs',     label: 'Costs' },
+        { id: 'evals',     label: 'Evals' },
         { id: 'keys',      label: 'API Keys' },
         { id: 'settings',  label: 'Settings' },
       ],

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -6,6 +6,84 @@ import {
   channels, sessionStats, sessionToolCalls, sessionSkillUsages,
 } from './fixtures/index.js'
 
+// --- Eval fixtures ---------------------------------------------------------
+// Inline like the other server-shaped fixtures below (auth sessions, providers,
+// server config) rather than in fixtures/index.js, since only the Evals page
+// reads them.
+
+export const evalTaskSets = [
+  { id: 1, name: 'golden-set', description: 'Curated from live history', task_count: 37, created_at: '2026-08-01T09:00:00Z' },
+  { id: 2, name: 'tool-heavy', description: '', task_count: 8, created_at: '2026-08-05T09:00:00Z' },
+]
+
+export const evalConfig = {
+  default_k: 3,
+  max_cost_per_run: 2,
+  max_concurrent: 2,
+  completeness_floor: 0.8,
+  win_threshold: 0.55,
+  gate_rejected_rate_pp: 2,
+  gate_rounds_pct: 20,
+  gate_cost_pct: 25,
+  audit: 'full',
+}
+
+export const evalEstimate = {
+  low: 0.12,
+  high: 0.4,
+  currency: 'USD',
+  basis: 'history',
+  tasks: 10,
+  k: 1,
+  per_variant: [
+    { name: 'current', low: 0.06, high: 0.2, basis: 'history' },
+    { name: 'openai/gpt-4o', low: 0.06, high: 0.2, basis: 'history' },
+  ],
+}
+
+export const evalRuns = [
+  {
+    id: 1,
+    task_set_id: 1,
+    base_agent: 'default',
+    status: 'running',
+    k: 1,
+    cost_cap: 2,
+    cost_spent: 0.31,
+    as_of: '2026-08-18T09:00:00Z',
+    created_at: '2026-08-18T09:00:00Z',
+    task_count: 10,
+    variants: [
+      { id: 1, run_id: 1, name: 'current', overlay: '{}' },
+      { id: 2, run_id: 1, name: 'openai/gpt-4o', overlay: '{"llm_model":"openai/gpt-4o"}' },
+    ],
+    samples_done: 8,
+    samples_total: 20,
+    eta_seconds: 90,
+    active: true,
+  },
+  {
+    id: 2,
+    task_set_id: 1,
+    base_agent: 'default',
+    status: 'done',
+    k: 3,
+    cost_cap: 2,
+    cost_spent: 1.04,
+    as_of: '2026-08-17T09:00:00Z',
+    created_at: '2026-08-17T09:00:00Z',
+    finished_at: '2026-08-17T09:40:00Z',
+    task_count: 37,
+    variants: [
+      { id: 3, run_id: 2, name: 'current', overlay: '{}' },
+      { id: 4, run_id: 2, name: 'anthropic/claude-3-opus', overlay: '{"llm_model":"anthropic/claude-3-opus"}' },
+    ],
+    samples_done: 222,
+    samples_total: 222,
+    active: false,
+  },
+]
+
 export const handlers = [
   // Health
   http.get('/api/v1/health', () => HttpResponse.json({ status: 'ok' })),
@@ -263,6 +341,54 @@ export const handlers = [
   // Audit
   http.get('/api/v1/audit', () => HttpResponse.json({ events: auditEvents, total: auditEvents.length })),
   http.get('/api/v1/audit/stats', () => HttpResponse.json(auditStats)),
+
+  // Evals
+  http.get('/api/v1/eval/task-sets', () => HttpResponse.json(evalTaskSets)),
+  http.get('/api/v1/eval/task-sets/:name', ({ params }) => {
+    const set = evalTaskSets.find(s => s.name === params.name)
+    return set ? HttpResponse.json({ ...set, tasks: [] }) : new HttpResponse(null, { status: 404 })
+  }),
+  http.post('/api/v1/eval/task-sets', async ({ request }) => {
+    const body = await request.json()
+    return HttpResponse.json({ id: 99, name: body.name, description: body.description || '', task_count: 0 }, { status: 201 })
+  }),
+  http.patch('/api/v1/eval/task-sets/:name', () => HttpResponse.json({ ok: true })),
+  http.delete('/api/v1/eval/task-sets/:name', () => new HttpResponse(null, { status: 204 })),
+  http.post('/api/v1/eval/task-sets/:name/tasks', () => HttpResponse.json({ id: 1 }, { status: 201 })),
+  http.patch('/api/v1/eval/task-sets/:name/tasks/:id', () => HttpResponse.json({ ok: true })),
+  http.delete('/api/v1/eval/task-sets/:name/tasks/:id', () => new HttpResponse(null, { status: 204 })),
+  http.get('/api/v1/eval/task-sets/:name/export', () => HttpResponse.text('{"prompt":"hi","category":"chat"}\n')),
+  http.post('/api/v1/eval/task-sets/:name/import', () => HttpResponse.json({ imported: 3 })),
+  http.get('/api/v1/eval/config', () => HttpResponse.json(evalConfig)),
+  http.post('/api/v1/eval/estimate', () => HttpResponse.json(evalEstimate)),
+  http.get('/api/v1/eval/runs', () => HttpResponse.json(evalRuns)),
+  http.get('/api/v1/eval/runs/:id', ({ params }) => {
+    const run = evalRuns.find(r => String(r.id) === params.id)
+    return run ? HttpResponse.json(run) : new HttpResponse(null, { status: 404 })
+  }),
+  http.post('/api/v1/eval/runs', async ({ request }) => {
+    const body = await request.json()
+    return HttpResponse.json({
+      id: 3,
+      task_set_id: 1,
+      base_agent: body.base_agent,
+      status: 'pending',
+      k: body.k ?? 3,
+      cost_cap: body.cost_cap ?? 2,
+      cost_spent: 0,
+      created_at: '2026-08-19T09:00:00Z',
+      task_count: body.sample_tasks || 37,
+      variants: (body.variants || []).map((v, i) => ({ id: 10 + i, run_id: 3, name: v.name, overlay: '{}' })),
+      samples_done: 0,
+      samples_total: 0,
+      active: true,
+    }, { status: 201 })
+  }),
+  http.post('/api/v1/eval/runs/:id/stop', () => HttpResponse.json({ status: 'stopping' })),
+  http.get('/api/v1/eval/runs/:id/summary', () => HttpResponse.json({ variants: [], per_task: [], completeness: {}, verdicts: [] })),
+  http.get('/api/v1/eval/runs/:id/samples', () => HttpResponse.json([])),
+  http.get('/api/v1/eval/runs/:id/pairs', () => HttpResponse.json([])),
+  http.get('/api/v1/eval/suggest', () => HttpResponse.json([])),
 
   // Setup
   http.get('/api/v1/setup', () => HttpResponse.json({ needs_setup: false, has_account: true })),


### PR DESCRIPTION
Stage D1 of the eval subsystem: the 18th page, so a model comparison can be launched and watched without curl. Reached from the Admin section of the nav and MoreMenu — evals are not a daily driver.

Svelte + `api.js` + web tests only. No Go, no swagger.

## What's here

- **Empty state** (no test sets and no runs) teaches the loop in one paragraph, with CTAs to Chat and an inline JSONL import that creates the set on the fly. The "Suggest from history" CTA is deliberately **absent** rather than disabled until its endpoint lands.
- **Launcher** — "compare current vs candidate on a test set": agent select showing the live model, candidate via the existing `ModelSelector`, test set select with case counts, a **Quick check** (10 cases, `k=1`) / **Full eval** (whole set, `k` from `[eval] default_k`) toggle, an editable cost cap defaulted from `max_cost_per_run`, and a debounced estimate rendered beside the cap with its basis. An unknown basis shows the cap alone — the page never invents a number.
- **Runs list**: status chip, progress bar, spend against cap, ETA, the drawn subset when fewer than the whole set ran, and Stop behind a confirm. Polling runs only while something is live; an `eval_progress` frame is a wake-up that triggers a re-read of `GET /eval/runs/{id}`, never truth. Background-safe.
- `api.js` gains the remaining thirteen eval wrappers plus `evalEstimate`, `evalConfig`, `evalRunPairs`, `evalSuggest`.

`Start` posts the incumbent first as an empty overlay — per-task deltas and blinded pairing both baseline against the first variant by creation order. N-variant stays API-only.

## Results view

Terminal runs expand to a marked mount point:

```
<!-- D2: EvalResults mounts here -->
```

with a one-line placeholder. The results view is the next slice.

## Depends on endpoints still in flight

The page is built against the agreed D0 contracts and **degrades rather than breaking** where they have not merged yet:

| Endpoint | Absent behaviour |
|---|---|
| `POST /eval/estimate` | No range; the cap stands alone. Asked once, then not re-asked after a 404. |
| `GET /eval/config` | Falls back to the shipped `[eval]` defaults; the Full eval hint stops asserting a specific `k`. |
| `sample_tasks` on `POST /eval/runs` | Sent per the contract. **Until D0.1 lands the server ignores it and Quick check runs the whole set at `k=1`** — worth landing the two together, since the hint promises a sampled subset. |
| `task_count` on a run | The "10 of 37 test cases" line stays hidden. |

`GET /eval/runs` currently returns the bare run row, so every run is hydrated from its detail endpoint on mount; a richer list endpoint would make that a single request.

## Test evidence

`web/src/__tests__/pages/Evals.test.js` — 21 tests over the empty state (CTAs present, suggest absent), the launcher (preset → `sample_tasks`/`k`, incumbent-first variants, estimate basis including the unknown-basis fallback, stale-provider clearing, inline errors), and the runs list (progress, subset line, stop confirm + failure, polling start/stop, `evalProgress` wake-up).

```
just hook   →  fmt-check · vet · lint · lint-ui · test · test-ui · openapi-check  all ✓
just test-ui → 51 files, 911 tests passed
```

`Nav.test.js`'s link count moves 17 → 18 for the new entry.

A `ui-reviewer` pass ran over the page; its findings are the second commit (shared `FilterChips` instead of a hand-rolled radiogroup, dialog focus, inline stop error, status vocabulary, 320px overflow, aria-valuetext/aria-controls, and the run-hydration and stale-provider bugs above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
