### PR TITLE
docs(website): fix broken internal links, document missing API/config surface

### DIFF
--- a/denkeeper.toml.example
+++ b/denkeeper.toml.example
@@ -213,9 +213,12 @@ format = "text"
 # rate_limit = 10.0                # max requests per second per API key (0 = unlimited)
 
 # API keys — each key has a name, secret, and list of scopes.
-# Valid scopes: chat, sessions:read, costs:read, skills:read, skills:write,
+# Valid scopes: admin, chat, health, sessions:read, sessions:write, costs:read,
+#               agents:read, agents:write, skills:read, skills:write,
 #               schedules:read, schedules:write, approvals:read, approvals:write,
-#               health, admin
+#               tools:read, tools:write, browser:read, browser:write, kv:read,
+#               kv:write, audit:read, channels:read, channels:write, eval:read,
+#               eval:write. "admin" implies every other scope.
 
 # Web dashboard key — needs all read scopes + approvals:write to manage approvals.
 # Navigate to http://localhost:8080 and enter this key to log in.

--- a/website/content/docs/concepts/built-in-tools.md
+++ b/website/content/docs/concepts/built-in-tools.md
@@ -2,13 +2,13 @@
 title: "Built-in Tools"
 description: "Web search and fetch, JavaScript execution, the KV store, and browser automation."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 35
 toc: true
 ---
 
-Alongside external [MCP tool servers](/docs/concepts/tools-mcp/), Denkeeper ships tools that run in-process. They need no subprocess, no container, and no separate install — just a config section.
+Alongside external [MCP tool servers](/docs/concepts/tools/), Denkeeper ships tools that run in-process. They need no subprocess, no container, and no separate install — just a config section.
 
 All of them respect the agent's permission tier.
 
@@ -113,6 +113,6 @@ A browser with a persistent profile is the most powerful capability an agent can
 
 ## Memoization
 
-Identical calls to *idempotent* tools are memoized within a single turn — see [Tools (MCP)](/docs/concepts/tools-mcp/). Of the built-ins, `web_search`, `web_fetch`, `kv_get`, and `kv_list` are cache-eligible. `run_javascript` deliberately is not.
+Identical calls to *idempotent* tools are memoized within a single turn — see [Tools (MCP)](/docs/concepts/tools/). Of the built-ins, `web_search`, `web_fetch`, `kv_get`, and `kv_list` are cache-eligible. `run_javascript` deliberately is not.
 
 See the [configuration reference](/docs/reference/config/) for every option in `[web]`, `[script]`, `[kv]`, and `[browser]`.

--- a/website/content/docs/concepts/channels.md
+++ b/website/content/docs/concepts/channels.md
@@ -2,7 +2,7 @@
 title: "Channels"
 description: "Named routing endpoints that decouple conversations from adapter bindings."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 15
 toc: true
@@ -79,7 +79,7 @@ Wildcard bindings are not delivery targets — there is no single chat to send t
 
 Channels are reachable from every surface:
 
-- **REST** — `GET/POST/PATCH/DELETE /api/v1/channels`, plus `POST/DELETE /api/v1/channels/{name}/activate` to set the active override for an adapter key. See the [REST API reference](/docs/reference/rest-api-reference/).
+- **REST** — `GET/POST/PATCH/DELETE /api/v1/channels`, plus `POST/DELETE /api/v1/channels/{name}/activate` to set the active override for an adapter key. See the [REST API reference](/docs/reference/rest-api/).
 - **Config MCP** — agents can call `channel_list`, `channel_info`, and `channel_switch`.
 - **Dashboard** — the Channels page.
 

--- a/website/content/docs/concepts/dry-run.md
+++ b/website/content/docs/concepts/dry-run.md
@@ -3,7 +3,7 @@ title: "Dry Runs & Previews"
 description: "Seeing what a skill or schedule would do before it does it."
 slug: "dry-runs"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-12T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 55
 toc: true
@@ -103,4 +103,4 @@ Set `[eval] audit = "summary"` to record only lifecycle events and errors instea
 
 ## Where to find it
 
-The dashboard exposes previews from the Skills and Schedules pages; the transcript panel shows suppressed calls inline. See the [REST API reference](/docs/reference/rest-api-reference/) for the full request and response shapes.
+The dashboard exposes previews from the Skills and Schedules pages; the transcript panel shows suppressed calls inline. See the [REST API reference](/docs/reference/rest-api/) for the full request and response shapes.

--- a/website/content/docs/concepts/observability.md
+++ b/website/content/docs/concepts/observability.md
@@ -2,7 +2,7 @@
 title: "Observability"
 description: "The audit log, tool-call telemetry, cost tracking, and OpenTelemetry."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 60
 toc: true
