### PR TITLE
feat(eval): suggest test cases from history on the Evals page

### DIFF
--- a/web/src/__tests__/pages/Evals.test.js
+++ b/web/src/__tests__/pages/Evals.test.js
@@ -31,7 +31,7 @@ afterEach(() => {
 })
 
 describe('Evals page — empty state', () => {
-  test('teaches the loop and offers Chat and import, but not suggest', async () => {
+  test('teaches the loop and offers all three CTAs', async () => {
     emptyInstance()
     render(Evals)
 
@@ -39,10 +39,21 @@ describe('Evals page — empty state', () => {
     expect(
       screen.getByText(/Save real conversations as test cases, then compare your current model against a candidate on them/)
     ).toBeInTheDocument()
+    expect(screen.getByTestId('empty-suggest-cta')).toBeInTheDocument()
     expect(screen.getByTestId('empty-chat-cta')).toBeInTheDocument()
     expect(screen.getByTestId('empty-import-cta')).toBeInTheDocument()
-    // "Suggest from history" ships in a later slice — absent, not disabled.
-    expect(screen.queryByText(/Suggest/i)).not.toBeInTheDocument()
+  })
+
+  test('the suggest CTA opens the candidate cards', async () => {
+    emptyInstance()
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('evals-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('suggest-panel')).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByTestId('empty-suggest-cta'))
+    await waitFor(() => expect(screen.getByTestId('suggest-cards')).toBeInTheDocument())
+    expect(screen.getByText('/digest yesterday')).toBeInTheDocument()
   })
 
   test('hides the launcher and runs list until something exists', async () => {
@@ -395,5 +406,56 @@ describe('Evals page — runs list', () => {
 
     await waitFor(() => expect(detailReads).toBeGreaterThan(before))
     await waitFor(() => expect(screen.getByTestId('progress-1')).toHaveTextContent('17 / 20'))
+  })
+})
+
+describe('Evals page — suggestions', () => {
+  test('the header toggle mounts the panel above the launcher and closes it again', async () => {
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByTestId('suggest-toggle'))
+    await waitFor(() => expect(screen.getByTestId('suggest-cards')).toBeInTheDocument())
+
+    const panel = screen.getByTestId('suggest-panel')
+    const launcher = screen.getByTestId('launcher')
+    // Node.compareDocumentPosition: 4 = launcher follows the panel.
+    expect(panel.compareDocumentPosition(launcher) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    await fireEvent.click(screen.getByTestId('suggest-close'))
+    await waitFor(() => expect(screen.queryByTestId('suggest-panel')).not.toBeInTheDocument())
+  })
+
+  test('accepting a case re-reads the test sets and points the launcher at it', async () => {
+    let listCalls = 0
+    server.use(
+      http.get('/api/v1/eval/task-sets', () => {
+        listCalls++
+        return HttpResponse.json(
+          listCalls === 1
+            ? [{ id: 1, name: 'golden-set', description: '', task_count: 37 }]
+            : [
+                { id: 1, name: 'golden-set', description: '', task_count: 37 },
+                { id: 9, name: 'fresh-set', description: '', task_count: 1 },
+              ]
+        )
+      }),
+      http.post('/api/v1/eval/task-sets', async ({ request }) => {
+        const body = await request.json()
+        return HttpResponse.json({ id: 9, name: body.name, description: '', task_count: 0 }, { status: 201 })
+      }),
+      http.post('/api/v1/eval/task-sets/:name/tasks', () => HttpResponse.json({ id: 1 }, { status: 201 })),
+    )
+    render(Evals)
+    await waitFor(() => expect(screen.getByTestId('launcher')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByTestId('suggest-toggle'))
+    await waitFor(() => expect(screen.getByTestId('suggest-cards')).toBeInTheDocument())
+
+    await fireEvent.click(screen.getByText('New set…'))
+    await fireEvent.input(screen.getByTestId('suggest-new-set'), { target: { value: 'fresh-set' } })
+    await fireEvent.click(screen.getByTestId('accept-chan:ops:101'))
+
+    await waitFor(() => expect(screen.getByTestId('task-set-select')).toHaveValue('fresh-set'))
   })
 })

--- a/web/src/components/SuggestCases.svelte
+++ b/web/src/components/SuggestCases.svelte
@@ -1,0 +1,619 @@
+<script>
+  import { tick } from 'svelte'
+  import { api } from '../api.js'
+
+  // Offers past turns worth keeping as test cases, mined by GET /eval/suggest.
+  // Cold-start fill: an operator with no test set has nothing to compare on,
+  // and picking turns out of Chat one at a time is the slow way there.
+  //
+  // Accepting writes the same shape SaveTestCase does — including the pinned
+  // history, captured now and replayed verbatim at run time, because the source
+  // conversation drifts. Rejecting hides the candidate for the session only:
+  // nothing is written, so a reload offers it again.
+  let {
+    agent = '',
+    sets = [],
+    defaultSet = '',
+    onaccepted = undefined,
+    onclose = undefined,
+  } = $props()
+
+  const CATEGORY_LABEL = {
+    chat: 'Chat / persona',
+    skill_command: 'Skill command',
+    scheduled: 'Scheduled',
+    tool_heavy: 'Tool-heavy',
+  }
+
+  // Why this turn is worth keeping, in the operator's words. The API's signal
+  // names are the store's vocabulary, not a reason anyone can read.
+  const SIGNAL_LABEL = {
+    tool_fault: 'a tool call was rejected or failed',
+    many_rounds: 'took three or more tool rounds',
+    high_cost: 'cost in the top 10% of turns',
+    command_skill: 'triggered by a skill command',
+  }
+
+  let loading = $state(true)
+  let error = $state('')
+  let candidates = $state([])
+
+  // Keys hidden for this session — rejected, or already accepted.
+  let hiddenKeys = $state(new Set())
+  let selectedKeys = $state(new Set())
+  let busyKeys = $state(new Set())
+  let batching = $state(false)
+  // Batch progress, so a long serial add says where it is rather than sitting
+  // on one "Adding…" for the whole run.
+  let batchDone = $state(0)
+  let batchTotal = $state(0)
+  let acceptError = $state('')
+  let savedMsg = $state('')
+
+  // The set control, focused once the panel has something to act on: it is
+  // opened from a button elsewhere on the page, so focus has to follow it in.
+  let setControl = $state(null)
+  let targetSet = $state('')
+  let creatingNew = $state(false)
+  let newSetName = $state('')
+  // Sets created from here, so the picker shows them before the page reloads.
+  let created = $state([])
+
+  const allSets = $derived([
+    ...sets,
+    ...created.filter(c => !sets.some(s => s.name === c.name)),
+  ])
+  const visible = $derived(candidates.filter(c => !hiddenKeys.has(keyOf(c))))
+  const selectedCount = $derived(visible.filter(c => selectedKeys.has(keyOf(c))).length)
+  const busy = $derived(batching || busyKeys.size > 0)
+  const setChosen = $derived(creatingNew ? newSetName.trim() !== '' : targetSet !== '')
+
+  function keyOf(c) {
+    return `${c.conversation_id}:${c.message_id}`
+  }
+
+  function categoryLabel(c) {
+    return CATEGORY_LABEL[c] || c
+  }
+
+  /** The "why" line: the signals that made this turn interesting. */
+  function whyLine(c) {
+    const parts = (c.signals || []).map(s => SIGNAL_LABEL[s] || s)
+    if (parts.length === 0) return ''
+    return `Why: ${parts.join(' · ')}`
+  }
+
+  /** Names a card's controls, so 60 buttons are not all called "Accept". */
+  function shortLabel(c) {
+    const t = (c.prompt || '').trim().replace(/\s+/g, ' ')
+    return t.length > 60 ? `${t.slice(0, 60)}…` : t
+  }
+
+  function preview(text) {
+    const t = (text || '').trim()
+    return t.length > 400 ? `${t.slice(0, 400)}…` : t
+  }
+
+  // --- Loading --------------------------------------------------------------
+
+  // Guards against a slow response for an agent the operator has since changed
+  // away from overwriting a newer one.
+  let requestSeq = 0
+
+  async function load() {
+    const seq = ++requestSeq
+    loading = true
+    error = ''
+    acceptError = ''
+    savedMsg = ''
+    try {
+      const res = await api.evalSuggest({ agent: agent || undefined, limit: 20 })
+      if (seq !== requestSeq) return
+      // The endpoint answers {candidates: [...]}; tolerate a bare array so an
+      // older server does not render as an error.
+      candidates = Array.isArray(res) ? res : (res?.candidates || [])
+      selectedKeys = new Set()
+      // A fresh pass is a fresh offer: rejections were only for the last list.
+      // Accepted turns do not come back — the endpoint excludes saved sources.
+      hiddenKeys = new Set()
+    } catch (e) {
+      if (seq !== requestSeq) return
+      error = e.message || 'Could not load suggestions'
+    } finally {
+      if (seq === requestSeq) loading = false
+    }
+    if (seq === requestSeq && candidates.length > 0) {
+      await tick()
+      setControl?.focus()
+    }
+  }
+
+  function handleKeydown(e) {
+    if (e.key === 'Escape' && !busy && onclose) {
+      e.stopPropagation()
+      onclose()
+    }
+  }
+
+  /** "golden-set (4 cases)" — a bare count reads as runs. */
+  function setOption(s) {
+    const n = s.task_count ?? 0
+    return `${s.name} (${n} case${n === 1 ? '' : 's'})`
+  }
+
+  // Refetch when the agent changes: suggestions are that agent's history.
+  $effect(() => {
+    void agent
+    load()
+  })
+
+  // Pick a target set once one is known, defaulting to the launcher's. With no
+  // sets at all the only path is creating one, so open that directly.
+  let setInitialised = false
+  $effect(() => {
+    if (setInitialised) return
+    if (allSets.length > 0) {
+      targetSet = allSets.some(s => s.name === defaultSet) ? defaultSet : allSets[0].name
+      setInitialised = true
+    } else if (!loading) {
+      creatingNew = true
+      setInitialised = true
+    }
+  })
+
+  // --- Selection ------------------------------------------------------------
+
+  function toggleSelected(c) {
+    const k = keyOf(c)
+    const next = new Set(selectedKeys)
+    if (next.has(k)) next.delete(k)
+    else next.add(k)
+    selectedKeys = next
+  }
+
+  function selectAll() {
+    selectedKeys = new Set(visible.map(keyOf))
+  }
+
+  function clearSelection() {
+    selectedKeys = new Set()
+  }
+
+  function reject(c) {
+    const k = keyOf(c)
+    hiddenKeys = new Set(hiddenKeys).add(k)
+    const next = new Set(selectedKeys)
+    next.delete(k)
+    selectedKeys = next
+  }
+
+  // --- Accepting ------------------------------------------------------------
+
+  function startNewSet() {
+    creatingNew = true
+    newSetName = ''
+  }
+
+  function cancelNewSet() {
+    creatingNew = false
+    if (allSets.length > 0) targetSet = allSets[0].name
+  }
+
+  /** Resolves the target set name, creating the set on the fly when new. */
+  async function ensureSet() {
+    if (!creatingNew) return targetSet
+    const name = newSetName.trim()
+    if (!name) throw new Error('Name the test set first')
+    if (!allSets.some(s => s.name === name)) {
+      const set = await api.createEvalTaskSet({ name })
+      created = [...created, set]
+    }
+    creatingNew = false
+    targetSet = name
+    return name
+  }
+
+  async function addOne(setName, c) {
+    const pinned = (c.preceding || []).map(m => ({ role: m.role, content: m.content }))
+    await api.addEvalTask(setName, {
+      prompt: c.prompt,
+      category: c.category,
+      pinned_history: pinned.length ? pinned : undefined,
+      source_conversation_id: c.conversation_id || undefined,
+      source_message_id: c.message_id ?? null,
+    })
+  }
+
+  async function accept(c) {
+    if (busy) return
+    acceptError = ''
+    savedMsg = ''
+    const k = keyOf(c)
+    busyKeys = new Set(busyKeys).add(k)
+    try {
+      const setName = await ensureSet()
+      await addOne(setName, c)
+      hiddenKeys = new Set(hiddenKeys).add(k)
+      const sel = new Set(selectedKeys)
+      sel.delete(k)
+      selectedKeys = sel
+      savedMsg = `Added 1 test case to “${setName}”`
+      onaccepted?.(setName)
+    } catch (e) {
+      acceptError = e.message || 'Could not add the test case'
+    } finally {
+      const next = new Set(busyKeys)
+      next.delete(k)
+      busyKeys = next
+    }
+  }
+
+  async function acceptSelected() {
+    if (busy || selectedCount === 0) return
+    acceptError = ''
+    savedMsg = ''
+    batching = true
+    const chosen = visible.filter(c => selectedKeys.has(keyOf(c)))
+    batchTotal = chosen.length
+    let added = 0
+    try {
+      const setName = await ensureSet()
+      const done = new Set(hiddenKeys)
+      for (const c of chosen) {
+        // One failure stops the batch rather than silently skipping cases: a
+        // partial add the operator cannot see is worse than a short one.
+        await addOne(setName, c)
+        done.add(keyOf(c))
+        added++
+        batchDone = added
+      }
+      hiddenKeys = done
+      savedMsg = `Added ${added} test case${added === 1 ? '' : 's'} to “${setName}”`
+      onaccepted?.(setName)
+    } catch (e) {
+      acceptError = added > 0
+        ? `Added ${added} of ${chosen.length}, then failed: ${e.message}`
+        : (e.message || 'Could not add the test cases')
+      if (added > 0) onaccepted?.(targetSet)
+    } finally {
+      selectedKeys = new Set()
+      batching = false
+      batchDone = 0
+    }
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<section class="suggest" data-testid="suggest-panel" aria-label="Suggested test cases"
+  aria-busy={busy} onkeydown={handleKeydown}>
+  <div class="head">
+    <h2 class="section-title">Suggest from history</h2>
+    <div class="head-actions">
+      <button class="btn-ghost btn-sm" onclick={load} disabled={loading || busy}
+        data-testid="suggest-refresh">Refresh</button>
+      {#if onclose}
+        <button class="btn-ghost btn-sm" onclick={() => onclose?.()} disabled={busy}
+          data-testid="suggest-close">Close</button>
+      {/if}
+    </div>
+  </div>
+
+  {#if acceptError}<div class="inline-error" role="alert" data-testid="suggest-accept-error">{acceptError}</div>{/if}
+  {#if savedMsg}<div class="save-ok" role="status" data-testid="suggest-saved">{savedMsg}</div>{/if}
+
+  {#if loading}
+    <p class="muted row" role="status" data-testid="suggest-loading">
+      <span class="spinner" aria-hidden="true"></span>
+      Looking through recent turns…
+    </p>
+  {:else if error}
+    <div class="inline-error" role="alert" data-testid="suggest-error">{error}</div>
+    <button class="btn-ghost btn-sm" onclick={load}>Try again</button>
+  {:else if visible.length === 0}
+    <p class="muted" data-testid="suggest-empty">
+      {#if candidates.length === 0}
+        Nothing to suggest yet. Turns become candidates once they show something worth
+        testing — a failed tool call, several tool rounds, an unusually expensive reply,
+        or a skill command.
+      {:else}
+        All suggestions handled. Refresh to look again.
+      {/if}
+    </p>
+  {:else}
+    <div class="controls">
+      <div class="field set-field">
+        <label class="field-label" for="suggest-set">Add to test set</label>
+        {#if creatingNew}
+          <div class="row">
+            <input
+              id="suggest-set"
+              type="text"
+              bind:this={setControl}
+              bind:value={newSetName}
+              placeholder="e.g. golden-set"
+              maxlength="80"
+              disabled={busy}
+              data-testid="suggest-new-set"
+            />
+            {#if allSets.length > 0}
+              <button class="btn-link" onclick={cancelNewSet} disabled={busy}>Use existing</button>
+            {/if}
+          </div>
+          <span class="hint">Created when you accept the first case.</span>
+        {:else}
+          <div class="row">
+            <select id="suggest-set" bind:this={setControl} bind:value={targetSet}
+              disabled={busy} data-testid="suggest-set-select">
+              {#each allSets as s}
+                <option value={s.name}>{setOption(s)}</option>
+              {/each}
+            </select>
+            <button class="btn-link" onclick={startNewSet} disabled={busy}>New set…</button>
+          </div>
+        {/if}
+      </div>
+
+      <div class="batch">
+        <button class="btn-primary" onclick={acceptSelected}
+          disabled={busy || selectedCount === 0 || !setChosen}
+          data-testid="accept-selected">
+          {#if batching}<span class="spinner" aria-hidden="true"></span>Adding {Math.min(batchDone + 1, batchTotal)} of {batchTotal}…{:else}Accept selected ({selectedCount}){/if}
+        </button>
+        <button class="btn-ghost btn-sm" onclick={selectAll} disabled={busy}>Select all</button>
+        <button class="btn-ghost btn-sm" onclick={clearSelection}
+          disabled={busy || selectedCount === 0}>Clear</button>
+      </div>
+    </div>
+
+    {#if !setChosen}
+      <p class="hint" data-testid="suggest-blocker">Pick or name a test set to accept into.</p>
+    {/if}
+    <p class="hint">Rejecting writes nothing — a rejected suggestion comes back on refresh.</p>
+    <ul class="cards" data-testid="suggest-cards">
+      {#each visible as c (keyOf(c))}
+        {@const k = keyOf(c)}
+        <li class="card">
+          <div class="card-head">
+            <label class="pick">
+              <input type="checkbox" checked={selectedKeys.has(k)}
+                onchange={() => toggleSelected(c)} disabled={busy}
+                aria-label={`Select: ${shortLabel(c)}`} />
+            </label>
+            <span class="cat-chip">{categoryLabel(c.category)}</span>
+          </div>
+          <p class="prompt">{preview(c.prompt)}</p>
+          {#if whyLine(c)}<p class="why">{whyLine(c)}</p>{/if}
+          {#if c.preceding?.length}
+            <p class="hint">Pins {c.preceding.length} preceding turn{c.preceding.length === 1 ? '' : 's'} as history.</p>
+          {/if}
+          <div class="card-actions">
+            <button class="btn-primary" onclick={() => accept(c)}
+              disabled={busy || !setChosen} aria-label={`Accept: ${shortLabel(c)}`}
+              data-testid={`accept-${k}`}>
+              {#if busyKeys.has(k)}<span class="spinner" aria-hidden="true"></span>Adding…{:else}Accept{/if}
+            </button>
+            <button class="btn-ghost btn-sm" onclick={() => reject(c)} disabled={busy}
+              aria-label={`Reject: ${shortLabel(c)}`}
+              data-testid={`reject-${k}`}>Reject</button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .suggest {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 18px;
+    margin-bottom: 24px;
+  }
+
+  .head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .head-actions {
+    display: flex;
+    gap: 6px;
+  }
+
+  /* Matches the page's own section headings and field labels rather than the
+     shared sheet, which has neither. */
+  .section-title {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    margin: 0 0 12px;
+  }
+
+  .field-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+
+  .inline-error { color: var(--danger); font-size: 12px; margin: 0 0 10px; }
+
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .set-field {
+    flex: 1 1 240px;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .batch {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  select,
+  input[type='text'] {
+    flex: 1 1 auto;
+    min-width: 0;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    padding: 6px 10px;
+    font-size: 13px;
+  }
+
+  select:focus,
+  input:focus { outline: none; border-color: var(--accent); }
+
+  .cards {
+    list-style: none;
+    margin: 12px 0 0;
+    padding: 0;
+    display: grid;
+    /* min() keeps a single column from overflowing at 320px, where the page
+       and panel padding leave under 260px of track. */
+    grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
+    gap: 12px;
+  }
+
+  .card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .card-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .pick {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  /* A static label, so it takes the page's .status-chip shape rather than the
+     shared .chip, which is an interactive filter control. */
+  .cat-chip {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    white-space: nowrap;
+  }
+
+  .prompt {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text);
+    margin: 0;
+    /* Prompts are prose with unbreakable ids in them; preview() caps the
+       length, so the card grows rather than clipping into a scroll box a
+       keyboard user could not reach. */
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
+  .why {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .card-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: auto;
+  }
+
+  .muted {
+    color: var(--text-muted);
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  p.hint { margin: 0; }
+
+  /* The shared sheet styles the buttons; it has no disabled treatment for the
+     ghost/small pair, and an in-flight control has to read as unavailable. */
+  button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .btn-link {
+    border: none;
+    background: none;
+    padding: 4px 2px;
+    color: var(--accent);
+    font-size: 13px;
+    cursor: pointer;
+    flex: 0 0 auto;
+  }
+
+  button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  .spinner {
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.7s linear infinite;
+    display: inline-block;
+    margin-right: 4px;
+    vertical-align: -1px;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .spinner { animation-duration: 2s; }
+  }
+
+  @media (max-width: 520px) {
+    .suggest { padding: 14px; }
+  }
+</style>

--- a/web/src/components/__tests__/SuggestCases.test.js
+++ b/web/src/components/__tests__/SuggestCases.test.js
@@ -1,0 +1,257 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/server.js'
+import { evalSuggestions } from '../../test/handlers.js'
+import { token, authMode } from '../../store.js'
+
+const SuggestCases = (await import('../SuggestCases.svelte')).default
+
+// Assertions are about the requests a server would receive, not internal state.
+let created = []
+let addedTasks = []
+
+const SETS = [
+  { id: 1, name: 'golden-set', description: '', task_count: 4 },
+  { id: 2, name: 'smoke', description: '', task_count: 1 },
+]
+
+beforeEach(() => {
+  token.set('test-key')
+  authMode.set('token')
+  created = []
+  addedTasks = []
+  server.use(
+    http.post('/api/v1/eval/task-sets', async ({ request }) => {
+      const body = await request.json()
+      created.push(body)
+      return HttpResponse.json({ id: 9, name: body.name, description: '', task_count: 0 }, { status: 201 })
+    }),
+    http.post('/api/v1/eval/task-sets/:name/tasks', async ({ request, params }) => {
+      const body = await request.json()
+      addedTasks.push({ set: params.name, body })
+      return HttpResponse.json({ id: 10, ...body }, { status: 201 })
+    }),
+  )
+})
+
+/** Waits for the cards to replace the loading line. */
+async function renderPanel(props = {}) {
+  const r = render(SuggestCases, { sets: SETS, defaultSet: 'golden-set', ...props })
+  await waitFor(() => expect(screen.getByTestId('suggest-cards')).toBeInTheDocument())
+  return r
+}
+
+describe('SuggestCases — listing', () => {
+  test('renders prompt, category chip, and a why line per candidate', async () => {
+    await renderPanel()
+
+    expect(screen.getByText('Summarise the on-call handover for this week')).toBeInTheDocument()
+    expect(screen.getByText('/digest yesterday')).toBeInTheDocument()
+    expect(screen.getByText('Tool-heavy')).toBeInTheDocument()
+    expect(screen.getByText('Skill command')).toBeInTheDocument()
+    // The why line translates the API's signal names into operator words.
+    expect(
+      screen.getByText(/Why: a tool call was rejected or failed · took three or more tool rounds/)
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Pins 2 preceding turns as history/)).toBeInTheDocument()
+  })
+
+  test('asks the endpoint for the given agent', async () => {
+    let seen = null
+    server.use(
+      http.get('/api/v1/eval/suggest', ({ request }) => {
+        seen = new URL(request.url).searchParams.get('agent')
+        return HttpResponse.json(evalSuggestions)
+      }),
+    )
+    await renderPanel({ agent: 'helper' })
+    expect(seen).toBe('helper')
+  })
+
+  test('shows a spinner line while loading', async () => {
+    server.use(
+      http.get('/api/v1/eval/suggest', async () => {
+        await new Promise(r => setTimeout(r, 30))
+        return HttpResponse.json(evalSuggestions)
+      }),
+    )
+    render(SuggestCases, { sets: SETS })
+    expect(screen.getByTestId('suggest-loading')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId('suggest-cards')).toBeInTheDocument())
+  })
+
+  test('teaches what makes a candidate when history has nothing to offer', async () => {
+    server.use(http.get('/api/v1/eval/suggest', () => HttpResponse.json({ candidates: [] })))
+    render(SuggestCases, { sets: SETS })
+
+    await waitFor(() => expect(screen.getByTestId('suggest-empty')).toBeInTheDocument())
+    expect(screen.getByText(/a failed tool call, several tool rounds/)).toBeInTheDocument()
+  })
+
+  test('surfaces a load failure with a retry that succeeds', async () => {
+    let calls = 0
+    server.use(
+      http.get('/api/v1/eval/suggest', () => {
+        calls++
+        return calls === 1
+          ? HttpResponse.json({ error: 'telemetry not available' }, { status: 501 })
+          : HttpResponse.json(evalSuggestions)
+      }),
+    )
+    render(SuggestCases, { sets: SETS })
+
+    await waitFor(() => expect(screen.getByTestId('suggest-error')).toBeInTheDocument())
+    await fireEvent.click(screen.getByText('Try again'))
+    await waitFor(() => expect(screen.getByTestId('suggest-cards')).toBeInTheDocument())
+  })
+})
+
+describe('SuggestCases — accept', () => {
+  test('adds the case with its category, pinned history, and source ids', async () => {
+    await renderPanel()
+
+    await fireEvent.click(screen.getByTestId('accept-chan:ops:101'))
+    await waitFor(() => expect(addedTasks).toHaveLength(1))
+
+    expect(addedTasks[0].set).toBe('golden-set')
+    expect(addedTasks[0].body).toMatchObject({
+      prompt: 'Summarise the on-call handover for this week',
+      category: 'chat',
+      source_conversation_id: 'chan:ops',
+      source_message_id: 101,
+    })
+    expect(addedTasks[0].body.pinned_history).toEqual([
+      { role: 'user', content: 'morning' },
+      { role: 'assistant', content: 'hi' },
+    ])
+    expect(screen.getByTestId('suggest-saved')).toHaveTextContent('Added 1 test case')
+    // Accepted candidates leave the list.
+    expect(screen.queryByText('Summarise the on-call handover for this week')).not.toBeInTheDocument()
+  })
+
+  test('omits pinned history when the turn had none', async () => {
+    await renderPanel()
+
+    await fireEvent.click(screen.getByTestId('accept-chan:ops:102'))
+    await waitFor(() => expect(addedTasks).toHaveLength(1))
+    expect(addedTasks[0].body.pinned_history).toBeUndefined()
+  })
+
+  test('creates the chosen set on the fly before adding', async () => {
+    await renderPanel({ sets: [], defaultSet: '' })
+
+    await fireEvent.input(screen.getByTestId('suggest-new-set'), { target: { value: 'fresh-set' } })
+    await fireEvent.click(screen.getByTestId('accept-chan:ops:101'))
+
+    await waitFor(() => expect(addedTasks).toHaveLength(1))
+    expect(created).toEqual([{ name: 'fresh-set' }])
+    expect(addedTasks[0].set).toBe('fresh-set')
+  })
+
+  test('blocks accept until a set is named', async () => {
+    await renderPanel({ sets: [], defaultSet: '' })
+
+    expect(screen.getByTestId('suggest-blocker')).toBeInTheDocument()
+    expect(screen.getByTestId('accept-chan:ops:101')).toBeDisabled()
+    await fireEvent.input(screen.getByTestId('suggest-new-set'), { target: { value: 'x' } })
+    expect(screen.getByTestId('accept-chan:ops:101')).not.toBeDisabled()
+  })
+
+  test('reports a failed add and keeps the candidate on screen', async () => {
+    server.use(
+      http.post('/api/v1/eval/task-sets/:name/tasks', () =>
+        HttpResponse.json({ error: 'set is full' }, { status: 400 })),
+    )
+    await renderPanel()
+
+    await fireEvent.click(screen.getByTestId('accept-chan:ops:101'))
+    await waitFor(() => expect(screen.getByTestId('suggest-accept-error')).toHaveTextContent('set is full'))
+    expect(screen.getByText('Summarise the on-call handover for this week')).toBeInTheDocument()
+  })
+
+  test('notifies the parent with the set that grew', async () => {
+    const seen = []
+    await renderPanel({ onaccepted: name => seen.push(name) })
+
+    await fireEvent.click(screen.getByTestId('accept-chan:ops:101'))
+    await waitFor(() => expect(seen).toEqual(['golden-set']))
+  })
+})
+
+describe('SuggestCases — batch accept and reject', () => {
+  test('accepts every selected candidate into one set', async () => {
+    await renderPanel()
+
+    await fireEvent.click(screen.getByText('Select all'))
+    await fireEvent.click(screen.getByTestId('accept-selected'))
+
+    await waitFor(() => expect(addedTasks).toHaveLength(3))
+    expect(addedTasks.every(t => t.set === 'golden-set')).toBe(true)
+    await waitFor(() =>
+      expect(screen.getByTestId('suggest-saved')).toHaveTextContent('Added 3 test cases to “golden-set”'))
+    await waitFor(() => expect(screen.getByTestId('suggest-empty')).toBeInTheDocument())
+  })
+
+  test('the batch button counts the selection and is disabled while empty', async () => {
+    await renderPanel()
+
+    const btn = screen.getByTestId('accept-selected')
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveTextContent('Accept selected (0)')
+
+    const boxes = screen.getAllByRole('checkbox')
+    await fireEvent.click(boxes[0])
+    expect(btn).not.toBeDisabled()
+    expect(btn).toHaveTextContent('Accept selected (1)')
+  })
+
+  test('a mid-batch failure says how many landed', async () => {
+    let n = 0
+    server.use(
+      http.post('/api/v1/eval/task-sets/:name/tasks', async ({ request }) => {
+        n++
+        if (n === 2) return HttpResponse.json({ error: 'store is busy' }, { status: 500 })
+        const body = await request.json()
+        return HttpResponse.json({ id: n, ...body }, { status: 201 })
+      }),
+    )
+    await renderPanel()
+
+    await fireEvent.click(screen.getByText('Select all'))
+    await fireEvent.click(screen.getByTestId('accept-selected'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('suggest-accept-error')).toHaveTextContent('Added 1 of 3, then failed'))
+  })
+
+  test('reject hides the candidate without writing anything', async () => {
+    await renderPanel()
+
+    await fireEvent.click(screen.getByTestId('reject-chan:ops:102'))
+    expect(screen.queryByText('/digest yesterday')).not.toBeInTheDocument()
+    expect(addedTasks).toHaveLength(0)
+    // The other candidates stay.
+    expect(screen.getByText('Summarise the on-call handover for this week')).toBeInTheDocument()
+  })
+
+  test('refresh brings rejected candidates back', async () => {
+    await renderPanel()
+
+    await fireEvent.click(screen.getByTestId('reject-chan:ops:102'))
+    expect(screen.queryByText('/digest yesterday')).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByTestId('suggest-refresh'))
+    await waitFor(() => expect(screen.getByText('/digest yesterday')).toBeInTheDocument())
+  })
+
+  test('rejecting everything says the list is exhausted, not that history is empty', async () => {
+    await renderPanel()
+
+    for (const id of ['chan:ops:101', 'chan:ops:102', 'chan:dev:103']) {
+      await fireEvent.click(screen.getByTestId(`reject-${id}`))
+    }
+    await waitFor(() => expect(screen.getByTestId('suggest-empty')).toBeInTheDocument())
+    expect(screen.getByText(/All suggestions handled/)).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -8,6 +8,7 @@
   import ErrorBanner from '../components/ErrorBanner.svelte'
   import FilterChips from '../components/FilterChips.svelte'
   import ModelSelector from '../components/ModelSelector.svelte'
+  import SuggestCases from '../components/SuggestCases.svelte'
 
   // Quick check draws this many test cases; Full eval runs the whole set.
   const QUICK_TASKS = 10
@@ -49,6 +50,25 @@
   let importing = $state(false)
   let importError = $state('')
   let importOk = $state('')
+
+  // --- Suggestions ---
+  let showSuggest = $state(false)
+
+  function toggleSuggest() {
+    showSuggest = !showSuggest
+    // Two stacked panels above the launcher push it off screen, so they take
+    // turns.
+    if (showSuggest) showImport = false
+  }
+
+  // A suggestion accepted into a set changes its case count, and may have
+  // created the set the launcher should now be pointing at.
+  async function onSuggestAccepted(name) {
+    try {
+      await loadTaskSets()
+      if (name) taskSetName = name
+    } catch { /* the panel already reported the write; the count can lag */ }
+  }
 
   // --- Runs ---
   let expandedRun = $state(null)
@@ -257,6 +277,7 @@
 
   function toggleImport() {
     showImport = !showImport
+    if (showImport) showSuggest = false
     importError = ''
     importOk = ''
   }
@@ -397,6 +418,9 @@
 <div class="page-header">
   <h1 class="page-title">Evals</h1>
   {#if !isEmpty}
+    <button class="btn-ghost btn-sm" onclick={toggleSuggest}
+      aria-expanded={showSuggest} aria-controls="eval-suggest-panel"
+      data-testid="suggest-toggle">Suggest from history</button>
     <button class="btn-ghost btn-sm" onclick={toggleImport}
       aria-expanded={showImport} aria-controls="eval-import-panel"
       data-testid="import-toggle">Import JSONL</button>
@@ -414,7 +438,10 @@
       candidate on them.
     </p>
     <div class="empty-actions">
-      <button class="btn-primary" onclick={() => navigate('chat')} data-testid="empty-chat-cta">Go to Chat</button>
+      <button class="btn-primary" onclick={toggleSuggest}
+        aria-expanded={showSuggest} aria-controls="eval-suggest-panel"
+        data-testid="empty-suggest-cta">Suggest from history</button>
+      <button class="btn-ghost" onclick={() => navigate('chat')} data-testid="empty-chat-cta">Go to Chat</button>
       <button class="btn-ghost" onclick={toggleImport} data-testid="empty-import-cta"
         aria-expanded={showImport} aria-controls="eval-import-panel">Import JSONL</button>
     </div>
@@ -447,6 +474,23 @@
         <button class="btn-ghost" onclick={toggleImport} disabled={importing}>Close</button>
       </div>
     </div>
+  </div>
+</div>
+
+<!-- Collapses like the import panel above it. The wrapper always exists so the
+     triggers' aria-controls resolves; the component itself is gated, so nothing
+     is fetched until the panel is opened. -->
+<div class="inline-panel" id="eval-suggest-panel" class:open={showSuggest} use:inert={!showSuggest}>
+  <div class="inline-panel-inner">
+    {#if showSuggest}
+      <SuggestCases
+        agent={baseAgent}
+        sets={taskSets}
+        defaultSet={taskSetName}
+        onaccepted={onSuggestAccepted}
+        onclose={() => (showSuggest = false)}
+      />
+    {/if}
   </div>
 </div>
 

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -41,6 +41,39 @@ export const evalEstimate = {
   ],
 }
 
+// One candidate per category, the stratified shape GET /eval/suggest returns.
+export const evalSuggestions = {
+  candidates: [
+    {
+      prompt: 'Summarise the on-call handover for this week',
+      category: 'chat',
+      conversation_id: 'chan:ops',
+      message_id: 101,
+      created_at: '2026-08-20T09:00:00Z',
+      signals: ['high_cost'],
+      preceding: [{ role: 'user', content: 'morning' }, { role: 'assistant', content: 'hi' }],
+    },
+    {
+      prompt: '/digest yesterday',
+      category: 'skill_command',
+      conversation_id: 'chan:ops',
+      message_id: 102,
+      created_at: '2026-08-21T09:00:00Z',
+      signals: ['command_skill', 'many_rounds'],
+      preceding: [],
+    },
+    {
+      prompt: 'Fetch the release notes and diff them against the changelog',
+      category: 'tool_heavy',
+      conversation_id: 'chan:dev',
+      message_id: 103,
+      created_at: '2026-08-22T09:00:00Z',
+      signals: ['tool_fault', 'many_rounds'],
+      preceding: [],
+    },
+  ],
+}
+
 export const evalRuns = [
   {
     id: 1,
@@ -388,7 +421,7 @@ export const handlers = [
   http.get('/api/v1/eval/runs/:id/summary', () => HttpResponse.json({ variants: [], per_task: [], completeness: {}, verdicts: [] })),
   http.get('/api/v1/eval/runs/:id/samples', () => HttpResponse.json([])),
   http.get('/api/v1/eval/runs/:id/pairs', () => HttpResponse.json([])),
-  http.get('/api/v1/eval/suggest', () => HttpResponse.json([])),
+  http.get('/api/v1/eval/suggest', () => HttpResponse.json(evalSuggestions)),
 
   // Setup
   http.get('/api/v1/setup', () => HttpResponse.json({ needs_setup: false, has_account: true })),


### PR DESCRIPTION
Client half of Stage D slice D3. The `GET /eval/suggest` backend shipped in #343; this is the surface that uses it.

## What it does

New `web/src/components/SuggestCases.svelte` renders the stratified candidates as cards under the launcher: prompt, category chip, and a "why" line translating the API's signal names into operator English (`tool_fault` -> "a tool call was rejected or failed").

- **Accept** adds the case to the chosen test set via `addEvalTask`, creating the set on the fly and pinning the candidate's preceding turns as history, the way `SaveTestCase.svelte` does.
- **Reject** hides the candidate for the session only. Nothing is written, so a refresh offers it again - the copy says so.
- **Batch accept** via per-card checkboxes, with a progress label and a partial-failure message naming how many landed.

"Suggest from history" becomes the empty state's first CTA, completing the three the design specifies, plus a header toggle once a test set or run exists. The suggest and import panels take turns so they cannot stack above the launcher.

## Review notes

- The diff to `Evals.svelte` is deliberately confined to the mount points (46 lines: import, toggle state, two triggers, the collapsible block, and an `onaccepted` callback that re-reads the test sets). The results-panel region is untouched - a parallel D2 branch is editing it.
- `web/src/test/handlers.js` had a `/eval/suggest` handler returning a bare `[]`; the endpoint actually answers `{candidates: [...]}`. Fixed, with a fixture carrying one candidate per category.
- `Evals.test.js` carried an assertion that "Suggest" was absent from the empty state, per the D1 note "until it lands the CTA is absent". It has landed, so that assertion is inverted.
- A `ui-reviewer` pass ran over the component; its findings are applied. The substantive one: success feedback lived inside the `visible.length > 0` branch, so "select all, accept" emptied the list and swallowed its own confirmation.

<details>
<summary>Checks</summary>

`just test-ui`: 931 passed (19 new). `just hook`: fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check all green.

Note for the other eval worktrees: `just lint` first failed citing files under `../feat-eval-d2-results/`. The golangci-lint cache under `~/Library/Caches/golangci-lint` is shared across worktrees; a cache clean cleared it and the same tree linted 0 issues.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KnwwPWFVDU4UQQ8jW9zzg