### PR TITLE
chore(just): serve UI and API together, add `just dev`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ Tooling: `just` (user-facing) → Task (`Taskfile.yml`, per-target fingerprint c
 
 ```bash
 just build                    # Build binary → pkg/bin/denkeeper
-just serve                    # go run (optional config path)
+just serve                    # Build UI, then serve dashboard + API on :8080 (live reload)
+just dev                      # Backend :8080 + Vite dev server :5173 (hot reload)
 just test                     # All Go tests with -race
 just test-v                   # Verbose test output
 just test-pkg internal/agent  # Single package
@@ -22,7 +23,7 @@ just build-ui                 # Build web UI (auto-run by build/test/vet/lint wh
 just build-full               # Build web then binary
 just openapi                  # Generate OpenAPI spec (requires swag CLI)
 just openapi-check            # Fail if the committed spec is stale (CI gate)
-just web-dev                  # Vite dev server (hot reload)
+just dev-ui                   # Vite dev server only (hot reload)
 just test-integration         # E2E integration tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,13 @@ just build
 ./pkg/bin/denkeeper serve
 ```
 
-Or run directly without building:
+Or run directly without building (builds the dashboard, then serves it and the API on `:8080`):
 
 ```bash
 just serve
 ```
+
+For frontend work, `just dev` runs the Go server on `:8080` and the Vite dev server on `:5173` (hot module reload, proxying `/api` and `/auth` to the backend).
 
 ### Configuration
 
@@ -619,8 +621,9 @@ The API key must have scopes matching the tools you want to use (e.g. `chat`, `a
 just build           # Build the denkeeper binary (requires web/dist/ to exist)
 just build-ui        # Build the Svelte web dashboard (requires Node.js)
 just build-full      # Build web dashboard then Go binary in one step
-just serve           # Start the agent (just serve ./path/to/config.toml)
-just web-dev         # Start Vite dev server for dashboard hot-reload
+just serve           # Serve dashboard + API on :8080 (just serve ./path/to/config.toml)
+just dev             # Backend on :8080 plus Vite dev server on :5173 (hot reload)
+just dev-ui          # Vite dev server only (expects a backend on :8080)
 just test            # Run all tests with race detector
 just test-v          # Verbose test output
 just test-pkg <pkg>  # Test a single package (e.g. just test-pkg internal/agent)

--- a/justfile
+++ b/justfile
@@ -40,8 +40,10 @@ test-integration:
 test-pkg pkg: ensure-web-dist
     go test -race -count=1 -v ./{{pkg}}/...
 
-# Start the agent with live reload (optionally pass config path: just serve ./denkeeper.toml)
-serve config="":
+# Builds the dashboard, then runs the Go server with live reload on Go changes.
+# Optionally pass a config path: just serve ./denkeeper.toml
+# Serve UI and API together on :8080 (embedded dashboard, live reload)
+serve config="": ensure-web-dist
     #!/usr/bin/env sh
     if [ -n "{{config}}" ]; then
         air -- serve --config "{{config}}"
@@ -49,8 +51,26 @@ serve config="":
         air
     fi
 
+# Go server on :8080 (live reload) and the Vite dev server on :5173 (hot module
+# reload, proxying /api and /auth to :8080). Ctrl-C stops both.
+# Run backend and UI as separate processes with hot reload
+dev config="": ensure-web-dist
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mise x -- task ui:install
+    if [ -n "{{config}}" ]; then
+        air -- serve --config "{{config}}" &
+    else
+        air &
+    fi
+    api_pid=$!
+    (cd web && npm run dev) &
+    ui_pid=$!
+    trap 'kill "$api_pid" "$ui_pid" 2>/dev/null || true' EXIT INT TERM
+    wait
+
 # Run with debug logging and live reload
-serve-debug config="":
+serve-debug config="": ensure-web-dist
     #!/usr/bin/env sh
     export DENKEEPER_LOG_LEVEL=debug
     if [ -n "{{config}}" ]; then
@@ -60,7 +80,7 @@ serve-debug config="":
     fi
 
 # Start the agent without live reload (optionally pass config path)
-serve-once config="":
+serve-once config="": ensure-web-dist
     #!/usr/bin/env sh
     if [ -n "{{config}}" ]; then
         go run ./cmd/denkeeper serve --config "{{config}}"
@@ -161,7 +181,8 @@ openapi:
 openapi-check:
     @mise x -- task openapi:check
 
-# Run the Vite dev server (proxies /api to localhost:8080)
+# See `just dev` to run it alongside the backend.
+# Run only the Vite dev server (proxies /api to localhost:8080)
 dev-ui:
     @mise x -- task ui:install
     cd web && npm run dev


### PR DESCRIPTION
`just serve` ran air directly, so a missing `internal/web/dist/` broke the `//go:embed` build and a stale one silently served old assets. It now depends on `ensure-web-dist`, building the dashboard before the server starts - one port, `:8080`, dashboard and API together.

`just dev` is the new split mode: air on `:8080` plus the Vite dev server on `:5173` for hot module reload, with a trap so Ctrl-C stops both.

Also:
- `serve-debug` and `serve-once` gain the same `ensure-web-dist` dependency - they had the same embed failure mode.
- README.md and CLAUDE.md documented `just web-dev`, which never existed. The recipe is `dev-ui`.

<details>
<summary>Verification</summary>

`just hook` green (fmt-check, vet, lint, lint-ui, test, test-ui, openapi-check).

Both recipes were run live against a scratch data dir:

- `just serve` from a wiped `internal/web/dist/`: UI rebuilt, `/` 200 with the SPA HTML, hashed asset 200, `/api/v1/health` 200.
- `just dev`: `:5173` 200, `:8080/api/v1/health` 200, `:5173/api/v1/health` 200 (proxied). After stopping, both ports dead - the trap kills both children.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBS5PT1MsGQctC1k77b3db