### PR TITLE
ci: let the @claude workflow rebase, gated to the repo owner

### DIFF
--- a/.github/scripts/claude-push.sh
+++ b/.github/scripts/claude-push.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Push helper for the @claude workflow.
+#
+# The workflow's allowlist deliberately does NOT contain `git push`. Prefix rules
+# cannot express "force-push this branch but never main": `-f` evades a
+# `--force` rule, `+HEAD:main` force-pushes with no flag at all, and
+# `--force-with-lease` has to stay permitted for the rebase case. Allowlisting
+# this script instead means the push target comes from the checked-out branch
+# rather than from anything the model composed.
+#
+# Backstop, not the only control: branch protection on `main` rejects a force
+# push server-side regardless of what reaches the wire.
+set -euo pipefail
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# Detached HEAD resolves to the literal "HEAD" - refuse rather than guess a target.
+case "$branch" in
+main | master | HEAD | "")
+	echo "claude-push: refusing to push to '${branch}'" >&2
+	exit 1
+	;;
+esac
+
+echo "claude-push: pushing HEAD to origin/${branch}" >&2
+git push --force-with-lease origin "HEAD:refs/heads/${branch}"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,14 +13,20 @@ on:
 jobs:
   claude:
     # This job holds `contents: write` and may push. The repo is public, so anyone
-    # can comment `@claude` - the OWNER gate is what keeps a stranger's comment from
+    # can comment `@claude` - the owner gate is what keeps a stranger's comment from
     # steering a job that can write to the repo. Do not widen it without also
     # narrowing the permissions block below.
+    #
+    # The gate is on `github.actor` (who performed the action) rather than
+    # `author_association` (who wrote the text). They diverge on `issues.assigned`:
+    # a collaborator assigning an owner-authored issue that says `@claude` would
+    # pass an authorship check while not being the owner.
     if: |
-      (github.event_name == 'issue_comment' && github.event.comment.author_association == 'OWNER' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && github.event.comment.author_association == 'OWNER' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && github.event.review.author_association == 'OWNER' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.issue.author_association == 'OWNER' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == github.repository_owner &&
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     permissions:
       contents: write # Push rebased/amended branches
@@ -51,9 +57,15 @@ jobs:
           # Git write operations. Without these the run gets only the read-only
           # default set (status/log/diff) and a rebase stalls on "requires
           # approval" - an Actions run has no one to approve it.
+          #
+          # `gh pr` is enumerated by verb, not `gh pr:*`. The owner gate above
+          # controls who *starts* the run, but not what the run then reads: PR
+          # diffs, commit messages, and CI logs on a public repo are attacker
+          # -authored text, so a run steered by injected instructions must not be
+          # able to reach `gh pr merge/close/edit` or `gh pr review --approve`.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: >-
             --allowedTools
-            Bash(git fetch:*),Bash(git checkout:*),Bash(git rebase:*),Bash(git stash:*),Bash(git push:*),Bash(gh pr:*)
+            Bash(git fetch:*),Bash(git checkout:*),Bash(git rebase:*),Bash(git stash:*),Bash(git push:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr checkout:*),Bash(gh pr comment:*)
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,23 +12,28 @@ on:
 
 jobs:
   claude:
+    # This job holds `contents: write` and may push. The repo is public, so anyone
+    # can comment `@claude` - the OWNER gate is what keeps a stranger's comment from
+    # steering a job that can write to the repo. Do not widen it without also
+    # narrowing the permissions block below.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && github.event.comment.author_association == 'OWNER' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.author_association == 'OWNER' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && github.event.review.author_association == 'OWNER' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.issue.author_association == 'OWNER' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write # Push rebased/amended branches
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          # Full history - a shallow clone has nothing to rebase onto.
+          fetch-depth: 0
 
       - name: Run Claude Code
         id: claude
@@ -43,8 +48,12 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
+          # Git write operations. Without these the run gets only the read-only
+          # default set (status/log/diff) and a rebase stalls on "requires
+          # approval" - an Actions run has no one to approve it.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: >-
+            --allowedTools
+            Bash(git fetch:*),Bash(git checkout:*),Bash(git rebase:*),Bash(git stash:*),Bash(git push:*),Bash(gh pr:*)
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,14 +58,22 @@ jobs:
           # default set (status/log/diff) and a rebase stalls on "requires
           # approval" - an Actions run has no one to approve it.
           #
-          # `gh pr` is enumerated by verb, not `gh pr:*`. The owner gate above
-          # controls who *starts* the run, but not what the run then reads: PR
-          # diffs, commit messages, and CI logs on a public repo are attacker
-          # -authored text, so a run steered by injected instructions must not be
-          # able to reach `gh pr merge/close/edit` or `gh pr review --approve`.
+          # The owner gate above controls who *starts* the run, but not what the
+          # run then reads: PR diffs, commit messages, and CI logs on a public
+          # repo are attacker-authored text. So the allowlist is scoped on the
+          # assumption a run can be steered by injected instructions.
+          #
+          # `gh pr` is enumerated by verb rather than `gh pr:*`, keeping `merge`,
+          # `close`, `edit`, and `review --approve` out of reach.
+          #
+          # `git push` is absent on purpose - see .github/scripts/claude-push.sh.
+          # A prefix rule cannot express "force-push this branch but never main",
+          # so the push target is decided by that script, not by the model.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: >-
             --allowedTools
-            Bash(git fetch:*),Bash(git checkout:*),Bash(git rebase:*),Bash(git stash:*),Bash(git push:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr checkout:*),Bash(gh pr comment:*)
+            Bash(git fetch:*),Bash(git checkout:*),Bash(git rebase:*),Bash(git stash:*),Bash(.github/scripts/claude-push.sh),Bash(./.github/scripts/claude-push.sh),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr checkout:*),Bash(gh pr comment:*)
+            --append-system-prompt
+            "To push, run ./.github/scripts/claude-push.sh - it force-pushes the current branch with --force-with-lease. Plain `git push` is not permitted and will be refused."
 