@@ -90,7 +90,7 @@ Whichever source won is recorded as the `pricing_source` attribute, so a real pr
 
 Cached prompt tokens are tracked separately, read from the provider's own cache-read counts.
 
-Limits are enforced per session against the agent's `cost_limit_soft` and `cost_limit_hard`; see [Sessions & Permissions](/docs/concepts/sessions-permissions/). Fallback rules can switch to a cheaper model when a limit is approached rather than simply stopping.
+Limits are enforced per session against the agent's `cost_limit_soft` and `cost_limit_hard`; see [Sessions & Permissions](/docs/concepts/sessions/). Fallback rules can switch to a cheaper model when a limit is approached rather than simply stopping.
 
 ## OpenTelemetry
 

--- a/website/content/docs/concepts/sessions.md
+++ b/website/content/docs/concepts/sessions.md
@@ -1,8 +1,9 @@
 ---
 title: "Sessions & Permissions"
 description: "Permission tiers, session management, and approval workflows."
+slug: "sessions"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 40
 toc: true

--- a/website/content/docs/concepts/skills.md
+++ b/website/content/docs/concepts/skills.md
@@ -2,7 +2,7 @@
 title: "Skills"
 description: "Markdown-based instruction files that teach the agent how to behave."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 20
 toc: true
@@ -35,7 +35,7 @@ tools = ["web-search", "calendar"]
 
 Skills are activated by triggers:
 
-- **`command:name`** — activated when the user sends `/name` in Telegram
+- **`command:name`** — activated when the user's message starts with `/name` or `!name` (case-insensitive), on any adapter or channel — Telegram, Discord, the web dashboard, or the REST chat API
 - **`schedule:...`** — marks the skill as scheduler-driven
 - **Ambient** — skills without triggers are always included in the system prompt
 
@@ -52,6 +52,11 @@ skill = "daily-briefing"
 
 A skill with a `schedule:` trigger and no matching `[[schedules]]` entry will never fire on its own.
 {{< /callout >}}
+
+## Other frontmatter fields
+
+- **`requires.tools`** — names the MCP tools the skill depends on (`[requires] tools = [...]` in the example above). A skill naming a tool that isn't currently advertised is dropped from matching for that turn rather than included and left to fail; it reactivates automatically once the tool comes back.
+- **`max_tool_rounds`** — caps how many tool-call rounds this skill's turn may use, on top of the agent's own round limit. It can only lower the effective budget, never raise it, and only applies when this skill is the one driving the turn (a schedule naming it, or the sole matching `command:` trigger) — an ambient skill matching every message does not cap unrelated turns.
 
 ## Directory structure
 

--- a/website/content/docs/concepts/tools.md
+++ b/website/content/docs/concepts/tools.md
@@ -1,8 +1,9 @@
 ---
 title: "Tools (MCP)"
 description: "External tool servers connected via the Model Context Protocol."
+slug: "tools"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 30
 toc: true

--- a/website/content/docs/guides/raspberry-pi.md
+++ b/website/content/docs/guides/raspberry-pi.md
@@ -1,8 +1,9 @@
 ---
 title: "Raspberry Pi Deployment"
 description: "Deploy Denkeeper on a Raspberry Pi 5."
+slug: "raspberry-pi"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-03-28T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 20
 toc: true

--- a/website/content/docs/reference/cli.md
+++ b/website/content/docs/reference/cli.md
@@ -1,8 +1,9 @@
 ---
 title: "CLI Reference"
 description: "Denkeeper command-line interface reference."
+slug: "cli"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 20
 toc: true

--- a/website/content/docs/reference/config.md
+++ b/website/content/docs/reference/config.md
@@ -1,8 +1,9 @@
 ---
 title: "Configuration Reference"
 description: "Complete reference for denkeeper.toml options."
+slug: "config"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 10
 toc: true
