### PR TITLE
fix(eval): identify a quick check by its pinned task list, not the set size

### DIFF
--- a/web/src/__tests__/pages/Evals.test.js
+++ b/web/src/__tests__/pages/Evals.test.js
@@ -268,6 +268,18 @@ describe('Evals page — launcher', () => {
   })
 })
 
+/** Pins run 2 into the shape of a Quick check: a drawn subset at k = 1. */
+function quickCheckRun2() {
+  server.use(
+    http.get('/api/v1/eval/runs/:id', ({ params }) => {
+      const run = evalRuns.find(r => String(r.id) === params.id)
+      if (!run) return new HttpResponse(null, { status: 404 })
+      const pinned = { ...run, k: 1, task_ids: [11, 12, 13], task_count: 3 }
+      return HttpResponse.json(String(run.id) === '2' ? pinned : run)
+    }),
+  )
+}
+
 describe('Evals page — runs list', () => {
   test('renders status, progress, spend and the test set for each run', async () => {
     render(Evals)
@@ -423,13 +435,8 @@ describe('Evals page — results panel', () => {
   })
 
   test('"Run full eval" refills the launcher with the same candidate', async () => {
-    // Run 2 covered 37 of 37 cases, so make it a subset to earn the CTA.
-    server.use(
-      http.get('/api/v1/eval/runs/:id', ({ params }) => {
-        const run = evalRuns.find(r => String(r.id) === params.id)
-        return run ? HttpResponse.json({ ...run, task_count: 10 }) : new HttpResponse(null, { status: 404 })
-      }),
-    )
+    // Run 2 ran the whole set at k = 3, so pin it into a quick check.
+    quickCheckRun2()
     render(Evals)
 
     await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
@@ -439,6 +446,78 @@ describe('Evals page — results panel', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('preset-hint')).toHaveTextContent(/All \d+ cases/))
+    expect(document.querySelector('.model-selector input'))
+      .toHaveValue('anthropic/claude-3-opus')
+    // Focus follows the escalation: the button that was clicked is now gone.
+    expect(document.activeElement).toBe(screen.getByTestId('launcher'))
+  })
+
+  test('a full run at k = 1 is not mistaken for a quick check', async () => {
+    // The old test was "fewer cases than the set holds", which called any run
+    // predating a set that has since grown a quick check.
+    server.use(
+      http.get('/api/v1/eval/runs/:id', ({ params }) => {
+        const run = evalRuns.find(r => String(r.id) === params.id)
+        return run
+          ? HttpResponse.json({ ...run, k: 1, task_ids: undefined, task_count: 10 })
+          : new HttpResponse(null, { status: 404 })
+      }),
+    )
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('results-2'))
+    await waitFor(() => expect(screen.getByTestId('verdict-4')).toBeInTheDocument())
+    expect(screen.queryByTestId('escalate-4')).not.toBeInTheDocument()
+  })
+
+  test('escalating onto a test set that is gone says so instead of running the wrong one', async () => {
+    quickCheckRun2()
+    // The set the run used is no longer on offer, so the launcher cannot
+    // reproduce the comparison.
+    server.use(
+      http.get('/api/v1/eval/task-sets', () =>
+        HttpResponse.json([{ id: 2, name: 'tool-heavy', description: '', task_count: 8 }])),
+    )
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('results-2'))
+    await waitFor(() => expect(screen.getByTestId('escalate-4')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('escalate-4'))
+
+    await waitFor(() => expect(screen.getByTestId('launcher'))
+      .toHaveTextContent(/golden-set.*no longer available/))
+    expect(screen.getByTestId('task-set-select')).toHaveValue('tool-heavy')
+  })
+
+  test('applying a model re-reads only the agent that changed', async () => {
+    quickCheckRun2()
+    let listCalls = 0
+    let read = ''
+    server.use(
+      http.get('/api/v1/agents', () => {
+        listCalls++
+        return HttpResponse.json(AGENTS)
+      }),
+      http.patch('/api/v1/agents/:name', () => HttpResponse.json({ ok: true })),
+      http.get('/api/v1/agents/:name', ({ params }) => {
+        read = params.name
+        return HttpResponse.json({ ...AGENTS[0], model: 'anthropic/claude-3-opus' })
+      }),
+    )
+    render(Evals)
+
+    await waitFor(() => expect(screen.getByTestId('results-2')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('results-2'))
+    await waitFor(() => expect(screen.getByTestId('apply-4')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('apply-4'))
+    await fireEvent.click(screen.getByTestId('apply-confirm-btn'))
+
+    await waitFor(() => expect(read).toBe('default'))
+    // One list read on mount and no second one: the page patched the one row.
+    expect(listCalls).toBe(1)
+    expect(screen.getByTestId('launcher')).toHaveTextContent('anthropic/claude-3-opus')
   })
 })
 

--- a/web/src/components/EvalResults.svelte
+++ b/web/src/components/EvalResults.svelte
@@ -5,7 +5,7 @@
   // Terminology: the API's task_set/variant/sample are "test set", "current vs
   // candidate" and "turns" here — six new nouns is a teaching tax this page
   // should not charge.
-  import { onMount } from 'svelte'
+  import { onMount, onDestroy } from 'svelte'
   import { api, evalSampleTranscript } from '../api.js'
   import ErrorBanner from './ErrorBanner.svelte'
   import DryRunTranscript from './DryRunTranscript.svelte'
@@ -39,8 +39,11 @@
   // The candidate this view has already switched the agent to, so the button
   // cannot be clicked twice for the same change.
   let appliedVariant = $state('')
-  // '' | 'ok' | 'failed' — a silently dead Copy button reads as broken.
-  let copyState = $state('')
+  // { variant_id, state: 'ok' | 'failed' } — a silently dead Copy button reads
+  // as broken. Carrying the variant keeps a multi-candidate run honest: one
+  // pending block per verdict, and copying in one must not flip every button.
+  let copyFeedback = $state(null)
+  let copyTimer = null
 
   const VERDICT_LABEL = {
     upgrade: 'Upgrade',
@@ -103,6 +106,14 @@
     return `${sign}${v.toFixed(1)}${unit === 'pp' ? ' pp' : '%'}`
   }
 
+  /** The allowed column is a ceiling, not a measurement, so it reads as one. */
+  function fmtThreshold(gate) {
+    if (gate.threshold == null) return '—'
+    return gate.unit === 'pp'
+      ? `≤ +${gate.threshold.toFixed(1)} pp`
+      : `≤ +${gate.threshold.toFixed(0)}%`
+  }
+
   /** Gate values are rates for the pp gate and magnitudes for the rest. */
   function fmtGateValue(gate, v) {
     if (gate.unit === 'pp') return fmtPct(v)
@@ -119,6 +130,23 @@
     return variants.find(v => v.name === name) || null
   }
 
+  /**
+   * Variant names are free text chosen by whoever created the run, so a run
+   * started over the API or MCP can be called `variant-a`. The model it
+   * actually ran is the honest label; the raw name is only the last resort.
+   */
+  function displayName(name) {
+    return metricsFor(name)?.overlay?.llm_model || name
+  }
+
+  /**
+   * Applying needs a model to patch, so a variant whose overlay carries none
+   * (an API-created run that only renamed the incumbent) is not offerable.
+   */
+  function canApply(verdict) {
+    return !!run?.base_agent && !!metricsFor(verdict.variant)?.overlay?.llm_model
+  }
+
   function isPending(verdict) {
     const j = verdict.judgment || {}
     return (j.pairs || 0) > 0 && (j.judged_pairs || 0) < j.pairs
@@ -131,16 +159,23 @@
 
   let judgeCommand = $derived(`claude -p "judge pending pairs for eval run ${run?.id}"`)
 
-  async function copyCommand() {
+  async function copyCommand(variantID) {
     try {
       await navigator.clipboard.writeText(judgeCommand)
-      copyState = 'ok'
-      setTimeout(() => (copyState = ''), 2000)
+      copyFeedback = { variant_id: variantID, state: 'ok' }
+      clearTimeout(copyTimer)
+      copyTimer = setTimeout(() => (copyFeedback = null), 2000)
     } catch {
       // Clipboard access denied or unavailable: the command is on screen and
       // selectable, so the button says to select it rather than dying quietly.
-      copyState = 'failed'
+      copyFeedback = { variant_id: variantID, state: 'failed' }
     }
+  }
+
+  /** Feedback belongs to the button that was pressed, not to every button. */
+  function copyLabel(variantID) {
+    if (copyFeedback?.variant_id !== variantID) return 'Copy'
+    return copyFeedback.state === 'ok' ? 'Copied' : 'Select it above'
   }
 
   async function load() {
@@ -163,6 +198,7 @@
   }
 
   onMount(load)
+  onDestroy(() => clearTimeout(copyTimer))
 
   async function toggleTask(taskID) {
     if (expandedTask === taskID) {
@@ -214,11 +250,11 @@
   function askApply(verdict) {
     applyError = ''
     applyOk = ''
-    const m = metricsFor(verdict.variant)
+    const overlay = metricsFor(verdict.variant)?.overlay || {}
     confirmApply = {
       variant: verdict.variant,
-      model: m?.overlay?.llm_model || verdict.variant,
-      provider: m?.overlay?.llm_provider || '',
+      model: overlay.llm_model,
+      provider: overlay.llm_provider || '',
     }
   }
 
@@ -233,7 +269,7 @@
       appliedVariant = confirmApply.variant
       confirmApply = null
       // The page owns the agent list, so it re-reads and "current" updates.
-      onapplied()
+      onapplied(run.base_agent)
     } catch (e) {
       // Kept inside the dialog: closing it on failure would read as success.
       applyError = e.message
@@ -243,10 +279,12 @@
   }
 
   function escalate(verdict) {
-    const m = metricsFor(verdict.variant)
+    const overlay = metricsFor(verdict.variant)?.overlay || {}
     onrunfull({
-      model: m?.overlay?.llm_model || verdict.variant,
-      provider: m?.overlay?.llm_provider || '',
+      // Only a real model id, never the raw variant name: the launcher's
+      // candidate field is what the next run is built from.
+      model: overlay.llm_model || '',
+      provider: overlay.llm_provider || '',
       taskSet: summary?.task_set || '',
     })
   }
@@ -263,7 +301,7 @@
 </script>
 
 {#if loading}
-  <p class="muted" data-testid="results-loading">Loading results…</p>
+  <p class="muted" role="status" data-testid="results-loading">Loading results…</p>
 {:else if error}
   <ErrorBanner message={error} />
   <button class="btn-sm" onclick={load} data-testid="results-retry">Try again</button>
@@ -279,7 +317,7 @@
       <header class="verdict-head">
         <span class="verdict-label" data-testid="verdict-label-{v.variant_id}">{verdictLabel(v.verdict)}</span>
         <span class="verdict-sub">
-          <span class="mono">{v.variant}</span> against your current model
+          <span class="mono">{displayName(v.variant)}</span> against your current model
           {#if agent?.model}<span class="mono">({agent.model})</span>{/if}
         </span>
       </header>
@@ -297,9 +335,9 @@
           </p>
           <p class="pending-step">Judge them from Claude Code with <code>/judge-eval</code>, or run:</p>
           <div class="cmd-row">
-            <code class="cmd" data-testid="judge-command">{judgeCommand}</code>
-            <button class="btn-sm" onclick={copyCommand} data-testid="copy-command">
-              {#if copyState === 'ok'}Copied{:else if copyState === 'failed'}Select it above{:else}Copy{/if}
+            <code class="cmd" data-testid="judge-command-{v.variant_id}">{judgeCommand}</code>
+            <button class="btn-sm" onclick={() => copyCommand(v.variant_id)} data-testid="copy-command-{v.variant_id}">
+              {copyLabel(v.variant_id)}
             </button>
           </div>
           <p class="hint">
@@ -329,7 +367,7 @@
                 <td>{fmtGateValue(g, g.baseline)}</td>
                 <td>{fmtGateValue(g, g.value)}</td>
                 <td>{fmtDelta(g.delta, g.unit)}</td>
-                <td>{fmtDelta(g.threshold, g.unit)}</td>
+                <td>{fmtThreshold(g)}</td>
                 <td>
                   <span class="gate-mark" class:pass={g.pass} data-testid="gate-{g.name}-{v.variant_id}">
                     {g.pass ? 'pass' : 'fail'}
@@ -407,7 +445,7 @@
       {/if}
 
       <div class="verdict-actions">
-        {#if v.verdict === 'upgrade'}
+        {#if v.verdict === 'upgrade' && canApply(v)}
           <button class="btn-primary" onclick={() => askApply(v)}
             disabled={appliedVariant === v.variant} data-testid="apply-{v.variant_id}">
             {appliedVariant === v.variant ? 'Applied' : `Apply to ${run.base_agent}`}
@@ -443,7 +481,7 @@
             <th>Measure</th>
             {#each variants as v (v.variant_id)}
               <th class="mono">
-                {v.name}
+                {displayName(v.name)}
                 <span class="flag">{v.name === baselineName ? 'current' : 'candidate'}</span>
               </th>
             {/each}
@@ -508,7 +546,7 @@
               <th>Kind</th>
               {#each variants as v (v.variant_id)}
                 <th class="mono">
-                  {v.name}
+                  {displayName(v.name)}
                   <span class="flag">{v.name === baselineName ? 'current' : 'candidate'}</span>
                 </th>
               {/each}

--- a/web/src/components/__tests__/EvalResults.test.js
+++ b/web/src/components/__tests__/EvalResults.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from 'vitest'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/svelte'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../test/server.js'
@@ -6,6 +6,11 @@ import { evalSummary, evalSamples, evalPairs } from '../../test/handlers.js'
 import { token, authMode } from '../../store.js'
 import { evalSampleTranscript } from '../../api.js'
 import EvalResults from '../EvalResults.svelte'
+
+// The pending block hands over a command, so the button needs a clipboard.
+Object.assign(navigator, {
+  clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+})
 
 const RUN = {
   id: 2,
@@ -115,7 +120,7 @@ describe('EvalResults — judgment pending', () => {
 
     await waitFor(() => expect(screen.getByTestId('judgment-pending-4')).toBeInTheDocument())
     expect(screen.getByTestId('judgment-pending-4')).toHaveTextContent('12 of 37 comparisons are judged')
-    expect(screen.getByTestId('judge-command')).toHaveTextContent(
+    expect(screen.getByTestId('judge-command-4')).toHaveTextContent(
       'claude -p "judge pending pairs for eval run 2"')
     // The least-privilege note travels with the command.
     expect(screen.getByTestId('judgment-pending-4')).toHaveTextContent('eval:read')
@@ -316,8 +321,8 @@ describe('EvalResults — apply to agent', () => {
         return HttpResponse.json({ ok: true })
       }),
     )
-    let reloaded = 0
-    render(EvalResults, { props: { run: RUN, agent: AGENT, onapplied: () => { reloaded++ } } })
+    let reloaded = null
+    render(EvalResults, { props: { run: RUN, agent: AGENT, onapplied: (name) => { reloaded = name } } })
 
     await waitFor(() => expect(screen.getByTestId('apply-4')).toBeInTheDocument())
     await fireEvent.click(screen.getByTestId('apply-4'))
@@ -335,7 +340,8 @@ describe('EvalResults — apply to agent', () => {
       name: 'default',
       body: { llm_model: 'anthropic/claude-3-opus', llm_provider: 'openrouter' },
     })
-    expect(reloaded).toBe(1)
+    // The page is told which agent to re-read, not to re-read the lot.
+    expect(reloaded).toBe('default')
     // The button cannot fire the same switch twice.
     expect(screen.getByTestId('apply-4')).toBeDisabled()
     expect(screen.getByTestId('apply-4')).toHaveTextContent('Applied')
@@ -355,6 +361,72 @@ describe('EvalResults — apply to agent', () => {
     await waitFor(() => expect(screen.getByTestId('apply-error')).toHaveTextContent('model not available'))
     expect(screen.getByTestId('apply-confirm')).toBeInTheDocument()
     expect(screen.queryByTestId('apply-ok')).not.toBeInTheDocument()
+  })
+})
+
+describe('EvalResults — honest labels and offerable actions', () => {
+  test('a variant named by the operator still reads as the model it ran', async () => {
+    withSummary({
+      variants: [
+        evalSummary.variants[0],
+        { ...evalSummary.variants[1], name: 'variant-b' },
+      ],
+      verdicts: [{ ...evalSummary.verdicts[0], variant: 'variant-b' }],
+      per_task: [],
+    })
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('verdict-4')).toBeInTheDocument())
+    // The overlay's model, not the free-text name the API run was created with.
+    expect(screen.getByTestId('verdict-4')).toHaveTextContent('anthropic/claude-3-opus')
+    expect(screen.getByTestId('verdict-4')).not.toHaveTextContent('variant-b')
+    expect(screen.getByTestId('objective-table')).toHaveTextContent('anthropic/claude-3-opus')
+  })
+
+  test('a candidate with no model to patch is not offered for applying', async () => {
+    withSummary({
+      // An API-created run that renamed the incumbent: nothing to switch to.
+      variants: [evalSummary.variants[0], { ...evalSummary.variants[1], overlay: {} }],
+    })
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('verdict-label-4')).toHaveTextContent('Upgrade'))
+    expect(screen.queryByTestId('apply-4')).not.toBeInTheDocument()
+  })
+
+  test('the allowed column reads as a ceiling, not another measurement', async () => {
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('gates-4')).toBeInTheDocument())
+    expect(screen.getByTestId('gates-4')).toHaveTextContent('≤ +2.0 pp')
+    expect(screen.getByTestId('gates-4')).toHaveTextContent('≤ +25%')
+  })
+})
+
+describe('EvalResults — copy feedback', () => {
+  test('only the button that was pressed says Copied', async () => {
+    const pending = { ...evalSummary.verdicts[0].judgment, pairs: 37, judged_pairs: 12 }
+    withSummary({
+      variants: [
+        evalSummary.variants[0],
+        evalSummary.variants[1],
+        { ...evalSummary.variants[1], variant_id: 5, name: 'openai/gpt-4o',
+          overlay: { llm_model: 'openai/gpt-4o', llm_provider: 'openrouter' } },
+      ],
+      verdicts: [
+        { ...evalSummary.verdicts[0], judgment: pending },
+        { ...evalSummary.verdicts[0], variant_id: 5, variant: 'openai/gpt-4o', judgment: pending },
+      ],
+      per_task: [],
+    })
+    render(EvalResults, { props: { run: RUN, agent: AGENT } })
+
+    await waitFor(() => expect(screen.getByTestId('copy-command-4')).toBeInTheDocument())
+    await fireEvent.click(screen.getByTestId('copy-command-4'))
+
+    await waitFor(() => expect(screen.getByTestId('copy-command-4')).toHaveTextContent('Copied'))
+    expect(screen.getByTestId('copy-command-5')).toHaveTextContent('Copy')
+    expect(screen.getByTestId('copy-command-5')).not.toHaveTextContent('Copied')
   })
 })
 

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -71,6 +71,10 @@
     } catch { /* the panel already reported the write; the count can lag */ }
   }
 
+  // The launcher section, so an escalation from a result can move focus and
+  // the viewport back to it.
+  let launcherEl = $state(null)
+
   // --- Runs ---
   let expandedRun = $state(null)
   let confirmStop = $state(null)
@@ -406,26 +410,55 @@
     confirmStop = id
   }
 
-  /** Re-reads the agent list so "current" reflects a just-applied model. */
-  async function reloadAgents() {
+  /**
+   * Re-reads the one agent that changed so "current" reflects a just-applied
+   * model. Only that agent: a full list re-read would also discard whatever
+   * the rest of the page holds for the others.
+   */
+  async function reloadAgents(name) {
     try {
-      agents = (await api.agents()) || []
+      const fresh = await api.agent(name)
+      agents = agents.map(a => (a.name === name ? { ...a, ...fresh } : a))
     } catch {
       // The banner in the results view already reported the applied change;
       // a stale "current" line is not worth failing the page over.
     }
   }
 
+  /**
+   * A Quick check is the preset that draws a subset and runs each case once, so
+   * a run is identified by both halves: a pinned task list (task_ids is only
+   * set when the server drew one) and k = 1. Comparing the run's task count
+   * against the set's current size would instead call an old full run a Quick
+   * check as soon as a case is added to the set.
+   */
+  function isQuickCheck(run) {
+    return run.k === 1 && Array.isArray(run.task_ids) && run.task_ids.length > 0
+  }
+
   /** Refills the launcher from a result and switches it to the full preset. */
   function runFull(pick) {
+    launchError = ''
     candidate = pick.model
     candidateProvider = pick.provider || ''
     providerFor = pick.model
-    // Only re-select a set the launcher can still offer — a deleted one would
-    // leave the select showing a name it cannot start.
-    if (pick.taskSet && taskSets.some(t => t.name === pick.taskSet)) taskSetName = pick.taskSet
+    if (pick.taskSet) {
+      if (taskSets.some(t => t.name === pick.taskSet)) {
+        taskSetName = pick.taskSet
+      } else {
+        // Launching against a different corpus than the quick check ran on is
+        // not the same comparison, so say so rather than silently keeping
+        // whatever set the select happened to hold.
+        launchError = `The test set that quick check used ("${pick.taskSet}") is no longer available — pick one below.`
+      }
+    }
     preset = 'full'
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    // The button that had focus lives in the results panel, so focus moves to
+    // the launcher explicitly; without it a keyboard user lands on <body>.
+    launcherEl?.focus?.({ preventScroll: true })
+    // A JS scroll ignores the stylesheet's reduced-motion block on its own.
+    const still = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches
+    launcherEl?.scrollIntoView?.({ behavior: still ? 'auto' : 'smooth', block: 'start' })
   }
 
   function toggleResults(id) {
@@ -518,7 +551,7 @@
 </div>
 
 {#if !loading && !isEmpty}
-  <section class="launcher" data-testid="launcher">
+  <section class="launcher" data-testid="launcher" bind:this={launcherEl} tabindex="-1">
     <h2 class="section-title">Compare current vs candidate</h2>
     {#if launchError}<div class="inline-error" role="alert">{launchError}</div>{/if}
 
@@ -669,7 +702,7 @@
           <div class="results-panel" id="results-panel-{run.id}" data-testid="results-panel-{run.id}">
             <EvalResults {run}
               agent={agents.find(a => a.name === run.base_agent) || null}
-              quick={run.task_count != null && setCases != null && run.task_count < setCases}
+              quick={isQuickCheck(run)}
               onapplied={reloadAgents}
               onrunfull={runFull} />
           </div>
@@ -745,6 +778,8 @@
   /* Launcher */
   .launcher {
     background: var(--surface);
+    /* Focused programmatically after an escalation; the ring would be noise. */
+    outline: none;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     padding: 18px;

--- a/web/src/test/handlers.js
+++ b/web/src/test/handlers.js
@@ -85,6 +85,8 @@ export const evalRuns = [
     cost_spent: 0.31,
     as_of: '2026-08-18T09:00:00Z',
     created_at: '2026-08-18T09:00:00Z',
+    // A Quick check pins the subset it drew; task_ids is what identifies it.
+    task_ids: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
     task_count: 10,
     variants: [
       { id: 1, run_id: 1, name: 'current', overlay: '{}' },
@@ -535,6 +537,9 @@ export const handlers = [
       cost_cap: body.cost_cap ?? 2,
       cost_spent: 0,
       created_at: '2026-08-19T09:00:00Z',
+      ...(body.sample_tasks
+        ? { task_ids: Array.from({ length: body.sample_tasks }, (_, i) => 11 + i) }
+        : {}),
       task_count: body.sample_tasks || 37,
       variants: (body.variants || []).map((v, i) => ({ id: 10 + i, run_id: 3, name: v.name, overlay: '{}' })),
       samples_done: 0,


### PR DESCRIPTION
Reconciles the results view shipped in #356 with the parallel scorecard branch that never got a PR. Six behaviour changes, each with a regression test.

## What to review

1. **Quick-check detection** (`Evals.svelte`) - the view called a run a Quick check when it covered fewer cases than its test set *currently* holds, so an old full run became a quick check as soon as a case was added to the set. It is now the two halves of the preset: `task_ids` pinned (only set when the server drew a subset) and `k === 1`.
2. **Escalation to a full eval** - moves focus to the launcher (the button that was clicked lives in the results panel, so a keyboard user was landing on `<body>`), honours `prefers-reduced-motion` on the scroll, and reports a test set that is no longer available through `launchError` instead of silently launching against whatever set the select happened to hold. The candidate is only ever a real model id now, never the raw variant name.
3. **Applying a model** - re-reads the one agent that changed (`GET /agents/{name}`) rather than the whole list.
4. **Honest variant labels** (`EvalResults.svelte`) - variant names are free text, so a run created over the API or MCP can be called `variant-b`. Verdict header, scorecard, and per-case columns now render the model the variant actually ran. A variant whose overlay carries no model is not offered for applying at all.
5. **Copy feedback** - keyed by variant, so one pending block's Copy no longer flips every other button to "Copied"; the timer is cleared on destroy. The `judge-command` / `copy-command` test ids are now variant-scoped.
6. **Gate table** - the Allowed column reads as a ceiling (`≤ +25%`) rather than as another measurement.

## Tests

`just test-ui` - 961 pass (53 files). New coverage: a full run at k = 1 is not mistaken for a quick check, escalating onto a deleted test set, the targeted single-agent re-read, an operator-named variant rendering as its model, apply hidden with no model to patch, ceiling formatting, and per-variant copy feedback.

The MSW run fixtures now carry `task_ids` on the quick check, which is what the endpoint returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gt3GUz14Wkz5hhhYvuKeB