### PR TITLE
docs(eval): document the Evals page and complete the llms.txt endpoint list

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ A dry run answers one question once. An eval asks it across a saved set of real 
 
 The **Evals** page in the dashboard drives the loop; everything it does is REST underneath.
 
-**1. Build a test set.** Three fill paths: "Save as test case" from the Chat page's message menu (optionally pinning the preceding turns as context), `GET /api/v1/eval/suggest` for candidates mined from past turns (failed or rejected tool calls, three-plus rounds, top-decile cost, command-triggered skills — stratified across the four categories, not ranked overall), or JSONL import. Sets export and import as JSONL (`GET`/`POST /eval/task-sets/{name}/export|import`), so a curated set can be hand-edited, committed to git, or moved between instances. A test set is an appreciating asset — the next candidate model starts here rather than at a blank page.
+**1. Build a test set.** Three fill paths: "Save as test case" from the Chat page's message menu (optionally pinning the preceding turns as context), **Suggest from history** on the Evals page, which offers past turns worth keeping (failed or rejected tool calls, three-plus rounds, top-decile cost, command-triggered skills — stratified across the four categories, not ranked overall, and backed by `GET /api/v1/eval/suggest`), or JSONL import. Sets export and import as JSONL (`GET`/`POST /eval/task-sets/{name}/export|import`), so a curated set can be hand-edited, committed to git, or moved between instances. A test set is an appreciating asset — the next candidate model starts here rather than at a blank page.
 
 **2. Run it.** Pick the agent, a candidate model, and a test set, then **Quick check** (10 cases sampled, one run each) or **Full eval** (the whole set at `[eval] default_k`). The launcher shows a cost estimate beside the editable cap; `POST /api/v1/eval/estimate` prices it from the tasks' own history where there is telemetry, list price otherwise, and says `unknown` rather than fabricating a number. The same run over curl:
 
@@ -402,9 +402,11 @@ curl -X POST localhost:8080/api/v1/eval/runs \
 
 The run proceeds in the background on the agent's **live** engine — real persona, real skills, real tools — under the same policy dry runs use, so reads happen and writes do not. `sample_tasks` draws a stratified subset server-side and pins the drawn ids on the run, so a task added later cannot retroactively change what it measured.
 
+Leaving the page loses nothing. The run's card shows a status chip, turns done against expected, spend against the cap, and an ETA while it is active, with a Stop button behind a confirmation. `GET /api/v1/eval/runs/{id}` is the authoritative view; the `eval_progress` WebSocket frame only nudges the page to refresh sooner.
+
 Runs are bounded twice, by spend and by rate. Crossing `cost_cap` stops dispatching new samples, lets the in-flight ones finish, and keeps the partial results as `capped` — never a silent truncation. `POST /api/v1/panic` cancels active runs along with everything else, and resume deliberately does not revive them: a panic is not a pause. A sample that fails takes only itself down; the summary says how many of the expected samples landed and calls the run inconclusive below `completeness_floor` rather than reading a verdict off thin data.
 
-**3. Read the scorecard.** `GET /eval/runs/{id}/summary` reports the objective half with no judge involved: per-variant rejected and failed tool-call rates, mean rounds, wrap-up count, cost per task, latency, and per-task deltas against the incumbent.
+**3. Read the scorecard.** `GET /eval/runs/{id}/summary` reports the objective half with no judge involved: per-variant rejected and failed tool-call rates, mean rounds, wrap-up count, cost per task, latency, and per-task deltas against the incumbent. The in-page results panel is still in flight, so for now this is where the scorecard is read; `GET /eval/runs/{id}/pairs` is the matching unblinded view of the judged pairs.
 
 #### Judging — blinded A/B pairs, scored from Claude Code
 

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Leaving the page loses nothing. The run's card shows a status chip, turns done a
 
 Runs are bounded twice, by spend and by rate. Crossing `cost_cap` stops dispatching new samples, lets the in-flight ones finish, and keeps the partial results as `capped` — never a silent truncation. `POST /api/v1/panic` cancels active runs along with everything else, and resume deliberately does not revive them: a panic is not a pause. A sample that fails takes only itself down; the summary says how many of the expected samples landed and calls the run inconclusive below `completeness_floor` rather than reading a verdict off thin data.
 