@@ -39,6 +40,7 @@ All configuration lives in a single TOML file. Default location: `~/.denkeeper/d
 | `default_model` | string | `"anthropic/claude-sonnet-4-20250514"` | Model identifier (format depends on provider) |
 | `cost_limit_soft` | float | `0` | Soft cost limit per session in USD (warns but continues) |
 | `cost_limit_hard` | float | `1.0` | Hard cost limit per session in USD (stops generation) |
+| `stream_idle_timeout_secs` | int | `120` | Seconds a streaming LLM response may sit idle before the request is aborted |
 
 ## `[[llm.providers]]`
 
@@ -72,6 +74,21 @@ api_key = "lm-studio"
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `api_key` | string | *required* | OpenRouter API key |
+| `provider_order` | []string | none | Explicit preference list of upstream provider slugs (e.g. `"moonshotai"`) that overrides sticky routing when set — usually unnecessary |
+| `provider_allow_fallbacks` | bool | unset (OpenRouter default: allowed) | Whether OpenRouter may fall back to providers outside `provider_order` |
+| `provider_sticky` | bool | `true` | Prefer the last-served upstream provider for `provider_sticky_ttl` after a successful response, so upstream prompt caching keeps hitting. Reset by upstream errors (429/5xx/network), not by client cancellation or 4xx |
+| `provider_sticky_ttl` | duration string | `"1h"` | How long to keep the sticky provider preference |
+
+### `[llm.openrouter.reasoning]`
+
+Controls the `reasoning` parameter sent to OpenRouter.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | inferred `true` if `effort` or `max_tokens` is set | Activate reasoning with model defaults |
+| `effort` | string | none | `"xhigh"`, `"high"`, `"medium"`, `"low"`, `"minimal"`, or `"none"`. Mutually exclusive with `max_tokens` |
+| `max_tokens` | int | `0` | Reasoning token budget. Mutually exclusive with `effort` |
+| `exclude` | bool | `false` | Omit reasoning from the response (tokens are still billed) |
 
 ## `[llm.anthropic]` *(legacy)*
 
@@ -377,6 +394,25 @@ Dry-run turns persist nothing — no messages, telemetry, or memory — and exec
 | `onboarding_dismissed` | bool | `false` | Set by the dashboard when the onboarding checklist is dismissed |
 | `wizard_completed` | bool | `false` | Set by the dashboard when the setup wizard finishes |
 
+## `[[api.keys]]`
+
+Static API keys, in addition to any created at runtime via the Keys CLI, the `keys` REST endpoints, or first-run setup. All keys — static and runtime — are stored and checked the same way.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | *required* | Unique, human-readable key name |
+| `key` | string | *required* | The token clients send as `Authorization: Bearer <key>` |
+| `scopes` | string[] | *required* | Permissions this key grants; `["admin"]` grants everything |
+
+```toml
+[[api.keys]]
+name = "ci"
+key = "dk_..."
+scopes = ["chat", "sessions:read"]
+```
+
+**Valid scopes:** `admin`, `chat`, `health`, `sessions:read`, `sessions:write`, `costs:read`, `agents:read`, `agents:write`, `skills:read`, `skills:write`, `schedules:read`, `schedules:write`, `approvals:read`, `approvals:write`, `tools:read`, `tools:write`, `browser:read`, `browser:write`, `kv:read`, `kv:write`, `audit:read`, `channels:read`, `channels:write`, `eval:read`, `eval:write`. `admin` implies every other scope.
+
 ## `[api.mcp_server]`
 
 Exposes this Denkeeper instance *as* an MCP server, so an external MCP client (another agent, an IDE) can drive its agents, skills, schedules, and audit log. Opt-in.
@@ -501,13 +537,17 @@ per-tool-call timeout, so a call that was going to succeed gets to.
 | `url` | string | *required for sse* | Remote server URL (SSE only, must be http/https) |
 | `headers` | map | — | HTTP headers sent with SSE requests (SSE only) |
 | `request_timeout_secs` | int | `0` | Per-server timeout override (0 = use global `[mcp]` value) |
+| `sse_keep_alive_secs` | int | `0` | Per-server keep-alive override (0 = use global `[mcp]` value, SSE only) |
 | `auth` | string | `""` | Authentication method: `""` (none) or `"oauth"` (OAuth 2.1, SSE only) |
 | `client_id` | string | — | OAuth2 client ID (optional; some servers use dynamic registration) |
 | `client_secret` | string | — | OAuth2 client secret (optional; must be set together with `client_id`) |
 | `scopes` | string[] | — | OAuth2 scopes to request (optional) |
+| `disabled_tools` | string[] | — | Tool names on this server to exclude from the LLM's tool payload |
 | `idempotent` | bool | `false` | Memoize identical calls to this server's tools within one message turn (identical name+args returns the cached result instead of re-executing). Only set on servers whose tools are **all** read-only — a cached write is a silently dropped side effect |
 | `idempotent_tools` | string[] | — | Per-tool memoization opt-in for servers that mix read and write tools; union with `idempotent` |
 | `trust_annotations` | bool | `false` | Also memoize tools this server marks read-only via the MCP `readOnlyHint` annotation. Annotations are self-declared by the server — enable only for servers you trust to describe their tools honestly |
+| `env_passthrough` | string[] | — | Additional parent-process env vars to forward into this stdio server's subprocess, on top of the built-in allowlist and the global `[mcp] env_passthrough`. `DENKEEPER_*` and other secret-matching names are always filtered out |
+| `allow_loopback` | bool | `false` | Bypass SSRF protection against localhost/127.x/::1 for this server's `url` (SSE only) — unsafe, only for a server you control |
 
 **SSE security**: SSRF protection blocks localhost, link-local (169.254.x.x), and cloud metadata endpoints. `${NAME}` placeholders in `url` and `headers` are resolved from environment but secrets matching `DENKEEPER_*_SECRET`, `DENKEEPER_*_PASSWORD*`, and related patterns are denied. URL and header values are redacted in API responses.
 
@@ -532,6 +572,8 @@ When enabled, Prometheus metrics are exposed at `GET /metrics` (no auth required
 | `password_hash` | string | — | bcrypt hash from `denkeeper passwd` CLI |
 | `session_secret` | string | — | Hex-encoded AES-256 key (64 hex chars). Generate with `openssl rand -hex 32` |
 | `session_max_age` | string | `"24h"` | Session cookie lifetime |
+| `preferred_login_method` | string | `"auto"` | Which login method the login page shows first: `"auto"`, `"password"`, or `"apikey"` |
+| `session_record_retention` | string | `"720h"` | How long to keep session records after they expire |
 
 Env override: `DENKEEPER_API_AUTH_SESSION_SECRET` sets `session_secret`.
 

--- a/website/content/docs/reference/rest-api.md
+++ b/website/content/docs/reference/rest-api.md
@@ -1,8 +1,9 @@
 ---
 title: "REST API Reference"
 description: "HTTP API endpoints for external integrations."
+slug: "rest-api"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-14T00:00:00+00:00
+lastmod: 2026-08-21T00:00:00+00:00
 draft: false
 weight: 30
 toc: true
@@ -42,12 +43,14 @@ Send a message to an agent and receive a response.
   "session_id": "optional-session-id",
   "message": "Hello!",
   "user_id": "api-user",
-  "user_name": "API User"
+  "user_name": "API User",
+  "channel": "optional-channel-name"
 }
 ```
 
 - `session_id` is auto-generated if omitted. Pass the same value in subsequent requests to continue the conversation.
 - `agent` defaults to `"default"` if omitted.
