### PR TITLE
fix(eval): unblind dimension letters, label kinds, show latency

### DIFF
--- a/web/src/components/EvalResults.svelte
+++ b/web/src/components/EvalResults.svelte
@@ -55,6 +55,15 @@
     mean_cost_per_task: 'Cost per test case',
   }
 
+  // Categories are stored as slugs; SuggestCases.svelte labels them the same
+  // way, and the two lists have to agree.
+  const CATEGORY_LABEL = {
+    chat: 'Chat / persona',
+    skill_command: 'Skill command',
+    scheduled: 'Scheduled',
+    tool_heavy: 'Tool-heavy',
+  }
+
   const OUTCOME_LABEL = {
     win: 'candidate won',
     loss: 'current won',
@@ -91,6 +100,11 @@
     return v.toFixed(digits)
   }
 
+  /** A signed plain number, for delta cells with no unit of their own. */
+  function fmtSignedNum(v, digits = 2) {
+    return `${v > 0 ? '+' : ''}${v.toFixed(digits)}`
+  }
+
   function fmtMs(ms) {
     if (!ms) return '—'
     return ms >= 1000 ? `${(ms / 1000).toFixed(1)} s` : `${Math.round(ms)} ms`
@@ -112,6 +126,10 @@
 
   function verdictLabel(v) {
     return VERDICT_LABEL[v] || v
+  }
+
+  function categoryLabel(c) {
+    return CATEGORY_LABEL[c] || c || '—'
   }
 
   /** The candidate's own metrics row, for the objective table's ordering. */
@@ -202,7 +220,41 @@
 
   /** Judge calls only — the operator's calibration marks are shown apart. */
   function judgeVerdicts(pair) {
-    return (pair?.items || []).flatMap(it => (it.verdicts || []).map(v => ({ ...v, order: it.presentation_order })))
+    return (pair?.items || []).flatMap(it => {
+      const key = letterKey(it, pair)
+      return (it.verdicts || []).map(v => ({ ...v, order: it.presentation_order, key }))
+    })
+  }
+
+  // A judge names a presented letter, and only the pair's assignment — which
+  // never leaves the server — says which model that letter was. The pairs
+  // endpoint resolves the overall winner but leaves the per-dimension letters
+  // raw, so an unresolved "persona_fit: b" names nothing the reader can act
+  // on. A non-tie verdict on an item is itself the key for that item's
+  // letters: its winner letter is its winner_variant, so the other letter is
+  // the other side of the pair. An item everyone judged a tie stays
+  // unresolvable and keeps its letter.
+  function letterKey(item, pair) {
+    for (const v of item.verdicts || []) {
+      if (!v.winner_variant || !v.winner) continue
+      const won = v.winner.toLowerCase()
+      if (won !== 'a' && won !== 'b') continue
+      const other = v.winner_variant === pair.candidate?.variant
+        ? pair.baseline?.variant
+        : pair.candidate?.variant
+      return won === 'a'
+        ? { a: v.winner_variant, b: other }
+        : { a: other, b: v.winner_variant }
+    }
+    return null
+  }
+
+  /** One dimension's winner, as a model name where the letter resolves. */
+  function dimensionWinner(value, key) {
+    const v = (value || '').toLowerCase()
+    if (v === 'tie') return 'tie'
+    if (key && (v === 'a' || v === 'b')) return key[v] || value
+    return value
   }
 
   /** The model behind a variant, for the transcript header. */
@@ -390,7 +442,7 @@
               {#each v.categories as c (c.category)}
                 <tr class:failed={c.regressed}>
                   <td>
-                    {c.category}
+                    {categoryLabel(c.category)}
                     {#if c.regressed}<span class="flag" data-testid="regressed-{c.category}">regressed</span>{/if}
                   </td>
                   <td>{c.judged_pairs}</td>
@@ -529,17 +581,33 @@
                   </span>
                 </td>
                 <td class="prompt-cell">{shortPrompt(t.prompt)}</td>
-                <td>{t.category}</td>
+                <td>{categoryLabel(t.category)}</td>
                 {#each variants as v (v.variant_id)}
                   {@const cell = (t.variants || []).find(c => c.variant_id === v.variant_id)}
                   <td>
                     {#if cell}
-                      {fmtUSD(cell.mean_cost)} · {fmtNum(cell.mean_rounds, 1)} rounds
+                      {fmtUSD(cell.mean_cost)}
                       {#if v.name !== baselineName && cell.delta_cost}
                         <span class="delta" class:worse={cell.delta_cost > 0}>
                           {fmtCostDelta(cell.delta_cost)}
                         </span>
                       {/if}
+                      <span class="cell-line">
+                        {fmtNum(cell.mean_rounds, 1)} rounds
+                        {#if v.name !== baselineName && cell.delta_rounds}
+                          <span class="delta" class:worse={cell.delta_rounds > 0}>
+                            {fmtSignedNum(cell.delta_rounds, 1)}
+                          </span>
+                        {/if}
+                      </span>
+                      <span class="cell-line">
+                        {fmtMs(cell.mean_latency_ms)}
+                        {#if v.name !== baselineName && cell.delta_latency_ms}
+                          <span class="delta" class:worse={cell.delta_latency_ms > 0}>
+                            {cell.delta_latency_ms > 0 ? '+' : '-'}{fmtMs(Math.abs(cell.delta_latency_ms))}
+                          </span>
+                        {/if}
+                      </span>
                     {:else}
                       —
                     {/if}
@@ -605,7 +673,7 @@
                                   {#if jv.dimensions}
                                     <ul class="dimensions">
                                       {#each Object.entries(jv.dimensions) as [dim, who] (dim)}
-                                        <li><span class="dim">{dim}</span>: {who}</li>
+                                        <li><span class="dim">{dim}</span>: {dimensionWinner(who, jv.key)}</li>
                                       {/each}
                                     </ul>
                                   {/if}
@@ -756,6 +824,9 @@
 
   /* Per-task diffs */
   .prompt-cell { max-width: 380px; overflow-wrap: anywhere; }
+  /* Rounds and latency sit under the cost, so a cell reads as three lines
+     rather than one run-on string. */
+  .cell-line { display: block; font-size: 11px; color: var(--text-muted); }
   .delta { color: var(--success); margin-left: 6px; font-size: 11px; }
   .delta.worse { color: var(--warn); }
   .detail-row td { background: var(--surface); }

--- a/web/src/components/__tests__/EvalResults.test.js
+++ b/web/src/components/__tests__/EvalResults.test.js
@@ -55,9 +55,11 @@ describe('EvalResults — verdict banner', () => {
     expect(screen.getByTestId('agreement-4')).toHaveTextContent('4 of 5 spot checks')
     expect(screen.getByTestId('rubric-4')).toHaveTextContent('Rubric v1')
 
+    // Categories are labelled, not shown as their stored slugs.
     const cats = screen.getByTestId('categories-4')
-    expect(cats).toHaveTextContent('tool_heavy')
-    expect(cats).toHaveTextContent('chat')
+    expect(cats).toHaveTextContent('Tool-heavy')
+    expect(cats).toHaveTextContent('Chat / persona')
+    expect(cats).not.toHaveTextContent('tool_heavy')
   })
 
   test('flags a failed gate and a regressed category, and appends divergence', async () => {
@@ -288,6 +290,75 @@ describe('EvalResults — per-task diffs', () => {
 
     await fireEvent.click(screen.getByTestId('turns-retry'))
     await waitFor(() => expect(screen.getByTestId('turn-11-0')).toBeInTheDocument())
+  })
+
+  test('a row carries cost, rounds and latency, each with its own delta', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    const row = await screen.findByTestId('task-row-11')
+    // Current: $0.02, 3 rounds, 5 s. Candidate: cheaper, a round shorter,
+    // 900 ms faster — all three deltas signed against the current model.
+    expect(row).toHaveTextContent('3.0 rounds')
+    expect(row).toHaveTextContent('5.0 s')
+    expect(row).toHaveTextContent('2.0 rounds')
+    expect(row).toHaveTextContent('4.1 s')
+    expect(row).toHaveTextContent('-1.0')
+    expect(row).toHaveTextContent('-900 ms')
+  })
+
+  test('labels the test case kind rather than showing its slug', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    const row = await screen.findByTestId('task-row-11')
+    expect(row).toHaveTextContent('Tool-heavy')
+    expect(row).not.toHaveTextContent('tool_heavy')
+  })
+
+  test('resolves each dimension letter to the model that won it', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('task-row-11')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('task-row-11'))
+
+    await waitFor(() => expect(screen.getByTestId('pair-judgment-71')).toBeInTheDocument())
+    const dims = [...screen.getByTestId('pair-judgment-71').querySelectorAll('.dimensions li')]
+      .map(li => li.textContent.replace(/\s+/g, ' ').trim())
+    // The letters are the blinded presentation order, not a model. Both
+    // orders named the candidate, so every non-tie dimension resolves to it.
+    expect(dims).toEqual([
+      'correctness: anthropic/claude-3-opus',
+      'tool_use: anthropic/claude-3-opus',
+      'tone: tie',
+      'correctness: anthropic/claude-3-opus',
+    ])
+  })
+
+  test('keeps the raw letter when nothing on the item can unblind it', async () => {
+    server.use(http.get('/api/v1/eval/runs/:id/pairs', () => HttpResponse.json({
+      ...evalPairs,
+      pairs: [{
+        ...evalPairs.pairs[0],
+        outcome: 'tie',
+        items: [{
+          item_id: 141, presentation_order: 'ab', status: 'judged',
+          verdicts: [{
+            judge_ident: 'claude-code', winner: 'tie', winner_variant: '',
+            dimensions: { correctness: 'a' }, notes: '', rubric_version: 'v1',
+            created_at: '2026-08-17T10:00:00Z',
+          }],
+        }],
+      }],
+    })))
+
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('task-row-11')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('task-row-11'))
+
+    await waitFor(() => expect(screen.getByTestId('pair-judgment-71')).toBeInTheDocument())
+    const judgment = screen.getByTestId('pair-judgment-71')
+    expect(judgment).toHaveTextContent('called it a tie')
+    expect(judgment.querySelector('.dimensions li')).toHaveTextContent('correctness: a')
   })
 
   test('an unjudged comparison says so rather than showing nothing', async () => {


### PR DESCRIPTION
Three gaps in the per-test-case results, found comparing #356 against a parallel implementation of the same slice (now closed as superseded, #362).

## 1. Dimension winners named nothing

Per-dimension winners are stored as the blinded letter the judge saw, and `GET /eval/runs/{id}/pairs` resolves only the overall winner (`PairVerdict.WinnerVariant`), not the map. So the judge block rendered:

```
correctness: b
tool_use: b
tone: tie
```

A non-tie verdict on an item is the key for that item’s letters - its winner letter is its `winner_variant`, so the other letter is the other side of the pair. Now:

```
correctness: anthropic/claude-3-opus
tool_use: anthropic/claude-3-opus
tone: tie
```

An item everyone judged a tie stays unresolvable and keeps its letter.

**This is a stopgap.** The server holds the assignment and can resolve it properly via `VariantFor` - #358. Drop this client-side resolver when that lands.

## 2. Categories rendered as slugs

`tool_heavy` in both the per-category table and the per-case rows. Now "Tool-heavy", matching the labels `SuggestCases.svelte` already uses.

## 3. Per-case cells hid latency

Cells showed cost and rounds, with a delta on cost alone. Latency is the third metric the scorecard tracks, and a candidate that is cheaper but slower was invisible in that row. Each of the three now carries its own signed delta.

<details>
<summary>Tests</summary>

Four new tests in `EvalResults.test.js`: all three metrics with their deltas, kind labelling, letter resolution, and the unresolvable-tie fallback. One existing category assertion updated to expect labels.

`just test-ui`: 958 passed, 53 files. `just lint-ui`: clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)