### PR TITLE
ci: detach E2E background servers and capture their logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,11 +227,11 @@ jobs:
           echo "DENKEEPER_DATA_DIR=$dir" >> "$GITHUB_ENV"
       - name: Start mock LLM server
         run: |
-          cd web && node -e "
+          cd web && setsid nohup node -e "
             import('./test/e2e/helpers/mock-llm.js')
               .then(m => m.startMockLLM(19111))
               .then(() => console.log('Mock LLM ready on :19111'))
-          " &
+          " > "$RUNNER_TEMP/mock-llm.log" 2>&1 &
           for i in $(seq 1 10); do
             curl -sf http://127.0.0.1:19111/api/tags > /dev/null && echo "Mock LLM ready" && exit 0
             sleep 0.5
@@ -239,7 +239,11 @@ jobs:
           echo "Mock LLM failed to start" && exit 1
       - name: Start denkeeper
         run: |
-          ./denkeeper-linux-amd64 serve --config web/test/e2e/fixtures/test.toml &
+          # setsid + nohup: in a container job each step is its own docker exec,
+          # so a plain `&` child can die with the step's shell. Logs go to a
+          # file so a crash mid-run is diagnosable.
+          setsid nohup ./denkeeper-linux-amd64 serve --config web/test/e2e/fixtures/test.toml \
+            > "$RUNNER_TEMP/denkeeper.log" 2>&1 &
           for i in $(seq 1 30); do
             curl -sf 'http://localhost:8080/api/v1/health?ready=true' > /dev/null && echo "Server ready" && exit 0
             sleep 1
@@ -259,3 +263,14 @@ jobs:
         with:
           name: playwright-traces
           path: web/test-results/
+      - name: Print server log tail
+        if: failure()
+        run: tail -n 100 "$RUNNER_TEMP/denkeeper.log" || true
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-server-logs
+          path: |
+            ${{ runner.temp }}/denkeeper.log
+            ${{ runner.temp }}/mock-llm.log


### PR DESCRIPTION
E2E has been red on main since c907150 (prebuilt playwright container): 17 tests pass, then the denkeeper process is gone and every later \`page.goto\` gets \`ERR_CONNECTION_REFUSED\`. The server's output after the "Start denkeeper" step ends is not captured, so the actual crash is invisible. \`0ffc3e9\` (one commit earlier, with all the Stage D0/D1 merges) is green, so it is the job shape, not the app.

- \`setsid nohup\` both background processes - in a container job each step is its own \`docker exec\`, so a plain \`&\` child is tied to the step's shell
- redirect their output to \`$RUNNER_TEMP\` and print the tail + upload it on failure

If the detach alone fixes it, the logs are a bonus. If it does not, the next run tells us why the server died.

🤖 Generated with [Claude Code](https://claude.com/claude-code)