### PR TITLE
feat(eval): per-test-case diffs and the sample trace adapter

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -479,3 +479,65 @@ export const api = {
   resume: () => apiFetch('/api/v1/resume', { method: 'POST' }),
   panicStatus: () => apiFetch('/api/v1/panic'),
 }
+
+// --- Eval trace adapter ----------------------------------------------------
+// An eval sample stores its trace as raw []agent.ToolCallRecord JSON
+// (tool_name, outcome "suppressed", duration_ms) with cost and latency on the
+// sample itself, while DryRunTranscript renders the dry-run transcript shape
+// (tool, suppressed bool, duration_ms, cost_usd — internal/api/dryrun.go).
+// The mapping lives here so the component stays one component: forking it for
+// evals would mean every future transcript change has two homes.
+
+/**
+ * Decodes a sample's trace into DryRunTranscript's tool-call shape.
+ * Accepts the stored JSON string or an already-decoded array; an unparseable
+ * or absent trace yields an empty list rather than throwing — a sample with a
+ * broken trace should still render its response.
+ */
+export function evalTraceCalls(trace) {
+  let records = trace
+  if (typeof trace === 'string') {
+    if (trace.trim() === '') return []
+    try {
+      records = JSON.parse(trace)
+    } catch {
+      return []
+    }
+  }
+  if (!Array.isArray(records)) return []
+  return records.map(r => ({
+    tool: r.tool_name || '',
+    server: r.server_name || '',
+    round: r.round || 0,
+    // Records written before outcome existed carry success only.
+    outcome: r.outcome || (r.success === false ? 'failed' : 'ok'),
+    suppressed: r.outcome === 'suppressed',
+    duration_ms: r.duration_ms || 0,
+    arguments: r.arguments || '',
+    result: r.result || '',
+    error: r.error_msg || '',
+  }))
+}
+
+/**
+ * Adapts one eval sample to a dry-run transcript for DryRunTranscript.
+ * opts.model / opts.requestedModel name the model that answered — a sample
+ * does not carry one, so the caller passes the variant's overlay model.
+ */
+export function evalSampleTranscript(sample, opts = {}) {
+  const smp = sample || {}
+  const calls = evalTraceCalls(smp.trace)
+  return {
+    model: opts.model || '',
+    requested_model: opts.requestedModel || '',
+    response: smp.response || '',
+    rounds: smp.rounds || 0,
+    stop_reason: smp.stop_reason || '',
+    duration_ms: smp.latency_ms || 0,
+    cost_usd: smp.cost || 0,
+    // The sample's own counter is authoritative: the trace is trimmed for
+    // rendering, the counts are not.
+    suppressed_count: smp.outcome_suppressed ?? calls.filter(c => c.suppressed).length,
+    tool_calls: calls,
+  }
+}

--- a/web/src/components/EvalTaskDiffs.svelte
+++ b/web/src/components/EvalTaskDiffs.svelte
@@ -112,9 +112,55 @@
     return (pairs || []).find(p => p.task_id === taskID && p.k === k) || null
   }
 