+- `channel` is optional; when set, the message routes through the named [channel](/docs/concepts/channels/) instead of a direct agent binding.
 
 **Response (JSON):**
 
@@ -291,7 +294,7 @@ Create an agent. Creates the persona directory and persists an `[[agents]]` bloc
 
 **Scope:** `agents:write`
 
-Update an agent's configuration. Mutable fields: `name` (rename), `session_tier`, `llm_provider`, `llm_model`, `description`, `browser_url_allowlist`, `fallbacks`, `cost_limit_soft`, `cost_limit_hard`, `supervisor`, `supervisor_timeout`, `supervisor_context_messages`.
+Update an agent's configuration. Mutable fields: `name` (rename), `session_tier`, `llm_provider`, `llm_model`, `description`, `max_tool_rounds`, `browser_url_allowlist`, `fallbacks`, `cost_limit_soft`, `cost_limit_hard`, `supervisor`, `supervisor_timeout`, `supervisor_context_messages`, `supervisor_body_excerpt_len`, `supervisor_tool_desc_len`, `reviewer_model`, `reviewer_provider`, `review_max_iterations`, `review_timeout`, `nudge_memory_interval`, `nudge_skill_interval`. Every field is optional and only present ones change; omit a field to leave it as-is.
 
 ### `DELETE /api/v1/agents/{name}`
 
@@ -386,6 +389,18 @@ Aggregate audit statistics. Accepts `?since=` and the same `?exclude_source=` fi
 ## Evals
 
 An eval run compares two or more config variants of one agent over a saved set of test cases and reports an objective scorecard. Samples execute on the agent's live engine under the same execution policy dry runs use: reads run for real, writes are suppressed, and nothing is persisted to conversations, telemetry, or memory. Runs spend real tokens, bounded by a per-run cost cap and by `[eval] max_concurrent`.
