### PR TITLE
docs(website): fix stale skill-trigger and persona-approval claims

### DIFF
--- a/website/content/docs/concepts/agents.md
+++ b/website/content/docs/concepts/agents.md
@@ -2,7 +2,7 @@
 title: "Agents"
 description: "Multi-agent routing, personas, and adapter bindings."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-03-28T00:00:00+00:00
+lastmod: 2026-09-04T00:00:00+00:00
 draft: false
 weight: 10
 toc: true
@@ -57,6 +57,5 @@ session_tier = "restricted"
 
 Agents can modify their own persona files within their permission tier:
 
-- **MEMORY.md** — freely writable (working memory)
-- **USER.md** — writable in `supervised` and `autonomous` tiers
-- **SOUL.md** — writable in `supervised` (requires approval) and `autonomous` tiers
+- **MEMORY.md** — freely writable in every tier (working memory)
+- **USER.md** and **SOUL.md** — writable in `autonomous` (applies directly) and `supervised` (goes through the same per-tool-call human approval as any other MCP call); not writable in `restricted`

--- a/website/content/docs/guides/writing-skills.md
+++ b/website/content/docs/guides/writing-skills.md
@@ -2,7 +2,7 @@
 title: "Writing Skills"
 description: "How to create custom skills for your Denkeeper agent."
 date: 2025-01-01T00:00:00+00:00
-lastmod: 2026-08-11T00:00:00+00:00
+lastmod: 2026-09-04T00:00:00+00:00
 draft: false
 weight: 30
 toc: true
@@ -59,7 +59,7 @@ Always acknowledge with: "Logged: $AMOUNT for CATEGORY"
 
 ## Trigger types
 
-- **`command:name`** — activates on the `/name` Telegram command
+- **`command:name`** — activates when the user's message starts with `/name` or `!name` (case-insensitive), on any adapter or channel — Telegram, Discord, the web dashboard, or the REST chat API
 - **`schedule:...`** — marks the skill as scheduler-driven. The text after the colon is ignored; timing comes from a `[[schedules]]` entry whose `skill` field names this skill. Without one, the skill never fires
 - **No triggers** — *ambient*: always included in the system prompt, and matched on every turn
 


### PR DESCRIPTION
## Summary

Scheduled staleness audit of the marketing/docs site (`website/`). The homepage, install instructions, CLI/config/REST-API reference docs, and most concept/guide pages checked out accurate against the current codebase. Two real inaccuracies were found and fixed:

- **`docs/guides/writing-skills.md`** — said `command:name` triggers only fire on the Telegram `/name` command. In `internal/skill/match.go` (`commandMatches`), the trigger fires on either `/name` **or** `!name` (case-insensitive), checked against the raw message text generically — so it works the same on Discord, the web dashboard, and the REST `/api/v1/chat` endpoint, not just Telegram. The sibling page `docs/concepts/skills.md` already described this correctly; `writing-skills.md` was out of sync with it and undersold the feature.
- **`docs/concepts/agents.md`** — said `USER.md` writes directly in the `supervised` tier while only `SOUL.md` requires approval there. Both sections route through the identical path in `internal/configmcp/persona_tools.go` (`applyOrSubmit`), and per `.claude/rules/approval.md`, every MCP tool call in the `supervised` tier requires approval — there's no per-section carve-out for `USER.md`. Fixed to state both require approval in `supervised` and apply directly only in `autonomous` (and neither is writable in `restricted`).

Both pages' `lastmod` frontmatter was bumped to reflect the review.

## Test plan

- [x] Verified the `!name`/`/name`/cross-adapter behavior directly against `internal/skill/match.go:58-79`
- [x] Verified the persona-approval flow against `internal/configmcp/persona_tools.go` and `.claude/rules/approval.md`
- [x] Confirmed no other doc pages (CLI/config/REST-API reference, remaining concept/guide pages, homepage, install instructions) have discrepancies against the code
- [ ] `just build-website` — could not run to completion in this sandbox (missing Dart Sass binary + Node 22 vs required >=24.13.0); confirmed via `git stash` that this failure is pre-existing on `main` and unrelated to this change, which is markdown-content-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPQg5JUAwcWYpUKaeZ3sxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPQg5JUAwcWYpUKaeZ3sxT)_