### PR TITLE
docs(website): document [safety.reply_guard], the judge endpoint, fix lastmod drift

### DIFF
--- a/website/content/docs/concepts/evals.md
+++ b/website/content/docs/concepts/evals.md
@@ -3,7 +3,7 @@ title: "Evals"
 description: "Comparing a candidate model against the one you run today, on your own conversations."
 slug: "evals"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-25T00:00:00+00:00
+lastmod: 2026-08-28T00:00:00+00:00
 draft: false
 weight: 57
 toc: true

--- a/website/content/docs/reference/config.md
+++ b/website/content/docs/reference/config.md
@@ -3,7 +3,7 @@ title: "Configuration Reference"
 description: "Complete reference for denkeeper.toml options."
 slug: "config"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-21T00:00:00+00:00
+lastmod: 2026-08-28T00:00:00+00:00
 draft: false
 weight: 10
 toc: true
@@ -478,6 +478,22 @@ Subprocess plugins run as child processes with direct MCP stdio. Docker plugins 
 | `allow_unsigned` | bool | `true` | Allow unsigned subprocess plugin binaries |
 
 When `allow_unsigned = false`, all subprocess plugin binaries must have a valid Ed25519 signature from one of the trusted keys.
+
+## `[safety.reply_guard]`
+
+Runtime guardrail that holds back an obviously broken final reply on schedule-driven turns — a live user reacts to a bad reply, a schedule fires unattended. Distinct from `[security]`, which covers plugin signing. The turn is still stored in full and an audit event lands under category `safety`, action `reply_guard`; what changes is the delivered text, replaced by a one-line notice. Dry runs and evals evaluate the guard and report the verdict on the transcript, but never substitute the text.
+
+Each signal takes `"withhold"`, `"warn"` (audit but deliver anyway), or `"off"`.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | `true` | Master switch |
+| `on_role_markup` | string | `"withhold"` | Reply carries role/tool-call scaffolding as plain text (`<rs_tool_calls>`, `<\|im_start\|>`, `"\n\nHuman:"`, ...) instead of calling a tool |
+| `on_oversized` | string | `"withhold"` | Reply exceeds `max_reply_bytes` or `max_completion_tokens` |
+| `on_no_tool_calls` | string | `"warn"` | A schedule named a skill and the turn made no tool calls at all; only flags, since some skills legitimately finish without tools |
+| `max_reply_bytes` | int | `16000` | Caps the final reply in bytes (~4 Telegram chunks, under half that adapter's own render limit). Negative disables |
+| `max_completion_tokens` | int | `0` | Caps provider-reported completion tokens. `0` disables — it measures the same thing as `max_reply_bytes` |
+| `excerpt_bytes` | int | `200` | How much of the held reply reaches the audit detail. Negative disables |
 
 ## `[kv]`
 

--- a/website/content/docs/reference/rest-api.md
+++ b/website/content/docs/reference/rest-api.md
@@ -3,7 +3,7 @@ title: "REST API Reference"
 description: "HTTP API endpoints for external integrations."
 slug: "rest-api"
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-25T00:00:00+00:00
+lastmod: 2026-08-28T00:00:00+00:00
 draft: false
 weight: 30
 toc: true
@@ -578,6 +578,12 @@ This is the operator's results view and is deliberately **not** reachable from t
 **Scope:** `eval:read`
 
 Per-sample transcripts, including the full tool trace with arguments and results.
+
+### `POST /api/v1/eval/runs/{id}/judge`
+
+**Scope:** `eval:write`
+
+Starts a server-side judging pass over the run's outstanding blinded pairs with the internal judge, so a run can be judged unattended instead of only from Claude Code over MCP. Requires `[eval] judge_model`; without it the endpoint returns `503` and the MCP judge path is unaffected. Only a terminal run can be judged. The pass runs in the background — progress shows up as `completeness.pairs_judged` on the summary — is bounded by `[eval] judge_max_cost_per_run`, and its spend is recorded separately on the run's `judge_cost`. `202 Accepted` with the pass's item count; `409 Conflict` if the run isn't terminal or is already being judged; optional body `{"sample_n": N, "limit": N}` to judge a calibration subset or cap the pass.
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Routine staleness sweep of the docs site (`website/content/docs/`) against the current codebase turned up docs that had fallen behind three same-day feature commits (`66c1309`, `e65de47`, `fd3b21e`):

- `website/content/docs/reference/config.md` was missing the `[safety.reply_guard]` section entirely (`internal/config/config.go`'s `SafetyConfig`/`ReplyGuardConfig`), even though `website/static/llms-full.txt` already documented it. Added a table matching the existing section style.
- `website/content/docs/reference/rest-api.md` was missing `POST /api/v1/eval/runs/{id}/judge` (registered in `internal/api/server.go`, documented in `internal/api/eval.go`'s OpenAPI annotations), even though `config.md`'s `[eval]` prose already references it. Added a matching endpoint entry.
- `evals.md`, `config.md`, and `rest-api.md` were all content-edited by those same commits earlier today without bumping `lastmod` frontmatter, so the pages under-reported how current they actually are. Bumped all three to today's date.

Everything else checked out clean: CLI reference matches the Cobra command definitions, all other config sections match their structs, all other REST endpoints are documented, homepage feature claims still hold, and no broken internal links were found (full audit covered getting-started/guides pages too).

## Test plan

- [x] Diffed changes against `internal/config/config.go` (`SafetyConfig`, `ReplyGuardConfig`) and `internal/api/eval.go` (`handleJudgeEvalRun` doc comment) for accuracy
- [x] Confirmed `prettier --check` warnings on the touched files are pre-existing (present before these edits too), not introduced by this change
- [x] `hugo` build reaches content/frontmatter parsing successfully (fails later on an unrelated missing Dart Sass dependency in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ7gtMKvQu7nMh7d2Rsyo1)_