-**3. Read the scorecard.** `GET /eval/runs/{id}/summary` reports the objective half with no judge involved: per-variant rejected and failed tool-call rates, mean rounds, wrap-up count, cost per task, latency, and per-task deltas against the incumbent. The in-page results panel is still in flight, so for now this is where the scorecard is read; `GET /eval/runs/{id}/pairs` is the matching unblinded view of the judged pairs.
+**3. Read the scorecard.** `GET /eval/runs/{id}/summary` reports the objective half with no judge involved: per-variant rejected and failed tool-call rates, mean rounds, wrap-up count, cost per task, latency, and per-task deltas against the incumbent. The Evals page shows the same thing in three layers — the verdict with its gate table and reason, the scorecard with a completeness line, and a row per test case expanding to the two responses side by side with their tool traces and the judge's call on that pair. An `upgrade` offers **Apply to agent**; a run with pairs still outstanding says so and hands you the command to judge them.
 
 #### Judging — blinded A/B pairs, scored from Claude Code
 

--- a/internal/api/llmstxt.go
+++ b/internal/api/llmstxt.go
@@ -39,10 +39,13 @@ API keys are scoped. Required scopes are noted per endpoint below.
 - GET  /api/v1/approvals               (scope: approvals:read)  Pending tool-call approvals
 - POST /api/v1/approvals/{id}/approve  (scope: approvals:write) Approve a pending tool call
 - POST /api/v1/schedules/{name}/dry-run (scope: schedules:write) Preview a schedule; writes suppressed, nothing persisted
+- POST /api/v1/skills/{name}/dry-run   (scope: skills:write)    Preview a skill as a message, command or scheduled fire
 - GET  /api/v1/eval/task-sets          (scope: eval:read)       Saved eval test sets
 - GET  /api/v1/eval/suggest            (scope: eval:read)       Suggest test cases from past turns, stratified by category
 - POST /api/v1/eval/task-sets/{name}/tasks (scope: eval:write)  Save a test case
 - POST /api/v1/eval/runs               (scope: eval:write)      Compare agent config variants on a test set
+- GET  /api/v1/eval/runs               (scope: eval:read)       List runs with status, progress and spend
+- POST /api/v1/eval/runs/{id}/stop     (scope: eval:write)      Stop a run; finished samples are kept
 - GET  /api/v1/eval/runs/{id}/summary  (scope: eval:read)       Scorecard, gate table and verdict for a run
 - GET  /api/v1/eval/runs/{id}/pairs    (scope: eval:read)       Judged pairs, unblinded: verdicts, dimensions and outcomes
 - POST /api/v1/eval/estimate           (scope: eval:read)       Cost range for a run before starting it