### PR DESCRIPTION
`@claude` could not run any git write operation on a PR ([example](https://github.com/Temikus/denkeeper/pull/344#issuecomment-3548959747)). Three independent blockers in `claude.yml`, all three needed fixing:

| Blocker | Fix |
|---|---|
| `contents: read` - the token cannot push | `contents: write` |
| `fetch-depth: 1` - shallow clone, nothing to rebase onto | `fetch-depth: 0` |
| no `--allowedTools` - `fetch`/`checkout`/`rebase`/`stash` hit "requires approval", unanswerable in Actions | `claude_args` allowlist |

**The review decision is how write access is contained**, since granting it on a public repo is the whole risk here. Two independent layers, because they fail differently.

### 1. Who can start a run

The gate is on `github.actor` (who performed the action), not `author_association` (who wrote the text). The two diverge on `issues.assigned`: a collaborator assigning an owner-authored issue containing `@claude` passes an authorship check while not being the owner. Gating the actor also collapses four per-event checks into one condition. Effectively owner-only.

### 2. What a running job can reach

The owner gate does **not** cover injected input - it controls who starts a run, not what the run reads. PR diffs, commit messages, and CI logs on a public repo are attacker-authored text, so the allowlist assumes a run can be steered:

- `gh pr` is enumerated by verb, keeping `merge`, `close`, `edit`, and `review --approve` out of reach.
- `git push` is **not** in the allowlist. A prefix rule cannot express "force-push this branch but never main": `-f` evades a `--force` deny rule, `+HEAD:main` force-pushes with no flag at all, and `--force-with-lease` has to stay permitted for the rebase case. Any allowlist spelling of this is a control in appearance only.

  Instead `.github/scripts/claude-push.sh` is allowlisted. It derives the target from the checked-out branch rather than from anything the model composed, refuses `main`/`master`/detached HEAD, and always uses `--force-with-lease`.

Backing both: **branch protection is now enabled on `main`** (force-pushes and deletions blocked), so a force push is rejected server-side regardless of what reaches the wire. Admin enforcement is off, so direct pushes to `main` are unaffected for the repo owner; `github-actions[bot]` is not an admin and does not inherit that bypass.

`claude-code-review.yml` is untouched: it runs on `pull_request` including from forks, and only reads.

<details>
<summary>Allowlisted tools</summary>

```
Bash(git fetch:*), Bash(git checkout:*), Bash(git rebase:*), Bash(git stash:*),
Bash(.github/scripts/claude-push.sh), Bash(./.github/scripts/claude-push.sh),
Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*),
Bash(gh pr checkout:*), Bash(gh pr comment:*)
```
</details>

<details>
<summary>Helper script behaviour, verified locally</summary>

| HEAD | Result |
|---|---|
| `main` | refused, exit 1 |
| detached | refused, exit 1 (resolves to the literal `HEAD`) |
| `feat/x` | proceeds to `git push --force-with-lease origin HEAD:refs/heads/feat/x` |

</details>

### Still unverified

The workflow only fires on an `@claude` comment, so the `claude` check "skipping" on this PR is expected. The real test is commenting `@claude` on a PR once this lands.