+
+### `GET /api/v1/eval/config`
+
+**Scope:** `eval:read`
+
+Returns the `[eval]` defaults and gate thresholds used to size and judge a run — `default_k`, `max_cost_per_run`, `max_concurrent`, `completeness_floor`, `win_threshold`, and the rest of the config used by `POST /eval/runs` and the verdict rule when a request doesn't override them.
+
+### `POST /api/v1/eval/estimate`
+
+**Scope:** `eval:read`
+
+Prices a prospective run before creating it — same request shape as `POST /eval/runs` — so a cost cap can be sized sensibly ahead of spending real tokens.
 
 ### `POST /api/v1/eval/task-sets`
 
@@ -748,7 +763,13 @@ No authentication required. Returns the first-run setup status.
 
 ### `POST /api/v1/setup`
 
-No authentication required. Initialize the first-run configuration.
+No authentication required — the endpoint locks itself after first use. Creates the first API key, defaulting to `name: "admin"` / `scopes: ["admin"]` if the body omits them, and returns the plaintext token (`201`). Returns `409 Conflict` once any active key already exists.
+
+**Request body:**
+
+```json
+{ "name": "admin", "scopes": ["admin"] }
+```
 
 ### `POST /api/v1/setup/account`
 


### PR DESCRIPTION
## Summary

Scheduled documentation-accuracy review of the marketing/docs site (`website/`). Three parallel audits (CLI/REST docs vs. code, config/concepts docs vs. code, live site check) turned up one real bug class and several content gaps. This PR fixes what's fixable in the repo; one issue is infra-only and called out below.

### Broken internal links (the real bug)

`cli.md`, `config.md`, `rest-api.md`, and `raspberry-pi.md` were recently renamed to shorter filenames, but never got an explicit `slug:` front matter field to match. Hugo's `:slug` permalink placeholder falls back to a **title**-derived slug when `slug` is absent (not the filename) — so these pages were actually being served at `/docs/reference/cli-reference/`, `/docs/reference/configuration-reference/`, `/docs/reference/rest-api-reference/`, `/docs/guides/raspberry-pi-deployment/` on production, while the overwhelming majority of internal links across the site (and the filenames themselves) assumed the short form. Same issue hit `concepts/tools.md` (→ `tools-mcp`) and `concepts/sessions.md` (→ `sessions-permissions`).

Fixed by adding explicit `slug:` overrides (matching the existing convention already used on `dry-run.md`, `supervisors.md`, `mcp-server.md`) and fixing the handful of stray links written against the long form. Verified with a local Hugo build — 0 broken `/docs/...` links in the rendered output (previously several).

### Content accuracy fixes

- **`skills.md`**: the Triggers section wrongly said `command:name` only fires "in Telegram" and omitted the `!name` prefix form. Trigger matching (`internal/skill/match.go`) runs on raw message text on every adapter/channel and accepts either `/name` or `!name`. Also documented `requires.tools` and `max_tool_rounds`, two real frontmatter fields the page never mentioned.
- **`rest-api.md`**: added the `channel` field to the `/chat` request example, the undocumented `GET /eval/config` and `POST /eval/estimate` endpoints, the full `PATCH /agents/{name}` mutable-field list (was missing 9 of 20 real fields), and a fuller `POST /setup` description.
- **`config.md`**: documented `[llm.openrouter]` reasoning/provider-routing fields, `[llm] stream_idle_timeout_secs`, `[api.auth] preferred_login_method`/`session_record_retention`, several missing `[tools.*]` fields (`disabled_tools`, `env_passthrough`, `sse_keep_alive_secs`, `allow_loopback`), and added a `[[api.keys]]` reference section enumerating all 25 valid scopes (previously undocumented anywhere on the page).
- **`denkeeper.toml.example`**: its scopes comment listed only 11 of the 25 real scopes — brought in line with `internal/scope/scope.go`.

Every claim above was cross-checked against the current Go source (`internal/api`, `internal/config`, `internal/skill`, `internal/scope`) rather than assumed.

### Not fixed here (needs human/infra action)

**`get.denkeeper.io` does not resolve (DNS failure).** This is the flagship one-line install command on the homepage and in `installation.md`/`raspberry-pi.md` — currently completely broken for anyone following it. Confirmed via repeated independent fetches (`denkeeper.io` and `github.com` resolve fine through the same path, so this isn't a general network issue). This is a DNS/registrar-level problem outside the git repo and can't be fixed via code change.

## Test plan

- [x] Local Hugo build (`npm run build` in `website/`) succeeds
- [x] Scripted check of the rendered `public/docs/` output confirms 0 broken internal `/docs/...` links (previously several, now fixed)
- [x] Every doc claim in this PR cross-checked against current Go source
- [ ] CI (`Deploy Website` workflow) redeploys production with the corrected slugs after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_019NECSRoXtSPEJUBMTreSe2)_