### PR TITLE
fix(eval): harden the results view's naming, confirm and Quick-check signal

### DIFF
--- a/web/src/__tests__/pages/Evals.test.js
+++ b/web/src/__tests__/pages/Evals.test.js
@@ -440,6 +440,40 @@ describe('Evals page — results panel', () => {
     await waitFor(() =>
       expect(screen.getByTestId('preset-hint')).toHaveTextContent(/All \d+ cases/))
   })
+
+  test('a Quick check over a whole small set still earns the CTA', async () => {
+    // The set has 8 cases and the Quick check drew all 8, so the counts match
+    // and only the pinned task list can tell this apart from a Full eval.
+    server.use(
+      http.get('/api/v1/eval/runs/:id', ({ params }) => {
+        const run = evalRuns.find(r => String(r.id) === params.id)
+        return run
+          ? HttpResponse.json({ ...run, task_set_id: 2, task_count: 8, task_ids: [1, 2, 3, 4, 5, 6, 7, 8] })
+          : new HttpResponse(null, { status: 404 })
+      }),
+    )
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('results-2'))
+    await waitFor(() => expect(screen.getByTestId('escalate-4')).toBeInTheDocument())
+  })
+
+  test('a whole-set run is not mistaken for a Quick check', async () => {
+    server.use(
+      http.get('/api/v1/eval/runs/:id', ({ params }) => {
+        const run = evalRuns.find(r => String(r.id) === params.id)
+        // No task_ids: the server did not draw a subset.
+        return run ? HttpResponse.json({ ...run, task_count: 37 }) : new HttpResponse(null, { status: 404 })
+      }),
+    )
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('results-2'))
+    await waitFor(() => expect(screen.getByTestId('verdict-4')).toBeInTheDocument())
+    expect(screen.queryByTestId('escalate-4')).not.toBeInTheDocument()
+  })
 })
 
 describe('Evals page — suggestions', () => {

--- a/web/src/components/EvalResults.svelte
+++ b/web/src/components/EvalResults.svelte
@@ -126,7 +126,8 @@
 
   /** A clean Quick check is worth escalating; a failed gate is not. */
   function canEscalate(verdict) {
-    return quick && (verdict.gates || []).every(g => g.pass) && verdict.verdict !== 'downgrade'
+    return quick && !!modelOf(verdict)
+      && (verdict.gates || []).every(g => g.pass) && verdict.verdict !== 'downgrade'
   }
 
   let judgeCommand = $derived(`claude -p "judge pending pairs for eval run ${run?.id}"`)
@@ -211,13 +212,28 @@
     return variant.overlay?.llm_model || variant.name
   }
 
+  /**
+   * Variant names are free text chosen by whoever created the run, so a run
+   * started over the API or MCP can be called `variant-a` or `sample-2`. The
+   * model the variant actually ran is the honest label, and the only one this
+   * page's terminology rule allows; the raw name is the last resort.
+   */
+  function displayName(variantName) {
+    return metricsFor(variantName)?.overlay?.llm_model || variantName
+  }
+
+  /** A variant with no model in its overlay is nothing the agent can switch to. */
+  function modelOf(verdict) {
+    return metricsFor(verdict.variant)?.overlay?.llm_model || ''
+  }
+
   function askApply(verdict) {
     applyError = ''
     applyOk = ''
     const m = metricsFor(verdict.variant)
     confirmApply = {
       variant: verdict.variant,
-      model: m?.overlay?.llm_model || verdict.variant,
+      model: modelOf(verdict),
       provider: m?.overlay?.llm_provider || '',
     }
   }
@@ -245,7 +261,7 @@
   function escalate(verdict) {
     const m = metricsFor(verdict.variant)
     onrunfull({
-      model: m?.overlay?.llm_model || verdict.variant,
+      model: modelOf(verdict),
       provider: m?.overlay?.llm_provider || '',
       taskSet: summary?.task_set || '',
     })
@@ -279,7 +295,7 @@
       <header class="verdict-head">
         <span class="verdict-label" data-testid="verdict-label-{v.variant_id}">{verdictLabel(v.verdict)}</span>
         <span class="verdict-sub">
-          <span class="mono">{v.variant}</span> against your current model
+          <span class="mono">{displayName(v.variant)}</span> against your current model
           {#if agent?.model}<span class="mono">({agent.model})</span>{/if}
         </span>
       </header>
@@ -312,6 +328,7 @@
       <h3 class="block-title">Objective checks</h3>
       <div class="table-wrapper">
         <table class="table" data-testid="gates-{v.variant_id}">
+          <caption class="sr-only">Objective checks for {displayName(v.variant)}</caption>
           <thead>
             <tr>
               <th>Check</th>
@@ -375,6 +392,7 @@
         <h3 class="block-title">By kind of test case</h3>
         <div class="table-wrapper">
           <table class="table" data-testid="categories-{v.variant_id}">
+            <caption class="sr-only">Per-category results for {displayName(v.variant)}</caption>
             <thead>
               <tr>
                 <th>Kind</th>
@@ -406,12 +424,42 @@
         </div>
       {/if}
 
+      <!-- Inline, not an overlay: this is a reversible config write, and the
+           gate table above it is the evidence for the decision. The house rule
+           is overlay for irreversible actions only (Stop run), inline here. -->
+      {#if confirmApply?.variant === v.variant}
+        <div class="apply-confirm" data-testid="apply-confirm">
+          <span>
+            Switch <strong>{run.base_agent}</strong> from
+            <span class="mono">{agent?.model || 'its current model'}</span> to
+            <span class="mono">{confirmApply.model}</span>{#if confirmApply.provider}
+              on <span class="mono">{confirmApply.provider}</span>{/if}?
+          </span>
+          <p class="hint">Every new conversation on this agent uses it from then on.</p>
+          {#if applyError}
+            <div class="inline-error" role="alert" data-testid="apply-error">{applyError}</div>
+          {/if}
+          <div class="confirm-actions">
+            <button class="btn-primary" onclick={doApply} disabled={applying}
+              data-testid="apply-confirm-btn" use:focusOnMount>
+              {applying ? 'Applying…' : 'Switch model'}
+            </button>
+            <button class="btn-ghost" onclick={() => confirmApply = null} disabled={applying}>Cancel</button>
+          </div>
+        </div>
+      {/if}
+
       <div class="verdict-actions">
         {#if v.verdict === 'upgrade'}
           <button class="btn-primary" onclick={() => askApply(v)}
-            disabled={appliedVariant === v.variant} data-testid="apply-{v.variant_id}">
+            disabled={appliedVariant === v.variant || !modelOf(v)} data-testid="apply-{v.variant_id}">
             {appliedVariant === v.variant ? 'Applied' : `Apply to ${run.base_agent}`}
           </button>
+          {#if !modelOf(v)}
+            <span class="hint" data-testid="apply-blocker-{v.variant_id}">
+              This run did not record a model to switch to.
+            </span>
+          {/if}
         {/if}
         {#if canEscalate(v)}
           <button class="btn-ghost" onclick={() => escalate(v)} data-testid="escalate-{v.variant_id}">
@@ -638,35 +686,35 @@
   {/if}
 {/if}
 
-{#if confirmApply}
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div class="overlay" onclick={(e) => { if (e.target === e.currentTarget) confirmApply = null }}
-    onkeydown={(e) => { if (e.key === 'Escape') confirmApply = null }}
-    role="dialog" aria-modal="true" aria-labelledby="apply-title"
-    tabindex="-1" use:focusOnMount>
-    <div class="confirm-modal" data-testid="apply-confirm">
-      <h2 id="apply-title">Switch model</h2>
-      <p>
-        Switch <strong>{run.base_agent}</strong> from
-        <span class="mono">{agent?.model || 'its current model'}</span> to
-        <span class="mono">{confirmApply.model}</span>{#if confirmApply.provider}
-          on <span class="mono">{confirmApply.provider}</span>{/if}? Every new conversation on this
-        agent uses it from then on.
-      </p>
-      {#if applyError}
-        <div class="inline-error" role="alert" data-testid="apply-error">{applyError}</div>
-      {/if}
-      <div class="modal-actions">
-        <button class="btn-primary" onclick={doApply} disabled={applying} data-testid="apply-confirm-btn">
-          {applying ? 'Applying…' : 'Switch model'}
-        </button>
-        <button class="btn-ghost" onclick={() => confirmApply = null} disabled={applying}>Cancel</button>
-      </div>
-    </div>
-  </div>
-{/if}
-
 <style>
+  .apply-confirm {
+    margin: 10px 0;
+    padding: 10px;
+    background: color-mix(in srgb, var(--accent) 5%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+    border-radius: var(--radius);
+    font-size: 13px;
+  }
+  .apply-confirm .hint { margin-top: 2px; }
+  .confirm-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
   .block-title {
     font-size: 11px;
     font-weight: 500;

--- a/web/src/components/__tests__/EvalResults.test.js
+++ b/web/src/components/__tests__/EvalResults.test.js
@@ -358,6 +358,105 @@ describe('EvalResults — apply to agent', () => {
   })
 })
 
+describe('EvalResults — variant naming', () => {
+  /** A run created over the API or MCP, whose variants carry arbitrary names. */
+  function apiNamedRun() {
+    withSummary({
+      baseline_variant: 'baseline',
+      variants: [
+        { ...evalSummary.variants[0], name: 'baseline' },
+        { ...evalSummary.variants[1], name: 'variant-a' },
+      ],
+      verdicts: [{ ...evalSummary.verdicts[0], variant: 'variant-a', baseline: 'baseline' }],
+    })
+  }
+
+  test('names the model a variant ran, never the raw variant name', async () => {
+    apiNamedRun()
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('verdict-4')).toBeInTheDocument())
+    expect(screen.getByTestId('verdict-4')).toHaveTextContent('anthropic/claude-3-opus')
+    expect(screen.getByTestId('verdict-4').textContent).not.toContain('variant-a')
+  })
+
+  test('applying sends the model, not the variant name', async () => {
+    let patched = null
+    apiNamedRun()
+    server.use(
+      http.patch('/api/v1/agents/:name', async ({ request }) => {
+        patched = await request.json()
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('apply-4')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('apply-4'))
+    await fireEvent.click(await screen.findByTestId('apply-confirm-btn'))
+
+    await waitFor(() => expect(patched).not.toBeNull())
+    expect(patched.llm_model).toBe('anthropic/claude-3-opus')
+  })
+
+  test('a variant with no model behind it cannot be applied', async () => {
+    withSummary({
+      variants: [evalSummary.variants[0], { ...evalSummary.variants[1], overlay: {} }],
+    })
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('apply-4')).toBeInTheDocument())
+    expect(screen.getByTestId('apply-4')).toBeDisabled()
+    expect(screen.getByTestId('apply-blocker-4')).toHaveTextContent('did not record a model')
+  })
+
+  test('nor escalated to a full eval', async () => {
+    withSummary({
+      variants: [evalSummary.variants[0], { ...evalSummary.variants[1], overlay: {} }],
+    })
+    render(EvalResults, { props: { run: RUN, agent: AGENT, quick: true } })
+
+    await waitFor(() => expect(screen.getByTestId('verdict-4')).toBeInTheDocument())
+    expect(screen.queryByTestId('escalate-4')).not.toBeInTheDocument()
+  })
+})
+
+describe('EvalResults — apply confirm placement', () => {
+  test('confirms inline, leaving the gate table on screen', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('apply-4')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('apply-4'))
+
+    await waitFor(() => expect(screen.getByTestId('apply-confirm')).toBeInTheDocument())
+    // The evidence for the decision must stay visible while it is made.
+    expect(document.querySelector('.overlay')).toBeNull()
+    expect(screen.getByTestId('gates-4')).toBeVisible()
+  })
+
+  test('the confirm sits in the verdict it belongs to', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('apply-4')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('apply-4'))
+
+    const confirm = await screen.findByTestId('apply-confirm')
+    expect(screen.getByTestId('verdict-4')).toContainElement(confirm)
+  })
+})
+
+describe('EvalResults — accessible tables', () => {
+  test('the gate and category tables carry captions', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('gates-4')).toBeInTheDocument())
+    expect(screen.getByTestId('gates-4').querySelector('caption'))
+      .toHaveTextContent('Objective checks for anthropic/claude-3-opus')
+    expect(screen.getByTestId('categories-4').querySelector('caption'))
+      .toHaveTextContent('Per-category results for anthropic/claude-3-opus')
+  })
+})
+
 describe('evalSampleTranscript', () => {
   test('maps a sample onto the dry-run transcript shape', () => {
     const t = evalSampleTranscript(evalSamples[0], 'kimi-k2.6')

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -114,6 +114,18 @@
     return taskSets.find(t => t.id === id)?.name || `#${id}`
   }
 
+  /**
+   * A Quick check drew a subset of the set. task_ids is the authoritative
+   * signal — the server records the drawn ids and leaves it unset for a whole-
+   * set run — so a Quick check over a set of ten or fewer cases is still
+   * recognised, which the count comparison alone misses. The comparison stays
+   * as the fallback for runs created before the ids were pinned.
+   */
+  function isQuickCheck(run, setCases) {
+    if (Array.isArray(run.task_ids)) return run.task_ids.length > 0
+    return run.task_count != null && setCases != null && run.task_count < setCases
+  }
+
   /** Total cases in the run's set, when that set is still around to ask. */
   function setTotal(id) {
     return taskSets.find(t => t.id === id)?.task_count ?? null
@@ -669,7 +681,7 @@
           <div class="results-panel" id="results-panel-{run.id}" data-testid="results-panel-{run.id}">
             <EvalResults {run}
               agent={agents.find(a => a.name === run.base_agent) || null}
-              quick={run.task_count != null && setCases != null && run.task_count < setCases}
+              quick={isQuickCheck(run, setCases)}
               onapplied={reloadAgents}
               onrunfull={runFull} />
           </div>


### PR DESCRIPTION
Four follow-ups on #356, found reviewing the same surface. Additive - no behaviour from that PR is removed.

## What to review

1. **Variant names could reach the user, and the API.** Variant names are free text (`evalRunInput` accepts any unique non-empty name), so a run created over REST or MCP renders `variant-a` where §6's terminology rule wants a model id. One `displayName()` helper resolves through the overlay for every render site.

   The sharper half: `askApply` and `escalate` both fell back to `|| verdict.variant`, so a variant carrying no `llm_model` would send that name as the `llm_model` in `PATCH /agents/{name}`, or into the launcher's candidate field. Neither action is offered now unless the overlay records a model, and the disabled Apply says why.

2. **Apply to agent confirms inline** instead of in an overlay. It is a reversible config write, and `.overlay` is `position: fixed`, so it covers the gate table that is the evidence for the decision. The house split is overlay for irreversible actions - `Schedules.svelte:480`, and Stop run, which keeps its overlay - and inline for the rest (`Providers.svelte:478`, `Agents.svelte:670`). The confirm renders inside the verdict it belongs to.

3. **Quick check is identified by the pinned task list.** `run.task_count < setCases` misses a Quick check over a set of ten or fewer cases: the draw covers the whole set, the counts match, and the escalation CTA never appears. `eval_runs.task_ids` is set only when the server drew a subset, which answers the question directly. The count comparison stays as the fallback for runs predating the pin.

4. **Gate and category tables gain captions**, so a screen reader meets them with a subject.

## Testing

`just test-ui` - 963 pass, 9 added. `just check` clean.

## Not here

The `.sr-only` / `.table-wrap` / `.inline-error` / `.section-title` duplication this touches the edge of is codebase-wide and filed as #357, along with keyboard-reachable scroll regions and documenting the confirm-pattern rule in `shared.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fu3N2A3g4JGoiok3u6AeHf
