### PR TITLE
fix(web): align the evals empty state with the panels below it

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -148,6 +148,10 @@
     --success:     #3d8f62;
     --warn:        #c87e30;
     --radius:      6px;
+    /* One inset for the Evals page's stacked cards (empty state, launcher,
+       suggest panel) so they stay aligned at every width; the 520px override
+       below is the single place the mobile inset is defined. */
+    --card-inset:  18px;
     --hover-overlay: rgba(0, 0, 0, 0.04);
     --overlay-bg:    rgba(0, 0, 0, 0.4);
     --bottom-nav-height: 60px;
@@ -186,6 +190,12 @@
     --sidebar-active-bg:    rgba(var(--accent-rgb), 0.15);
     --sidebar-hover-bg:     rgba(255, 255, 255, 0.06);
     --sidebar-divider:      rgba(255, 255, 255, 0.08);
+  }
+
+  @media (max-width: 520px) {
+    :global(:root) {
+      --card-inset: 14px;
+    }
   }
 
   :global(body) {

--- a/web/src/components/SuggestCases.svelte
+++ b/web/src/components/SuggestCases.svelte
@@ -407,7 +407,7 @@
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 18px;
+    padding: var(--card-inset);
     margin-bottom: 24px;
   }
 
@@ -611,9 +611,5 @@
 
   @media (prefers-reduced-motion: reduce) {
     .spinner { animation-duration: 2s; }
-  }
-
-  @media (max-width: 520px) {
-    .suggest { padding: 14px; }
   }
 </style>

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -761,9 +761,9 @@
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    /* Padding and trailing gap match .launcher and SuggestCases' .suggest so
-       the card lines up with whichever panel opens under it. */
-    padding: 18px;
+    /* Shares --card-inset with .launcher and SuggestCases' .suggest so the
+       card lines up with whichever panel opens under it at every width. */
+    padding: var(--card-inset);
     margin-bottom: 24px;
   }
   .empty-lead {
@@ -787,7 +787,7 @@
     outline: none;
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 18px;
+    padding: var(--card-inset);
     margin-bottom: 24px;
   }
   .launch-grid {

--- a/web/src/pages/Evals.svelte
+++ b/web/src/pages/Evals.svelte
@@ -761,14 +761,18 @@
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 24px;
-    max-width: 620px;
+    /* Padding and trailing gap match .launcher and SuggestCases' .suggest so
+       the card lines up with whichever panel opens under it. */
+    padding: 18px;
+    margin-bottom: 24px;
   }
   .empty-lead {
     font-size: 14px;
     color: var(--text);
     margin-bottom: 16px;
     line-height: 1.6;
+    /* Card is full width; the prose is not. */
+    max-width: 620px;
   }
   .empty-actions {
     display: flex;


### PR DESCRIPTION
The Evals empty-state card was capped at `max-width: 620px` and had no trailing margin, so it rendered narrower than the launcher, suggest, and import panels that open directly beneath it, with the two cards touching.

- Moved the width cap from `.empty-state` onto `.empty-lead` - the card now spans full width like its siblings while the prose stays readable.
- Added `margin-bottom: 24px`, matching `.launcher` and `SuggestCases`' `.suggest`.
- Dropped padding 24px to 18px so every card on the page shares one inset.

CSS-only, no behaviour change. `just hook` green (972 UI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRjWVpJsEmUUY1emCzYLXT