--- a/internal/api/llmstxt_test.go
+++ b/internal/api/llmstxt_test.go
@@ -33,6 +33,8 @@ func TestLLMsTxt_NoAuth(t *testing.T) {
 	for _, want := range []string{
 		"/api/v1/openapi.json",
 		"POST /api/v1/chat",
+		"POST /api/v1/schedules/{name}/dry-run",
+		"POST /api/v1/skills/{name}/dry-run",
 		"# Denkeeper",
 	} {
 		if !strings.Contains(body, want) {
@@ -66,6 +68,9 @@ func TestLLMsTxt_ListsEvalEndpoints(t *testing.T) {
 		"GET  /api/v1/eval/runs/{id}/summary",
 		"POST /api/v1/eval/estimate",
 		"GET  /api/v1/eval/config",
+		"GET  /api/v1/eval/suggest",
+		"GET  /api/v1/eval/runs/{id}/pairs",
+		"POST /api/v1/eval/runs/{id}/stop",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q", want)

--- a/website/content/docs/concepts/evals.md
+++ b/website/content/docs/concepts/evals.md
@@ -98,7 +98,7 @@ claude mcp add --transport http denkeeper https://your-denkeeper/api/v1/mcp \
   --header "Authorization: Bearer $DENKEEPER_JUDGE_KEY"
 ```
 
-The rubric lives in the repo at `.claude/skills/judge-eval/SKILL.md`, where it can be read and edited: four dimensions in priority order — `task_success`, `tool_path`, `persona_fit`, `length` — with instructions to cite the specific persona or skill clause behind any deduction. Unknown dimension names are rejected rather than stored, because a typo that silently vanishes from the results is worse than a failed call.
+The rubric lives in the repo at `.claude/skills/judge-eval/SKILL.md`, where it can be read and edited: four dimensions in priority order — `task_success`, `tool_path`, `persona_fit`, `length` — with instructions to cite the specific persona or skill clause behind any deduction. Unknown dimension names are rejected rather than stored, because a typo that silently vanishes from the results is worse than a failed call. A verdict records the rubric version the judge worked to, and the summary reports the distinct set it saw, so a queue worked across a rubric edit says so instead of averaging two rubrics into one number.
 
 {{< callout context="note" >}}
 **Calibrate a new rubric before trusting it headless.** Judge a random ~20-item subset yourself and record your own call alongside the judge's (`judge_ident: "operator"`). Operator marks sit beside the judge's rather than replacing it, are excluded from the win rate, and feed only the agreement figure `eval_summary` reports. Below roughly 80 % agreement, fix the rubric first — a drifted rubric quietly devalues every later run.

--- a/website/content/docs/concepts/evals.md
+++ b/website/content/docs/concepts/evals.md
@@ -35,7 +35,7 @@ Pinned history is captured at save time rather than re-read from the source conv
 There are three fill paths:
 
 - **Save as test case** in the Chat page's message menu, optionally pinning the preceding turns.
-- **Suggest from history** — `GET /api/v1/eval/suggest` mines past turns for ones worth saving: any rejected or failed tool call, three or more tool rounds, a reply cost in the pool's top decile, or a command-triggered skill. Candidates come back **stratified across the four categories** rather than ranked overall, because a set drawn purely by interestingness would be all failures and would represent nothing the agent normally does. Turns already saved as a task are skipped. Nothing is written — accepting a candidate is a separate call.
+- **Suggest from history** on the Evals page (`GET /api/v1/eval/suggest`) mines past turns for ones worth saving: any rejected or failed tool call, three or more tool rounds, a reply cost in the pool's top decile, or a command-triggered skill. Candidates come back **stratified across the four categories** rather than ranked overall, because a set drawn purely by interestingness would be all failures and would represent nothing the agent normally does. Turns already saved as a task are skipped. Nothing is written — accepting a candidate is a separate call.
 - **Import JSONL** — `POST /api/v1/eval/task-sets/{name}/import`, one case per line, all-or-none so a typo halfway down leaves the set untouched. `GET .../export` is the other half, so a curated set can be hand-edited or committed to git.
 
 A test set is an appreciating asset: the next candidate model starts here rather than at a blank page.
@@ -132,14 +132,35 @@ upgrade: judge win-rate 62% over 45 judged pair(s) meets the 55% threshold, and 
 
 ## In the dashboard
 
-The **Evals** page carries the loop as far as it has shipped: an empty state that explains it, an inline JSONL importer, a launcher, and the run list.
+The **Evals** page drives the loop, and everything it does is REST underneath — see the [REST API reference](/docs/reference/rest-api/) for the request and response shapes.
 
-The launcher is the simple case — "compare current vs candidate on a test set": pick the agent (its current model is shown), pick a candidate model with its pricing, pick a test set, then choose **Quick check** (10 cases, one run each) or **Full eval** (the whole set at `[eval] default_k`). The cost cap is editable and sits next to the live estimate, so it is never a mystery whether you are about to spend $0.10 or $2.
+With no test set saved yet, the page opens on an empty state that explains the loop and offers the two ways in: **Suggest from history**, or an inline JSONL import.
 
-Each run shows a status chip, a progress bar of turns done against expected, spend against the cap, an ETA while active, and a Stop button behind a confirm. Progress is polled and nudged by the `eval_progress` WebSocket frame, which is a droppable convenience — `GET /api/v1/eval/runs/{id}` is the authoritative view. Leaving the page loses nothing; a run continues in the background.
+### Filling a set from history
+
+**Suggest from history** opens a panel of past turns worth keeping, each card carrying the prompt, its category, and the reason it was offered — a tool call was rejected or failed, the turn took three or more rounds, it cost in the top ten per cent, or a skill command triggered it. Select the ones you want, choose an existing set or name a new one, and add them in a batch.
+
+Accepting a candidate writes the same shape the Chat page's "Save as test case" does, pinned history included, captured at that moment rather than re-read at run time. Rejecting a candidate writes nothing at all: it is hidden for the session, so reloading the page offers it again.
+
+### Launching a run
+
+The launcher covers the common case — "compare current against a candidate on a test set". Pick the agent, and its current model is shown beside it; pick a candidate model, with its pricing; pick a test set; then choose one of two presets:
+
+| Preset | What it runs |
+|---|---|
+| **Quick check** | 10 test cases sampled, one run each — the cheap first signal |
+| **Full eval** | The whole set at `[eval] default_k` runs per case |
+
+The cost cap is editable and sits next to a live estimate that updates as you change the shape of the run, so it is never a mystery whether you are about to spend ten cents or two dollars. When a run cannot be priced, the estimate says so rather than guessing, and the cap is shown alone.
+
+### Watching a run
+
+Each run gets a card with a status chip, a progress bar of turns done against expected, spend against the cap, an ETA while it is active, and a Stop button behind a confirmation dialogue that spells out what stopping keeps.
+
+Progress is polled, and the `eval_progress` WebSocket frame nudges the page to refresh sooner. The frame is a droppable convenience: `GET /api/v1/eval/runs/{id}` is the authoritative view, and if progress readings stop arriving the card says it is showing the last reading rather than freezing on a stale number. Leaving the page loses nothing — a run continues in the background, and stopping one keeps the work already finished.
 
 {{< callout context="caution" >}}
-The in-page results view is still in flight. Today the run card's **Results** panel is a placeholder: read the scorecard and verdict through `GET /api/v1/eval/runs/{id}/summary` and the judged pairs through `GET /api/v1/eval/runs/{id}/pairs`. The suggest-from-history cards are likewise API-only for now (`GET /api/v1/eval/suggest`).
+The in-page results view is still in flight. Expanding a run's **Results** panel today shows a placeholder: read the scorecard and verdict through `GET /api/v1/eval/runs/{id}/summary`, and the judged pairs through `GET /api/v1/eval/runs/{id}/pairs`.
 {{< /callout >}}
 
 ## Configuration

--- a/website/content/docs/concepts/evals.md
+++ b/website/content/docs/concepts/evals.md
@@ -159,9 +159,19 @@ Each run gets a card with a status chip, a progress bar of turns done against ex
 
 Progress is polled, and the `eval_progress` WebSocket frame nudges the page to refresh sooner. The frame is a droppable convenience: `GET /api/v1/eval/runs/{id}` is the authoritative view, and if progress readings stop arriving the card says it is showing the last reading rather than freezing on a stale number. Leaving the page loses nothing — a run continues in the background, and stopping one keeps the work already finished.
 
-{{< callout context="caution" >}}
-The in-page results view is still in flight. Expanding a run's **Results** panel today shows a placeholder: read the scorecard and verdict through `GET /api/v1/eval/runs/{id}/summary`, and the judged pairs through `GET /api/v1/eval/runs/{id}/pairs`.
-{{< /callout >}}
+### Reading the results
+
+Expanding a finished run's **Results** panel lays the evidence out in the three layers the decision rule uses.
+
+**The verdict, with its work.** One block per candidate: the label, the one-line reason, the divergence note when a candidate wins overall while regressing on a category, the gate table with each gate's value, delta, threshold, and pass mark, the judgment tally against the win threshold, the rubric versions the counted verdicts were made under, and the per-category breakdown. Never a bare label.
+
+When the objective half is in but the pairs are not all judged, the block says how many are outstanding, states plainly that the verdict rests on the objective checks alone until they are, and gives the next step: the `/judge-eval` invocation, or a copyable `claude -p` command, with a reminder to use a key scoped to `eval:read` and `eval:write` and nothing else. A run cannot silently dead-end.
+
+An `upgrade` offers **Apply to agent**, which switches the base agent's model through `PATCH /api/v1/agents/{name}` behind a confirmation naming the agent and both models. A quick check that cleared its gates offers to set up the full eval instead, pre-filled with the same candidate and test set.
+
+**The scorecard.** Each variant is a column, the objective metrics are rows, and a completeness line underneath reports turns finished, comparisons judged, and whether that clears the floor.
+
+**Test case by test case.** Every test case is a row with each variant's cost, rounds, and latency; expanding one puts the responses side by side with their tool traces and the judge's verdict for that pair, its per-dimension winners, notes, and rubric version.
 
 ## Configuration
 

--- a/website/content/docs/guides/web-dashboard.md
+++ b/website/content/docs/guides/web-dashboard.md
@@ -39,7 +39,7 @@ See [First Run](/docs/getting-started/first-run/) for the full flow, and [Securi
 | **Tools** | MCP servers: health, enable/disable, restart, OAuth |
 | **Browser** | Browser profiles and active sessions |
 | **Approvals** | Pending approvals and auto-approve rules |
-| **Evals** | Compare a candidate model against your current one on saved test cases |
+| **Evals** | Compare a candidate model against your current one on saved test cases ([Evals](/docs/concepts/evals/)) |
 | **Audit Log** | Filterable event history |
 | **Costs** | Spend by agent, model, and time range |
 | **KV** | Inspect and edit the agent key-value store |

--- a/website/content/docs/reference/rest-api.md
+++ b/website/content/docs/reference/rest-api.md
@@ -529,7 +529,7 @@ Cancel an active run. In-flight calls die on the context, queued samples never s
 
 **Scope:** `eval:read`
 
-The objective scorecard. Rates are tool-call level with cached and suppressed calls excluded, because nothing executed in either case. A run below `[eval] completeness_floor` still reports its numbers but is flagged inconclusive.
+The objective scorecard. Rates are tool-call level with cached and suppressed calls excluded, because nothing executed in either case. A run below `[eval] completeness_floor` still reports its numbers but is flagged inconclusive. The judgment block carries the win rate against its threshold, the operator agreement figure when calibration marks exist, and `rubric_versions`, the distinct set of rubric revisions the counted verdicts were made under.
 
 ### `GET /api/v1/eval/runs/{id}/pairs`
 


### PR DESCRIPTION
Stage D4: docs and API-surface polish for the eval subsystem. Docs-only apart from three lines added to `llms.txt` and their test assertions.

## What changed

1. **README** - the Evals section names the **Suggest from history** panel as a fill path, describes run monitoring and Stop, and describes the shipped results view (three layers, Apply to agent, judgment-pending next step).
2. **`internal/api/llmstxt.go`** - `estimate`, `suggest`, `pairs`, and `config` were already listed; added the three missing since Stage C: `POST /skills/{name}/dry-run`, `GET /eval/runs`, `POST /eval/runs/{id}/stop`. Test assertions extended to match.
3. **`website/content/docs/concepts/evals.md`** - "In the dashboard" rewritten into per-stage sections (empty state, filling a set from history, launching a run, watching a run, reading the results). Extended rather than a new page: the site runs one concept page per subsystem, and the UI is one section of that loop.
4. **`guides/web-dashboard.md`** - the Evals row links to the concept page.
5. **Rubric version** - D0.5 stores it on each verdict and the distinct set on the summary, but only the pairs reference entry mentioned it. Documented in the concept page and the summary endpoint entry.

`just openapi-check` exits 0 - no annotated handler was touched, so the spec is unchanged.

## Notes for the reviewer

- `web/src/pages/Evals.svelte` and `web/src/api.js` are untouched - other stations own them.
- Merged `origin/main` mid-branch after #356 landed, which is why the results docs describe the shipped view rather than a placeholder.
- `ui-reviewer` pass from the D4 checklist is **not** done here: it would have to run against files two other stations are editing. Worth running once those land.
- Carry-forward one-liners checked, no action needed: the `DryRunPanel` pricing-field bug is already fixed (reads `input_per_mtok`/`output_per_mtok`, test mocks the real shape), and the audit drop counter was measured unnecessary at Stage B.

<details>
<summary>Verification</summary>

- `just openapi-check` - exit 0, spec unchanged
- `just lint` - 0 issues
- `just test` - no failures
- `just test-ui` - 53 files, 954 tests passed
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)