### PR TITLE
ci: cache Go modules in the lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,25 @@ jobs:
           name: web-ui-dist
           path: internal/web/dist/
       - uses: jdx/mise-action@v4
+      - name: Cache Go modules and build
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-
+      - name: Download Go modules
+        # golangci-lint reports a failed module download as a `typecheck` issue
+        # against the importing file, so download first to surface the real error.
+        run: |
+          for attempt in 1 2 3; do
+            go mod download && exit 0
+            echo "go mod download failed (attempt $attempt/3)"
+            sleep 5
+          done
+          exit 1
       - name: Check formatting
         run: |
           unformatted=$(gofmt -l . | grep -v '^\\.claude/' || true)


### PR DESCRIPTION
## What to review

One workflow file. The `lint` job was the only Go job in `ci.yml` without a module cache, so every run cold-fetched the whole module graph and a transient `proxy.golang.org` stream reset surfaced as a bogus `typecheck` error.

Three changes to `lint`:

1. `actions/cache@v6` on `~/go/pkg/mod` + `~/.cache/go-build`, keyed on `go.sum` - identical to the `openapi`, `test`, and `vuln` jobs.
2. Explicit `go mod download` before `golangci-lint-action`, so a proxy failure fails at a step that names the real problem.
3. That download retries up to 3 times with a 5s gap, since proxy stream resets are not fully avoidable on a cache miss.

## Verification

`actionlint` passes on the file; the only shellcheck findings are pre-existing ones in other jobs (lines 40, 248, 260).

<details>
<summary>The failure this fixes (run 33095188224, PR #368)</summary>

```
internal/otel/otel.go:16:2: could not import go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
  (... github.com/cenkalti/backoff/v5@v5.0.3: read
   "https://proxy.golang.org/github.com/cenkalti/backoff/v5/@v/v5.0.3.zip":
   stream error: stream ID 239; INTERNAL_ERROR; received from peer)))) (typecheck)
```

A plain re-run passed with no code change. The other Go jobs on that run passed, consistent with them restoring from cache.
</details>

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsG8kPKZ1bv1D56F9BtLMG