-  /** Every verdict recorded against a pair, across both presentation orders. */
+  // A judge names a presented letter, and only the pair's assignment — which
+  // never leaves the server — says which model that letter was. The pair view
+  // resolves the overall winner (winner_variant) but leaves the per-dimension
+  // letters raw, so an unresolved "correctness: B" means nothing to the reader.
+  // A non-tie verdict on an item is itself the key for that item's letters:
+  // its winner letter is its winner_variant, so the other letter is the other
+  // side of the pair. An item judged a tie by everyone stays unresolvable and
+  // keeps its letter.
+  function letterKey(item, pair) {
+    for (const vd of item.verdicts || []) {
+      if (!vd.winner_variant || !vd.winner) continue
+      const won = vd.winner.toLowerCase()
+      if (won !== 'a' && won !== 'b') continue
+      const other = vd.winner_variant === pair.candidate?.variant
+        ? pair.baseline?.variant
+        : pair.candidate?.variant
+      return won === 'a'
+        ? { a: vd.winner_variant, b: other }
+        : { a: other, b: vd.winner_variant }
+    }
+    return null
+  }
+
+  /**
+   * Every verdict recorded against a pair, across both presentation orders,
+   * each carrying the letter key of the item it was recorded on.
+   */
   function verdictsOf(pair) {
-    return (pair?.items || []).flatMap(item => item.verdicts || [])
+    return (pair?.items || []).flatMap(item => {
+      const key = letterKey(item, pair)
+      return (item.verdicts || []).map(vd => ({ ...vd, key }))
+    })
+  }
+
+  /** One dimension's winner, as a model name where the letter can be resolved. */
+  function dimensionWinner(value, key) {
+    const v = (value || '').toLowerCase()
+    if (v === 'tie') return 'tie'
+    if (key && (v === 'a' || v === 'b')) return key[v] || value
+    return value
+  }
+
+  // Categories are stored as slugs; SuggestCases.svelte labels them the same
+  // way, and the two lists have to agree.
+  const CATEGORY_LABEL = {
+    chat: 'Chat / persona',
+    skill_command: 'Skill command',
+    scheduled: 'Scheduled',
+    tool_heavy: 'Tool-heavy',
   }
 
   const OUTCOME_LABEL = {
@@ -204,7 +250,7 @@
           {#each perTask as t (t.task_id)}
             <tr data-testid="task-row-{t.task_id}">
               <td class="col-prompt" title={t.prompt}>{shortPrompt(t.prompt)}</td>
-              <td><span class="pill">{t.category || '—'}</span></td>
+              <td><span class="pill">{CATEGORY_LABEL[t.category] || t.category || '—'}</span></td>
               {#each variants as v (v.variant_id)}
                 {@const cell = t.variants?.find(c => c.variant_id === v.variant_id)}
                 {#if !cell || cell.samples_ok === 0}
@@ -320,7 +366,7 @@
                                       {#if vd.dimensions && Object.keys(vd.dimensions).length > 0}
                                         <ul class="dimensions">
                                           {#each Object.entries(vd.dimensions) as [dim, winner] (dim)}
-                                            <li><span class="dim">{dim}</span><span class="dim-winner">{winner}</span></li>
+                                            <li><span class="dim">{dim}</span><span class="dim-winner">{dimensionWinner(winner, vd.key)}</span></li>
                                           {/each}
                                         </ul>
                                       {/if}

--- a/web/src/components/EvalTaskDiffs.svelte
+++ b/web/src/components/EvalTaskDiffs.svelte
@@ -1,0 +1,517 @@
+<script>
+  import { api, evalSampleTranscript } from '../api.js'
+  import DryRunTranscript from './DryRunTranscript.svelte'
+
+  // Per-test-case results for one run: a row per test case with each model's
+  // cost, rounds and latency plus the candidate's deltas, expanding inline to
+  // the runs behind those numbers side by side and the judge's call on them.
+  //
+  // Props:
+  //   runId  — the run to show (required).
+  //   summary — an already-fetched GET /eval/runs/{id}/summary, when the
+  //             parent has one. Omit and the component fetches its own.
+  //
+  // Mounting is therefore: <EvalTaskDiffs runId={id} {summary} />
+  //
+  // Samples and judged pairs are fetched once, on the first expansion: they
+  // carry whole transcripts, and a run's worth of them is not worth loading
+  // for a table nobody may open.
+  let { runId, summary = null } = $props()
+
+  let ownSummary = $state(null)
+  let loading = $state(false)
+  let error = $state('')
+
+  // Fetched lazily and shared by every row.
+  let samples = $state(null)
+  let pairs = $state(null)
+  let detailLoading = $state(false)
+  let detailError = $state('')
+  let detailPromise = null
+
+  let expanded = $state(new Set())
+
+  const view = $derived(summary || ownSummary)
+  const variants = $derived(view?.variants || [])
+  const perTask = $derived(view?.per_task || [])
+  // The baseline is the first variant by creation order — the incumbent.
+  const baselineName = $derived(view?.baseline_variant || variants[0]?.name || '')
+
+  $effect(() => {
+    if (summary || !runId) return
+    loadSummary(runId)
+  })
+
+  async function loadSummary(id) {
+    loading = true
+    error = ''
+    try {
+      ownSummary = await api.evalRunSummary(id)
+    } catch (e) {
+      error = e.message
+    } finally {
+      loading = false
+    }
+  }
+
+  function loadDetail() {
+    if (detailPromise) return detailPromise
+    detailLoading = true
+    detailError = ''
+    detailPromise = Promise.all([
+      api.evalRunSamples(runId),
+      api.evalRunPairs(runId),
+    ]).then(([s, p]) => {
+      samples = Array.isArray(s) ? s : []
+      // The pairs endpoint returns the whole judging grid, not a bare list.
+      pairs = Array.isArray(p?.pairs) ? p.pairs : (Array.isArray(p) ? p : [])
+    }).catch(e => {
+      detailError = e.message
+      // Cleared so the next expansion retries rather than showing a stale
+      // failure forever.
+      detailPromise = null
+    }).finally(() => {
+      detailLoading = false
+    })
+    return detailPromise
+  }
+
+  function toggle(taskID) {
+    const next = new Set(expanded)
+    if (next.has(taskID)) {
+      next.delete(taskID)
+    } else {
+      next.add(taskID)
+      loadDetail()
+    }
+    expanded = next
+  }
+
+  /** Model name to head a transcript with: the overlay's, else the variant's. */
+  function modelFor(name) {
+    const v = variants.find(x => x.name === name)
+    return v?.overlay?.llm_model || name
+  }
+
+  /** Samples for one test case, grouped by run index then variant name. */
+  function rowsFor(taskID) {
+    if (!samples) return []
+    const byK = new Map()
+    for (const smp of samples) {
+      if (smp.task_id !== taskID) continue
+      if (!byK.has(smp.k_index)) byK.set(smp.k_index, new Map())
+      const v = variants.find(x => x.variant_id === smp.variant_id)
+      byK.get(smp.k_index).set(v?.name || String(smp.variant_id), smp)
+    }
+    return [...byK.entries()]
+      .sort((a, b) => a[0] - b[0])
+      .map(([k, byVariant]) => ({ k, byVariant }))
+  }
+
+  function pairFor(taskID, k) {
+    return (pairs || []).find(p => p.task_id === taskID && p.k === k) || null
+  }
+
+  /** Every verdict recorded against a pair, across both presentation orders. */
+  function verdictsOf(pair) {
+    return (pair?.items || []).flatMap(item => item.verdicts || [])
+  }
+
+  const OUTCOME_LABEL = {
+    win: 'Candidate preferred',
+    loss: 'Current preferred',
+    tie: 'Tie',
+    pending: 'Not judged yet',
+  }
+
+  function money(n) {
+    return `$${(n || 0).toFixed(4)}`
+  }
+
+  function latency(ms) {
+    if (!ms) return '0 ms'
+    return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`
+  }
+
+  function rounds(n) {
+    return (n || 0).toFixed(1)
+  }
+
+  // Deltas are absolute, against the baseline, and zero on the baseline row.
+  // Lower is better for all three, so a negative delta is the good direction.
+  function deltaClass(d, epsilon) {
+    if (!d || Math.abs(d) < epsilon) return 'flat'
+    return d < 0 ? 'good' : 'bad'
+  }
+
+  function deltaCost(d) {
+    if (!d || Math.abs(d) < 0.00005) return '±0'
+    return `${d > 0 ? '+' : '−'}${money(Math.abs(d)).slice(1)}`
+  }
+
+  function deltaRounds(d) {
+    if (!d || Math.abs(d) < 0.05) return '±0'
+    return `${d > 0 ? '+' : '−'}${Math.abs(d).toFixed(1)}`
+  }
+
+  function deltaLatency(d) {
+    if (!d || Math.abs(d) < 1) return '±0'
+    return `${d > 0 ? '+' : '−'}${latency(Math.abs(d))}`
+  }
+
+  function shortPrompt(p) {
+    const s = (p || '').replace(/\s+/g, ' ').trim()
+    return s.length > 90 ? `${s.slice(0, 90)}…` : s
+  }
+</script>
+
+<div class="diffs">
+  <h3 class="section-title">Per-test-case results</h3>
+
+  {#if loading}
+    <p class="muted">Loading results...</p>
+  {:else if error}
+    <div class="banner error" role="alert">{error}</div>
+  {:else if perTask.length === 0}
+    <p class="muted">
+      No per-test-case results yet. Numbers appear once the run has produced
+      results for at least one test case.
+    </p>
+  {:else}
+    <div class="table-wrap">
+      <table class="table">
+        <thead>
+          <tr>
+            <th rowspan="2" class="col-prompt">Test case</th>
+            <th rowspan="2">Category</th>
+            {#each variants as v (v.variant_id)}
+              <th colspan="3" class="group" class:candidate={v.name !== baselineName}>
+                {v.name}
+                <span class="role">{v.name === baselineName ? 'Current' : 'Candidate'}</span>
+              </th>
+            {/each}
+            <th rowspan="2" class="col-toggle"></th>
+          </tr>
+          <tr>
+            {#each variants as v (v.variant_id)}
+              <th class="sub group-start">Cost</th>
+              <th class="sub">Rounds</th>
+              <th class="sub">Latency</th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each perTask as t (t.task_id)}
+            <tr data-testid="task-row-{t.task_id}">
+              <td class="col-prompt" title={t.prompt}>{shortPrompt(t.prompt)}</td>
+              <td><span class="pill">{t.category || '—'}</span></td>
+              {#each variants as v (v.variant_id)}
+                {@const cell = t.variants?.find(c => c.variant_id === v.variant_id)}
+                {#if !cell || cell.samples_ok === 0}
+                  <td class="num group-start muted">—</td>
+                  <td class="num muted">—</td>
+                  <td class="num muted">—</td>
+                {:else}
+                  <td class="num group-start">
+                    {money(cell.mean_cost)}
+                    {#if v.name !== baselineName}
+                      <span class="delta {deltaClass(cell.delta_cost, 0.00005)}">{deltaCost(cell.delta_cost)}</span>
+                    {/if}
+                  </td>
+                  <td class="num">
+                    {rounds(cell.mean_rounds)}
+                    {#if v.name !== baselineName}
+                      <span class="delta {deltaClass(cell.delta_rounds, 0.05)}">{deltaRounds(cell.delta_rounds)}</span>
+                    {/if}
+                  </td>
+                  <td class="num">
+                    {latency(cell.mean_latency_ms)}
+                    {#if v.name !== baselineName}
+                      <span class="delta {deltaClass(cell.delta_latency_ms, 1)}">{deltaLatency(cell.delta_latency_ms)}</span>
+                    {/if}
+                  </td>
+                {/if}
+              {/each}
+              <td class="col-toggle">
+                <button
+                  class="expand-btn"
+                  onclick={() => toggle(t.task_id)}
+                  aria-expanded={expanded.has(t.task_id)}
+                  aria-controls="task-detail-{t.task_id}"
+                  aria-label="{expanded.has(t.task_id) ? 'Hide' : 'Show'} the runs for this test case"
+                >
+                  <span class="chevron" class:open={expanded.has(t.task_id)}>&#x25B6;</span>
+                </button>
+              </td>
+            </tr>
+            {#if expanded.has(t.task_id)}
+              <tr class="detail-row">
+                <td colspan={2 + variants.length * 3 + 1}>
+                  <div class="detail" id="task-detail-{t.task_id}" data-testid="task-detail-{t.task_id}">
+                    <div class="prompt-full">{t.prompt}</div>
+
+                    {#if detailLoading}
+                      <p class="muted">Loading the runs for this test case...</p>
+                    {:else if detailError}
+                      <div class="banner error" role="alert">{detailError}</div>
+                    {:else}
+                      {@const groups = rowsFor(t.task_id)}
+                      {#if groups.length === 0}
+                        <p class="muted">This test case produced no runs.</p>
+                      {:else}
+                        {#each groups as g (g.k)}
+                          {@const pair = pairFor(t.task_id, g.k)}
+                          <div class="k-block" data-testid="k-block-{t.task_id}-{g.k}">
+                            {#if groups.length > 1}
+                              <div class="k-label">Run {g.k + 1} of {groups.length}</div>
+                            {/if}
+                            <div class="columns">
+                              {#each variants as v (v.variant_id)}
+                                {@const smp = g.byVariant.get(v.name)}
+                                <div class="column" class:candidate={v.name !== baselineName}>
+                                  {#if !smp}
+                                    <p class="muted">No result for {v.name}.</p>
+                                  {:else if smp.status !== 'ok'}
+                                    <div class="failed">
+                                      <span class="failed-label">{v.name} failed</span>
+                                      <span class="failed-msg">{smp.error || 'No error recorded.'}</span>
+                                    </div>
+                                  {:else}
+                                    <DryRunTranscript
+                                      transcript={evalSampleTranscript(smp, { model: modelFor(v.name) })}
+                                      label={v.name === baselineName ? 'CURRENT' : 'CANDIDATE'}
+                                      accent={v.name !== baselineName}
+                                      compact={true}
+                                    />
+                                  {/if}
+                                </div>
+                              {/each}
+                            </div>
+
+                            {#if pair}
+                              {@const verdicts = verdictsOf(pair)}
+                              <div class="judgment" data-testid="judgment-{t.task_id}-{g.k}">
+                                <div class="judgment-head">
+                                  <span class="outcome outcome-{pair.outcome}">
+                                    {OUTCOME_LABEL[pair.outcome] || pair.outcome}
+                                  </span>
+                                  {#if verdicts.length > 0}
+                                    <span class="hint">
+                                      {verdicts.length} judgement{verdicts.length === 1 ? '' : 's'}
+                                    </span>
+                                  {/if}
+                                </div>
+                                {#if verdicts.length === 0}
+                                  <p class="hint">
+                                    Nobody has judged this comparison yet.
+                                  </p>
+                                {:else}
+                                  {#each verdicts as vd, i (i)}
+                                    <div class="verdict">
+                                      <div class="verdict-head">
+                                        <span class="judge">{vd.judge_ident || 'unknown judge'}</span>
+                                        <span class="picked">
+                                          {vd.winner_variant ? `picked ${vd.winner_variant}` : 'called it a tie'}
+                                        </span>
+                                        {#if vd.rubric_version}
+                                          <span class="hint">rubric {vd.rubric_version}</span>
+                                        {/if}
+                                      </div>
+                                      {#if vd.dimensions && Object.keys(vd.dimensions).length > 0}
+                                        <ul class="dimensions">
+                                          {#each Object.entries(vd.dimensions) as [dim, winner] (dim)}
+                                            <li><span class="dim">{dim}</span><span class="dim-winner">{winner}</span></li>
+                                          {/each}
+                                        </ul>
+                                      {/if}
+                                      {#if vd.notes}
+                                        <p class="notes">{vd.notes}</p>
+                                      {/if}
+                                    </div>
+                                  {/each}
+                                {/if}
+                              </div>
+                            {/if}
+                          </div>
+                        {/each}
+                      {/if}
+                    {/if}
+                  </div>
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .diffs { margin-top: 24px; }
+
+  .section-title {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    margin: 0 0 12px;
+  }
+
+  .table-wrap { overflow-x: auto; }
+  .table-wrap .table { margin-bottom: 0; }
+
+  th.group {
+    text-align: center;
+    border-left: 1px solid var(--border);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  th.group.candidate { color: var(--accent); }
+  th.group .role {
+    display: block;
+    font-family: inherit;
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  th.sub { font-size: 10px; font-weight: 500; }
+  th.group-start, td.group-start { border-left: 1px solid var(--border); }
+
+  .col-prompt { max-width: 320px; }
+  .col-toggle { width: 32px; }
+
+  td.num {
+    text-align: right;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+  }
+  .delta { display: block; font-size: 11px; }
+  .delta.good { color: var(--success); }
+  .delta.bad { color: var(--danger); }
+  .delta.flat { color: var(--text-muted); }
+
+  .expand-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
+  .expand-btn:hover { color: var(--text); }
+  .expand-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .chevron { font-size: 9px; transition: transform 0.2s; }
+  .chevron.open { transform: rotate(90deg); }
+
+  /* The detail spans the whole row and carries its own padding, like the
+     dry-run preview row on the Schedules page. */
+  .detail-row > td { padding: 0; background: var(--surface); }
+  .detail { display: flex; flex-direction: column; gap: 16px; padding: 16px; }
+
+  .prompt-full {
+    font-size: 13px;
+    line-height: 19px;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    border-left: 2px solid var(--border);
+    padding-left: 12px;
+  }
+
+  .k-block { display: flex; flex-direction: column; gap: 12px; }
+  .k-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+
+  .columns { display: flex; align-items: stretch; gap: 0; }
+  .column {
+    flex: 1;
+    min-width: 0;
+    padding: 0 16px;
+  }
+  .column:first-child { padding-left: 0; }
+  .column.candidate { border-left: 1px solid var(--border); }
+
+  .failed {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 14px;
+    border: 1px solid var(--danger);
+    border-radius: var(--radius);
+  }
+  .failed-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--danger);
+  }
+  .failed-msg { font-size: 12px; color: var(--text); word-break: break-word; }
+
+  .judgment {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 14px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .judgment-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+  .outcome { font-size: 12px; font-weight: 600; color: var(--text); }
+  .outcome-win { color: var(--success); }
+  .outcome-loss { color: var(--danger); }
+  .outcome-pending { color: var(--text-muted); }
+
+  .verdict { display: flex; flex-direction: column; gap: 6px; }
+  .verdict-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; font-size: 12px; }
+  .judge { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text); }
+  .picked { color: var(--text-muted); }
+
+  .dimensions { list-style: none; display: flex; flex-wrap: wrap; gap: 6px; margin: 0; padding: 0; }
+  .dimensions li {
+    display: flex;
+    gap: 6px;
+    font-size: 11px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 6px;
+  }
+  .dim { color: var(--text-muted); }
+  .dim-winner { color: var(--text); font-weight: 500; }
+
+  .notes {
+    margin: 0;
+    font-size: 12px;
+    line-height: 18px;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chevron { transition: none; }
+  }
+
+  /* Below the split point the transcripts stack: two of them side by side
+     stop being readable long before 320px. */
+  @media (max-width: 720px) {
+    .columns { flex-direction: column; gap: 16px; }
+    .column { padding: 0; }
+    .column.candidate { border-left: none; border-top: 1px solid var(--border); padding-top: 16px; }
+    .detail { padding: 12px; }
+  }
+</style>

--- a/web/src/components/__tests__/EvalTaskDiffs.test.js
+++ b/web/src/components/__tests__/EvalTaskDiffs.test.js
@@ -79,7 +79,7 @@ const PAIRS = {
           item_id: 1, presentation_order: 'AB', status: 'judged',
           verdicts: [{
             judge_ident: 'claude-code', winner: 'B', winner_variant: 'openai/gpt-4o',
-            dimensions: { correctness: 'B', tone: 'tie' },
+            dimensions: { correctness: 'b', tone: 'tie' },
             notes: 'Candidate followed the persona more closely.',
             rubric_version: 'v1', created_at: '2026-08-20T10:00:00Z',
           }],
@@ -88,7 +88,7 @@ const PAIRS = {
           item_id: 2, presentation_order: 'BA', status: 'judged',
           verdicts: [{
             judge_ident: 'claude-code', winner: 'A', winner_variant: 'openai/gpt-4o',
-            dimensions: { correctness: 'A' }, notes: '', rubric_version: 'v1',
+            dimensions: { correctness: 'a' }, notes: '', rubric_version: 'v1',
             created_at: '2026-08-20T10:01:00Z',
           }],
         },
@@ -137,7 +137,7 @@ describe('EvalTaskDiffs — rows', () => {
     await renderDiffs()
 
     expect(screen.getByText('Summarise the on-call handover for this week')).toBeInTheDocument()
-    expect(screen.getByText('chat')).toBeInTheDocument()
+    expect(screen.getByText('Chat / persona')).toBeInTheDocument()
     // Both models' numbers, in the operator's units.
     expect(screen.getByText('$0.0200')).toBeInTheDocument()
     expect(screen.getByText('$0.0150')).toBeInTheDocument()
@@ -215,9 +215,10 @@ describe('EvalTaskDiffs — expansion', () => {
 
     expect(screen.getByText('Current model answer')).toBeInTheDocument()
     expect(screen.getByText('Candidate model answer')).toBeInTheDocument()
-    // The candidate column is headed by its model, in the table and again on
-    // the transcript.
-    expect(screen.getAllByText('openai/gpt-4o')).toHaveLength(2)
+    // The candidate column is headed by its model in the table, and the
+    // transcript beneath it names the model that answered.
+    expect(screen.getByRole('columnheader', { name: /openai\/gpt-4o/ })).toBeInTheDocument()
+    expect(screen.getByTestId('task-detail-11')).toHaveTextContent('openai/gpt-4o')
     // Tool calls came through the adapter, suppressed one included.
     expect(screen.getAllByText('kv_get')).toHaveLength(2)
     expect(screen.getAllByText('SUPPRESSED')).toHaveLength(2)
@@ -233,7 +234,47 @@ describe('EvalTaskDiffs — expansion', () => {
     expect(judgment).toHaveTextContent('picked openai/gpt-4o')
     expect(judgment).toHaveTextContent('correctness')
     expect(judgment).toHaveTextContent('Candidate followed the persona more closely.')
+    // Dimension letters are blinding artefacts: both orders named the
+    // candidate, so both resolve to it rather than showing 'a' and 'b'.
+    expect(judgment.querySelectorAll('.dim-winner')).toHaveLength(3)
+    expect(judgment).not.toHaveTextContent(/\bcorrectness\s*[ab]\b/i)
     expect(judgment).toHaveTextContent('rubric v1')
+  })
+
+  test('resolves each dimension letter to the model that won it', async () => {
+    await renderDiffs()
+    await expandFirstRow()
+
+    const winners = [...screen.getByTestId('judgment-11-0').querySelectorAll('.dim-winner')]
+      .map(el => el.textContent)
+    // AB order: correctness 'b' → the candidate, tone stays a tie.
+    // BA order: correctness 'a' → the candidate again.
+    expect(winners).toEqual(['openai/gpt-4o', 'tie', 'openai/gpt-4o'])
+  })
+
+  test('keeps the raw letter when nothing on the item can unblind it', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/pairs', () => HttpResponse.json({
+      ...PAIRS,
+      pairs: [{
+        ...PAIRS.pairs[0],
+        outcome: 'tie',
+        items: [{
+          item_id: 1, presentation_order: 'AB', status: 'judged',
+          verdicts: [{
+            judge_ident: 'claude-code', winner: 'tie', winner_variant: '',
+            dimensions: { correctness: 'a' }, notes: '', rubric_version: 'v1',
+            created_at: '2026-08-20T10:00:00Z',
+          }],
+        }],
+      }],
+    })))
+
+    await renderDiffs()
+    await expandFirstRow()
+
+    const judgment = screen.getByTestId('judgment-11-0')
+    expect(judgment).toHaveTextContent('called it a tie')
+    expect(judgment.querySelector('.dim-winner')).toHaveTextContent('a')
   })
 
   test('says when a comparison is unjudged rather than dead-ending', async () => {

--- a/web/src/components/__tests__/EvalTaskDiffs.test.js
+++ b/web/src/components/__tests__/EvalTaskDiffs.test.js
@@ -1,0 +1,338 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/server.js'
+import { token, authMode } from '../../store.js'
+import { evalSampleTranscript, evalTraceCalls } from '../../api.js'
+
+const EvalTaskDiffs = (await import('../EvalTaskDiffs.svelte')).default
+
+// One trace as the runner writes it: []agent.ToolCallRecord, with a write
+// suppressed by the eval execution policy.
+const TRACE = JSON.stringify([
+  {
+    tool_name: 'kv_get', server_name: 'kv', round: 1, duration_ms: 120,
+    success: true, outcome: 'ok', arguments: '{"key":"a"}', result: 'value',
+  },
+  {
+    tool_name: 'telegram_send', server_name: '', round: 2, duration_ms: 0,
+    success: true, outcome: 'suppressed', arguments: '{"text":"hi"}',
+    result: '[suppressed]',
+  },
+])
+
+const SUMMARY = {
+  run_id: 7,
+  status: 'done',
+  baseline_variant: 'current',
+  variants: [
+    { variant_id: 1, name: 'current', overlay: {} },
+    { variant_id: 2, name: 'openai/gpt-4o', overlay: { llm_model: 'openai/gpt-4o' } },
+  ],
+  per_task: [
+    {
+      task_id: 11,
+      prompt: 'Summarise the on-call handover for this week',
+      category: 'chat',
+      variants: [
+        {
+          variant_id: 1, name: 'current', samples_ok: 1,
+          mean_cost: 0.02, mean_rounds: 2, mean_latency_ms: 1500,
+          delta_cost: 0, delta_rounds: 0, delta_latency_ms: 0,
+        },
+        {
+          variant_id: 2, name: 'openai/gpt-4o', samples_ok: 1,
+          mean_cost: 0.015, mean_rounds: 3, mean_latency_ms: 2500,
+          delta_cost: -0.005, delta_rounds: 1, delta_latency_ms: 1000,
+        },
+      ],
+    },
+  ],
+  completeness: { samples_ok: 2, samples_expected: 2, pairs: 1, pairs_judged: 1 },
+  verdicts: [],
+}
+
+const SAMPLES = [
+  {
+    id: 101, run_id: 7, variant_id: 1, task_id: 11, k_index: 0, status: 'ok',
+    response: 'Current model answer', trace: TRACE, rounds: 2,
+    outcome_suppressed: 1, cost: 0.02, latency_ms: 1500,
+  },
+  {
+    id: 102, run_id: 7, variant_id: 2, task_id: 11, k_index: 0, status: 'ok',
+    response: 'Candidate model answer', trace: TRACE, rounds: 3,
+    outcome_suppressed: 1, cost: 0.015, latency_ms: 2500,
+  },
+]
+
+const PAIRS = {
+  run_id: 7,
+  baseline_variant: 'current',
+  pairs: [
+    {
+      pair_id: 1, task_id: 11, task_prompt: 'Summarise the on-call handover for this week',
+      category: 'chat', k: 0,
+      baseline: { variant_id: 1, variant: 'current', sample_id: 101 },
+      candidate: { variant_id: 2, variant: 'openai/gpt-4o', sample_id: 102 },
+      items: [
+        {
+          item_id: 1, presentation_order: 'AB', status: 'judged',
+          verdicts: [{
+            judge_ident: 'claude-code', winner: 'B', winner_variant: 'openai/gpt-4o',
+            dimensions: { correctness: 'B', tone: 'tie' },
+            notes: 'Candidate followed the persona more closely.',
+            rubric_version: 'v1', created_at: '2026-08-20T10:00:00Z',
+          }],
+        },
+        {
+          item_id: 2, presentation_order: 'BA', status: 'judged',
+          verdicts: [{
+            judge_ident: 'claude-code', winner: 'A', winner_variant: 'openai/gpt-4o',
+            dimensions: { correctness: 'A' }, notes: '', rubric_version: 'v1',
+            created_at: '2026-08-20T10:01:00Z',
+          }],
+        },
+      ],
+      outcome: 'win',
+    },
+  ],
+}
+
+let sampleCalls = 0
+let pairCalls = 0
+
+beforeEach(() => {
+  token.set('test-key')
+  authMode.set('token')
+  sampleCalls = 0
+  pairCalls = 0
+  server.use(
+    http.get('/api/v1/eval/runs/:id/summary', () => HttpResponse.json(SUMMARY)),
+    http.get('/api/v1/eval/runs/:id/samples', () => {
+      sampleCalls++
+      return HttpResponse.json(SAMPLES)
+    }),
+    http.get('/api/v1/eval/runs/:id/pairs', () => {
+      pairCalls++
+      return HttpResponse.json(PAIRS)
+    }),
+  )
+})
+
+async function renderDiffs(props = {}) {
+  const r = render(EvalTaskDiffs, { runId: 7, ...props })
+  await waitFor(() => expect(screen.getByTestId('task-row-11')).toBeInTheDocument())
+  return r
+}
+
+async function expandFirstRow() {
+  await fireEvent.click(screen.getByRole('button', { name: /Show the runs/ }))
+  await waitFor(() => expect(screen.getByTestId('task-detail-11')).toBeInTheDocument())
+  await waitFor(() =>
+    expect(screen.queryByText(/Loading the runs/)).not.toBeInTheDocument())
+}
+
+describe('EvalTaskDiffs — rows', () => {
+  test('fetches its own results when no summary is passed', async () => {
+    await renderDiffs()
+
+    expect(screen.getByText('Summarise the on-call handover for this week')).toBeInTheDocument()
+    expect(screen.getByText('chat')).toBeInTheDocument()
+    // Both models' numbers, in the operator's units.
+    expect(screen.getByText('$0.0200')).toBeInTheDocument()
+    expect(screen.getByText('$0.0150')).toBeInTheDocument()
+    expect(screen.getByText('1.5 s')).toBeInTheDocument()
+    expect(screen.getByText('2.5 s')).toBeInTheDocument()
+  })
+
+  test('uses a passed-in summary without refetching', async () => {
+    let summaryCalls = 0
+    server.use(http.get('/api/v1/eval/runs/:id/summary', () => {
+      summaryCalls++
+      return HttpResponse.json(SUMMARY)
+    }))
+
+    await renderDiffs({ summary: SUMMARY })
+
+    expect(summaryCalls).toBe(0)
+  })
+
+  test('shows deltas on the candidate only, signed by direction', async () => {
+    await renderDiffs()
+
+    // Cheaper is the good direction, slower and more rounds are not.
+    const cheaper = screen.getByText('−0.0050')
+    expect(cheaper).toHaveClass('good')
+    expect(screen.getByText('+1.0')).toHaveClass('bad')
+    expect(screen.getByText('+1.0 s')).toHaveClass('bad')
+    // The baseline row carries no deltas at all.
+    expect(screen.queryByText('±0')).not.toBeInTheDocument()
+  })
+
+  test('names each model and its role in the comparison', async () => {
+    await renderDiffs()
+
+    expect(screen.getByText('current')).toBeInTheDocument()
+    expect(screen.getByText('openai/gpt-4o')).toBeInTheDocument()
+    expect(screen.getByText('Current')).toBeInTheDocument()
+    expect(screen.getByText('Candidate')).toBeInTheDocument()
+  })
+
+  test('says so when the run has no per-test-case results', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/summary', () =>
+      HttpResponse.json({ ...SUMMARY, per_task: [] })))
+
+    render(EvalTaskDiffs, { runId: 7 })
+
+    await waitFor(() =>
+      expect(screen.getByText(/No per-test-case results yet/)).toBeInTheDocument())
+  })
+
+  test('surfaces a failed summary fetch inline', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/summary', () =>
+      HttpResponse.json({ error: 'run not found' }, { status: 404 })))
+
+    render(EvalTaskDiffs, { runId: 7 })
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('run not found'))
+  })
+})
+
+describe('EvalTaskDiffs — expansion', () => {
+  test('fetches nothing heavy until a row is expanded', async () => {
+    await renderDiffs()
+
+    expect(sampleCalls).toBe(0)
+    expect(pairCalls).toBe(0)
+  })
+
+  test('expanding shows both runs side by side with their traces', async () => {
+    await renderDiffs()
+    await expandFirstRow()
+
+    expect(sampleCalls).toBe(1)
+    expect(pairCalls).toBe(1)
+
+    expect(screen.getByText('Current model answer')).toBeInTheDocument()
+    expect(screen.getByText('Candidate model answer')).toBeInTheDocument()
+    // The candidate column is headed by its model, in the table and again on
+    // the transcript.
+    expect(screen.getAllByText('openai/gpt-4o')).toHaveLength(2)
+    // Tool calls came through the adapter, suppressed one included.
+    expect(screen.getAllByText('kv_get')).toHaveLength(2)
+    expect(screen.getAllByText('SUPPRESSED')).toHaveLength(2)
+  })
+
+  test('shows the judge verdict, dimension scores and notes for the pair', async () => {
+    await renderDiffs()
+    await expandFirstRow()
+
+    const judgment = screen.getByTestId('judgment-11-0')
+    expect(judgment).toHaveTextContent('Candidate preferred')
+    expect(judgment).toHaveTextContent('claude-code')
+    expect(judgment).toHaveTextContent('picked openai/gpt-4o')
+    expect(judgment).toHaveTextContent('correctness')
+    expect(judgment).toHaveTextContent('Candidate followed the persona more closely.')
+    expect(judgment).toHaveTextContent('rubric v1')
+  })
+
+  test('says when a comparison is unjudged rather than dead-ending', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/pairs', () => HttpResponse.json({
+      ...PAIRS,
+      pairs: [{ ...PAIRS.pairs[0], items: [], outcome: 'pending' }],
+    })))
+
+    await renderDiffs()
+    await expandFirstRow()
+
+    const judgment = screen.getByTestId('judgment-11-0')
+    expect(judgment).toHaveTextContent('Not judged yet')
+    expect(judgment).toHaveTextContent('Nobody has judged this comparison yet.')
+  })
+
+  test('shows a failed run\'s error instead of an empty transcript', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/samples', () => HttpResponse.json([
+      SAMPLES[0],
+      { ...SAMPLES[1], status: 'failed', error: 'provider timeout', response: '', trace: '' },
+    ])))
+
+    await renderDiffs()
+    await expandFirstRow()
+
+    expect(screen.getByText('openai/gpt-4o failed')).toBeInTheDocument()
+    expect(screen.getByText('provider timeout')).toBeInTheDocument()
+  })
+
+  test('surfaces a failed detail fetch inline and retries on reopen', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/samples', () =>
+      HttpResponse.json({ error: 'samples unavailable' }, { status: 500 })))
+
+    await renderDiffs()
+    await fireEvent.click(screen.getByRole('button', { name: /Show the runs/ }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('samples unavailable'))
+  })
+
+  test('collapses again and does not refetch on the next open', async () => {
+    await renderDiffs()
+    await expandFirstRow()
+
+    await fireEvent.click(screen.getByRole('button', { name: /Hide the runs/ }))
+    await waitFor(() =>
+      expect(screen.queryByTestId('task-detail-11')).not.toBeInTheDocument())
+
+    await expandFirstRow()
+    expect(sampleCalls).toBe(1)
+    expect(pairCalls).toBe(1)
+  })
+})
+
+describe('trace adapter', () => {
+  test('maps a stored trace onto the transcript shape', () => {
+    const calls = evalTraceCalls(TRACE)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]).toEqual({
+      tool: 'kv_get', server: 'kv', round: 1, outcome: 'ok', suppressed: false,
+      duration_ms: 120, arguments: '{"key":"a"}', result: 'value', error: '',
+    })
+  })
+
+  test('marks a suppressed write as suppressed', () => {
+    const [, suppressed] = evalTraceCalls(TRACE)
+
+    expect(suppressed.tool).toBe('telegram_send')
+    expect(suppressed.outcome).toBe('suppressed')
+    expect(suppressed.suppressed).toBe(true)
+    expect(suppressed.duration_ms).toBe(0)
+  })
+
+  test('takes an already-decoded array as well as the stored string', () => {
+    expect(evalTraceCalls(JSON.parse(TRACE))).toEqual(evalTraceCalls(TRACE))
+  })
+
+  test('yields no calls for an absent or unparseable trace', () => {
+    expect(evalTraceCalls('')).toEqual([])
+    expect(evalTraceCalls(undefined)).toEqual([])
+    expect(evalTraceCalls('{not json')).toEqual([])
+  })
+
+  test('moves the sample-level cost and latency onto the transcript', () => {
+    const t = evalSampleTranscript(SAMPLES[1], { model: 'openai/gpt-4o' })
+
+    expect(t.model).toBe('openai/gpt-4o')
+    expect(t.response).toBe('Candidate model answer')
+    expect(t.rounds).toBe(3)
+    expect(t.cost_usd).toBe(0.015)
+    expect(t.duration_ms).toBe(2500)
+    expect(t.suppressed_count).toBe(1)
+    expect(t.tool_calls).toHaveLength(2)
+  })
+
+  test('falls back to counting suppressed calls when the sample has no count', () => {
+    const { outcome_suppressed, ...noCount } = SAMPLES[0]
+
+    expect(evalSampleTranscript(noCount).suppressed_count).toBe(1)
+  })
+})

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -420,7 +420,13 @@ export const handlers = [
   http.post('/api/v1/eval/runs/:id/stop', () => HttpResponse.json({ status: 'stopping' })),
   http.get('/api/v1/eval/runs/:id/summary', () => HttpResponse.json({ variants: [], per_task: [], completeness: {}, verdicts: [] })),
   http.get('/api/v1/eval/runs/:id/samples', () => HttpResponse.json([])),
-  http.get('/api/v1/eval/runs/:id/pairs', () => HttpResponse.json([])),
+  // The whole judging grid, not a bare list — eval.PairView. Empty by default;
+  // tests that need judged pairs override this with their own.
+  http.get('/api/v1/eval/runs/:id/pairs', ({ params }) => HttpResponse.json({
+    run_id: Number(params.id),
+    baseline_variant: 'current',
+    pairs: [],
+  })),
   http.get('/api/v1/eval/suggest', () => HttpResponse.json(evalSuggestions)),
 
   // Setup


### PR DESCRIPTION
Layer 3 of the eval results view: a per-test-case table for one run, expanding inline to the runs behind the numbers.

The component is **not mounted yet** - `web/src/pages/Evals.svelte` is being edited in parallel for the other two layers, and the mount is a two-line change once that lands:

```svelte
<EvalTaskDiffs runId={id} {summary} />
```

## What is here

- `EvalTaskDiffs.svelte` - a row per test case (prompt, category, per-model cost/rounds/latency, candidate deltas), expanding inline to that test case’s runs side by side plus the pair’s judge verdict, dimension scores, and notes.
- `evalTraceCalls` / `evalSampleTranscript` in `api.js` - a sample stores its trace as raw `[]agent.ToolCallRecord` JSON while `DryRunTranscript` renders the dry-run transcript shape, so the mapping lives in one place rather than forking the component (`tool_name`→`tool`, `outcome: "suppressed"`→`suppressed`, sample-level `cost`/`latency_ms`→`cost_usd`/`duration_ms`).
- The `/pairs` MSW mock returned a bare array; the endpoint returns `eval.PairView`.

## Props

| Prop | Meaning |
|---|---|
| `runId` | Required. The run to show. |
| `summary` | Optional. An already-fetched `GET /eval/runs/{id}/summary`; omit and the component fetches its own. |

Samples and pairs are fetched once on the first expansion and shared across rows - they carry whole transcripts, and a run’s worth is not worth loading for a table nobody opens.

## Two fixes found reviewing this against the design

1. **Dimension winners were unreadable.** They are stored as the blinded letter the judge saw, and the pairs endpoint resolves only the overall winner, so the table read `correctness: B`. A non-tie verdict on an item is the key for that item’s letters, so they now resolve to model names; an item everyone judged a tie keeps its letter. The server holds the assignment and should do this properly - #358.
2. **Categories rendered as raw slugs** (`tool_heavy`). Now the same labels `SuggestCases.svelte` uses.

## Flagged, not done here

- #359 - `/samples` has no `task_id` filter, so one expansion pulls every sample in the run.
- #360 - `stop_reason` is never rendered, so a turn cut short looks like a completed one (affects schedule and skill previews too).
- #361 - a sample’s serving upstream is not surfaced.

<details>
<summary>Tests</summary>

21 new tests in `web/src/components/__tests__/EvalTaskDiffs.test.js` covering row rendering with deltas, lazy expansion, the letter resolution and its unresolvable fallback, failed samples, both error paths, and the trace adapter including a suppressed call.

`just test-ui`: 952 passed, 53 files. `just lint-ui`: clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)