### PR TITLE
fix(docker): upgrade base packages so the release scan gate passes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,19 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Stage 3: Runtime
 FROM alpine:3.24
-RUN apk add --no-cache ca-certificates tzdata
+# `apk upgrade` before `apk add`: the published alpine:3.24 tag lags the v3.24
+# branch repository, so a plain `apk add` leaves already-fixed CVEs in the
+# image and the release pipeline's Grype gate rejects it (v0.45.0 through
+# v0.47.1 failed this way on openssl 3.5.7-r0, fixed in 3.5.8-r0).
+#
+# VERSION is written to /etc/denkeeper-version so the upgrade layer's cache key
+# changes on every tagged release. Without it, buildx would replay the cached
+# layer from the registry buildcache whenever the alpine:3.24 tag itself has not
+# been republished, silently shipping the stale packages again.
+ARG VERSION=dev
+RUN echo "${VERSION}" > /etc/denkeeper-version && \
+    apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates tzdata
 COPY --from=builder /denkeeper /usr/local/bin/denkeeper
 VOLUME ["/data"]
 ENV DENKEEPER_CONFIG=/data/denkeeper.toml


### PR DESCRIPTION
## What's broken

The `Docker` job's Grype gate (`severity-cutoff: high`, `only-fixed: true`) has rejected every release image since **v0.45.0** — v0.45.0, v0.46.0, v0.47.0 and v0.47.1 all failed at the same `Scan container image` step. Because that step sits before signing, each of those releases pushed an **unsigned, unattested** image to `ghcr.io/temikus/denkeeper` (`Sign Docker image` and `Attest build provenance` were skipped), and `latest` currently points at it.

## Root cause

The runtime stage installed only `ca-certificates` and `tzdata` on top of `alpine:3.24`. The published `alpine:3.24` tag lags the v3.24 branch repository, so the image ships **openssl (libcrypto3/libssl3) 3.5.7-r0** while **3.5.8-r0** is already published in the branch repo for both `x86_64` and `aarch64`.

Reproduced against the released image:

```
$ grype registry:ghcr.io/temikus/denkeeper:0.47.1 --only-fixed
NAME        INSTALLED  FIXED IN  TYPE  VULNERABILITY   SEVERITY
libcrypto3  3.5.7-r0   3.5.8-r0  apk   CVE-2026-18798  High
libssl3     3.5.7-r0   3.5.8-r0  apk   CVE-2026-18798  High
libcrypto3  3.5.7-r0   3.5.8-r0  apk   CVE-2026-63076  High
...  (7 distinct High CVEs × 2 packages, plus 3 Medium/Unknown)
```

`0.45.0` and `0.46.0` scan identically — same package, same version.

## The fix

Run `apk upgrade --no-cache` before the install in the runtime stage. openssl is the only package in the image with an available fix; `busybox` CVE-2025-60876 has no upstream fix and is excluded by `only-fixed`. So the gate should come back clean.

The release version is also written to `/etc/denkeeper-version` in the same layer. Without something version-dependent in it, that layer's cache key stays constant while the `alpine:3.24` tag is not republished, and buildx would replay the `apk upgrade` from `cache-from: type=registry,...:buildcache` — quietly reintroducing the stale packages on a later tag. This makes the upgrade re-run once per release.

## Verification

- Confirmed openssl `3.5.8-r0` is present in the v3.24 `APKINDEX` for `x86_64` **and** `aarch64`, so both build platforms get the fix.
- Confirmed the base image is the source: `grype registry:alpine:3.24 --only-fixed` reports the same 20 matches, so nothing in our own layers contributes.
- Could not build the image here (no Docker daemon in this session) — the real proof is the `Scan container image` step on the release run.

## Not changed

`.grype.yaml`'s six ignore entries no longer match anything in the current Grype DB (verified by scanning with the config bypassed), so they are stale — but the CI run's DB reported 4 ignored matches, and dropping them in a hotfix risks re-blocking the release if CI's DB disagrees. Left alone deliberately; worth a separate cleanup pass.

## Follow-up

Needs a `v0.47.2` tag once merged. v0.47.1's image is unsigned and vulnerable, and `latest` points at it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2nRS1LnSfAHPbQrMYLFZQ)_