### PR TITLE
fix(llm): retry and withhold tool calls leaked as text

### DIFF
--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -2251,6 +2251,7 @@ func replyGuardFrom(cfg *config.Config) agent.ReplyGuard {
 		OnRoleMarkup:        rg.OnRoleMarkup,
 		OnOversized:         rg.OnOversized,
 		OnNoToolCalls:       rg.OnNoToolCalls,
+		OnLeakedToolCall:    rg.OnLeakedToolCall,
 		MaxReplyBytes:       rg.MaxReplyBytes,
 		MaxCompletionTokens: rg.MaxCompletionTokens,
 		ExcerptBytes:        rg.ExcerptBytes,

--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -611,6 +611,9 @@ func buildLLMAuditDetail(resp *llm.ChatResponse, provider string) map[string]any
 	if resp.Upstream != "" {
 		d["upstream"] = resp.Upstream
 	}
+	if resp.LeakRetry {
+		d["leaked_tool_call_retry"] = true
+	}
 	if resp.Content != "" {
 		text := resp.Content
 		if len(text) > maxLen {

--- a/internal/agent/engine_replyguard_test.go
+++ b/internal/agent/engine_replyguard_test.go
@@ -17,12 +17,13 @@ import (
 // tests exercise the shipped policy rather than an invented one.
 func defaultTestReplyGuard() ReplyGuard {
 	return ReplyGuard{
-		Enabled:       true,
-		OnRoleMarkup:  GuardWithhold,
-		OnOversized:   GuardWithhold,
-		OnNoToolCalls: GuardWarn,
-		MaxReplyBytes: defaultMaxReplyBytes,
-		ExcerptBytes:  defaultExcerptBytes,
+		Enabled:          true,
+		OnRoleMarkup:     GuardWithhold,
+		OnOversized:      GuardWithhold,
+		OnNoToolCalls:    GuardWarn,
+		OnLeakedToolCall: GuardWithhold,
+		MaxReplyBytes:    defaultMaxReplyBytes,
+		ExcerptBytes:     defaultExcerptBytes,
 	}
 }
 
@@ -420,5 +421,65 @@ func TestReplyGuard_OffActionSkipsSignal(t *testing.T) {
 	}
 	if events := guardEvents(auditor.events); len(events) != 0 {
 		t.Errorf("emitted %d reply_guard events, want 0", len(events))
+	}
+}
+
+func TestReplyGuard_LeakedToolCallWithheld(t *testing.T) {
+	raw := "Let me start with the idempotency guard.functions.kv_get:0{\"key\": \"log:heartbeat:2026-09-05\"}functions.kv_get:1{\"key\": \"log:heartbeat:2026-09-04\"}"
+	e, store, sent, auditor := newGuardTestEngine(t, raw, 120, defaultTestReplyGuard())
+
+	if err := e.HandleMessage(context.Background(), scheduledMsg("heartbeat")); err != nil {
+		t.Fatalf("HandleMessage: %v", err)
+	}
+
+	if len(sent.msgs) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(sent.msgs))
+	}
+	if !strings.HasPrefix(sent.msgs[0].Text, "[engine: reply withheld — "+signalLeakedToolCall) {
+		t.Errorf("wire text = %q, want the withheld notice naming %s", sent.msgs[0].Text, signalLeakedToolCall)
+	}
+	if strings.Contains(sent.msgs[0].Text, "functions.kv_get") {
+		t.Error("wire text leaked the raw call")
+	}
+	if got := storedAssistantContent(t, store, guardTestConvID); got != raw {
+		t.Errorf("stored content = %q, want the raw reply", got)
+	}
+
+	events := guardEvents(auditor.events)
+	if len(events) != 1 {
+		t.Fatalf("emitted %d reply_guard events, want 1", len(events))
+	}
+	detail := guardDetail(t, events[0])
+	signals, _ := detail["signals"].([]any)
+	if len(signals) != 2 || signals[0] != signalLeakedToolCall || signals[1] != signalNoToolCalls {
+		t.Errorf("detail signals = %v, want [%s %s]", signals, signalLeakedToolCall, signalNoToolCalls)
+	}
+	if detail["action"] != GuardWithhold {
+		t.Errorf("detail action = %v, want %q", detail["action"], GuardWithhold)
+	}
+}
+
+// The leak can happen on any round, so unlike no_tool_calls the signal must
+// fire even when tools ran earlier in the turn.
+func TestReplyGuard_LeakedToolCallTripsAfterToolRounds(t *testing.T) {
+	g := defaultTestReplyGuard()
+	content := "Wait, I called it twice.   functions.find-tasks-by-date:8{\"startDate\": \"today\"}"
+	records := []ToolCallRecord{{ToolName: "find-tasks", Outcome: "ok"}, {ToolName: "kv_get", Outcome: "ok"}}
+	res := evaluateReplyGuard(g, scheduledMsg("heartbeat"), content, &llm.ChatResponse{FinishReason: "stop"}, records)
+	if !res.tripped() || res.Action != GuardWithhold {
+		t.Fatalf("expected a withholding trip, got signals=%v action=%q", res.Signals, res.Action)
+	}
+	if len(res.Signals) != 1 || res.Signals[0] != signalLeakedToolCall {
+		t.Errorf("signals = %v, want only %s (tools did run)", res.Signals, signalLeakedToolCall)
+	}
+}
+
+func TestReplyGuard_LeakedToolCallOffSkipsSignal(t *testing.T) {
+	g := defaultTestReplyGuard()
+	g.OnLeakedToolCall = GuardOff
+	content := "functions.kv_get:0{\"key\": \"a\"}"
+	res := evaluateReplyGuard(g, scheduledMsg("heartbeat"), content, &llm.ChatResponse{FinishReason: "stop"}, []ToolCallRecord{{ToolName: "kv_get"}})
+	if res.tripped() {
+		t.Errorf("signal off must not trip, got %v", res.Signals)
 	}
 }

--- a/internal/agent/replyguard.go
+++ b/internal/agent/replyguard.go
@@ -16,6 +16,7 @@ const (
 	signalOversized      = "oversized_reply"
 	signalNoToolCalls    = "no_tool_calls"
 	signalOversizeTokens = "oversized_completion"
+	signalLeakedToolCall = "leaked_tool_call"
 )
 
 // Reply-guard actions. Each signal carries one.
@@ -71,6 +72,11 @@ type ReplyGuard struct {
 	OnRoleMarkup  string
 	OnOversized   string
 	OnNoToolCalls string
+	// OnLeakedToolCall fires when the final text carries a tool call the
+	// upstream failed to parse (llm.LeakedToolCallText). Unlike
+	// OnNoToolCalls it fires even after successful tool rounds, since the
+	// leak can happen on any round.
+	OnLeakedToolCall string
 	// MaxReplyBytes is the largest final reply, in bytes. Non-positive
 	// disables the byte measure.
 	MaxReplyBytes int
@@ -153,20 +159,29 @@ func evaluateReplyGuard(g ReplyGuard, msg adapter.IncomingMessage, content strin
 	if g.OnRoleMarkup != GuardOff && containsReplyMarkup(content) {
 		out.add(signalRoleMarkup, g.OnRoleMarkup)
 	}
-	if g.OnOversized != GuardOff {
-		if g.MaxReplyBytes > 0 && out.replyBytes > g.MaxReplyBytes {
-			out.add(signalOversized, g.OnOversized)
-		}
-		if g.MaxCompletionTokens > 0 && out.completionTokens > g.MaxCompletionTokens {
-			out.add(signalOversizeTokens, g.OnOversized)
-		}
+	if g.OnLeakedToolCall != GuardOff && llm.LeakedToolCallText(content) {
+		out.add(signalLeakedToolCall, g.OnLeakedToolCall)
 	}
+	out.addOversized(g)
 	// A schedule that named a skill expected that skill to do something. A
 	// triggerless or ad-hoc scheduled message has no such expectation.
 	if g.OnNoToolCalls != GuardOff && msg.SkillName != "" && out.toolCalls == 0 {
 		out.add(signalNoToolCalls, g.OnNoToolCalls)
 	}
 	return out
+}
+
+// addOversized evaluates both size measures under the single OnOversized action.
+func (r *replyGuardResult) addOversized(g ReplyGuard) {
+	if g.OnOversized == GuardOff {
+		return
+	}
+	if g.MaxReplyBytes > 0 && r.replyBytes > g.MaxReplyBytes {
+		r.add(signalOversized, g.OnOversized)
+	}
+	if g.MaxCompletionTokens > 0 && r.completionTokens > g.MaxCompletionTokens {
+		r.add(signalOversizeTokens, g.OnOversized)
+	}
 }
 
 // add records one tripped signal and promotes the result's action. withhold

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,12 @@ type ReplyGuardConfig struct {
 	// common, so this is a hint rather than proof. Set it to "withhold" when
 	// every scheduled skill on this instance is known to use tools.
 	OnNoToolCalls string `toml:"on_no_tool_calls"`
+	// OnLeakedToolCall fires when the final reply carries a tool call rendered
+	// as plain text (`functions.kv_get:0{...}`) — an upstream that failed to
+	// parse the model's native call format. The router already retries such
+	// a response once; this catches the retry also failing. Default:
+	// "withhold": the text is never a usable answer.
+	OnLeakedToolCall string `toml:"on_leaked_tool_call"`
 	// MaxReplyBytes caps the final reply in bytes. Default: 16000, roughly four
 	// Telegram chunks and under half that adapter's own render limit, so a trip
 	// is a strong signal rather than a long-but-legitimate reply. Negative
@@ -1634,6 +1640,9 @@ func applyReplyGuardDefaults(cfg *Config) {
 	if rg.OnNoToolCalls == "" {
 		rg.OnNoToolCalls = ReplyGuardWarn
 	}
+	if rg.OnLeakedToolCall == "" {
+		rg.OnLeakedToolCall = ReplyGuardWithhold
+	}
 	if rg.MaxReplyBytes == 0 {
 		rg.MaxReplyBytes = 16000
 	}
@@ -2287,11 +2296,12 @@ func validateKV(k *KVConfig) error {
 // strings can be wrong — and a typo there must not silently read as "off".
 func validateReplyGuard(rg *ReplyGuardConfig) error {
 	actions := map[string]string{
-		"on_role_markup":   rg.OnRoleMarkup,
-		"on_oversized":     rg.OnOversized,
-		"on_no_tool_calls": rg.OnNoToolCalls,
+		"on_role_markup":      rg.OnRoleMarkup,
+		"on_oversized":        rg.OnOversized,
+		"on_no_tool_calls":    rg.OnNoToolCalls,
+		"on_leaked_tool_call": rg.OnLeakedToolCall,
 	}
-	for _, key := range []string{"on_role_markup", "on_oversized", "on_no_tool_calls"} {
+	for _, key := range []string{"on_role_markup", "on_oversized", "on_no_tool_calls", "on_leaked_tool_call"} {
 		switch actions[key] {
 		case "", ReplyGuardOff, ReplyGuardWarn, ReplyGuardWithhold:
 		default:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5034,6 +5034,9 @@ func TestParse_ReplyGuardDefaults(t *testing.T) {
 	if rg.OnNoToolCalls != ReplyGuardWarn {
 		t.Errorf("on_no_tool_calls = %q, want %q", rg.OnNoToolCalls, ReplyGuardWarn)
 	}
+	if rg.OnLeakedToolCall != ReplyGuardWithhold {
+		t.Errorf("on_leaked_tool_call = %q, want %q", rg.OnLeakedToolCall, ReplyGuardWithhold)
+	}
 	if rg.MaxReplyBytes != 16000 {
 		t.Errorf("max_reply_bytes = %d, want 16000", rg.MaxReplyBytes)
 	}
@@ -5052,6 +5055,7 @@ enabled = false
 on_role_markup = "warn"
 on_oversized = "off"
 on_no_tool_calls = "withhold"
+on_leaked_tool_call = "warn"
 max_reply_bytes = -1
 max_completion_tokens = 8000
 excerpt_bytes = 500
@@ -5063,8 +5067,8 @@ excerpt_bytes = 500
 	if rg.IsEnabled() {
 		t.Error("explicit enabled = false was overwritten")
 	}
-	if rg.OnRoleMarkup != ReplyGuardWarn || rg.OnOversized != ReplyGuardOff || rg.OnNoToolCalls != ReplyGuardWithhold {
-		t.Errorf("actions = %q/%q/%q, want warn/off/withhold", rg.OnRoleMarkup, rg.OnOversized, rg.OnNoToolCalls)
+	if rg.OnRoleMarkup != ReplyGuardWarn || rg.OnOversized != ReplyGuardOff || rg.OnNoToolCalls != ReplyGuardWithhold || rg.OnLeakedToolCall != ReplyGuardWarn {
+		t.Errorf("actions = %q/%q/%q/%q, want warn/off/withhold/warn", rg.OnRoleMarkup, rg.OnOversized, rg.OnNoToolCalls, rg.OnLeakedToolCall)
 	}
 	// Negative is the "off" sentinel for the byte cap, since a written 0 is
 	// indistinguishable from an omitted key and takes the default.
@@ -5219,5 +5223,15 @@ func TestParse_KVDefaultTTL_RejectsBadEntries(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "kv.default_ttl") {
 			t.Errorf("%s: expected a kv.default_ttl validation error, got %v", name, err)
 		}
+	}
+}
+
+func TestParse_ReplyGuardRejectsUnknownLeakAction(t *testing.T) {
+	_, err := Parse([]byte(baseConfig + `
+[safety.reply_guard]
+on_leaked_tool_call = "hold"
+`))
+	if err == nil || !strings.Contains(err.Error(), "on_leaked_tool_call") {
+		t.Fatalf("expected validation error naming on_leaked_tool_call, got %v", err)
 	}
 }

--- a/internal/llm/leak.go
+++ b/internal/llm/leak.go
@@ -1,0 +1,42 @@
+package llm
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Some OpenRouter upstreams render Kimi's native call format into the text
+// channel as `functions.kv_get:0{"key": "..."}`. The brace is required so a
+// prose mention of a function name does not match.
+var leakedCallPattern = regexp.MustCompile(`(?m)functions\.[A-Za-z0-9_-]+:\d+\s*\{`)
+
+// Kimi's native tool-call delimiters; as plain text they mean the upstream did
+// not translate the call into tool_calls.
+var leakedCallMarkers = []string{
+	"<|tool_call_begin|>",
+	"<|tool_calls_section_begin|>",
+}
+
+// LeakedToolCallText reports whether content carries a tool call rendered as
+// plain text instead of a structured tool_calls entry.
+func LeakedToolCallText(content string) bool {
+	if leakedCallPattern.MatchString(content) {
+		return true
+	}
+	for _, m := range leakedCallMarkers {
+		if strings.Contains(content, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// LooksLikeLeakedToolCall reports whether resp is a "final" answer that is
+// really an unparsed tool call: an upstream fault worth one retry, not model
+// output.
+func LooksLikeLeakedToolCall(resp *ChatResponse) bool {
+	if resp == nil || resp.FinishReason != "stop" || len(resp.ToolCalls) > 0 {
+		return false
+	}
+	return LeakedToolCallText(resp.Content)
+}

--- a/internal/llm/leak_test.go
+++ b/internal/llm/leak_test.go
@@ -1,0 +1,50 @@
+package llm
+
+import "testing"
+
+func TestLeakedToolCallText_MatchesAuditShapes(t *testing.T) {
+	cases := map[string]string{
+		"single call after prose": "Let me start with the idempotency guard.functions.kv_get:0{\"key\": \"log:heartbeat:2026-09-05\"}",
+		"two calls concatenated":  "functions.kv_get:0{\"key\": \"a\"}functions.kv_get:1{\"key\": \"b\"}",
+		"hyphenated tool name":    "   functions.find-tasks-by-date:8{\"startDate\": \"today\"}",
+		"space before brace":      "functions.kv_set:6 {\"key\": \"x\"}",
+		"kimi native delimiter":   "thinking...<|tool_call_begin|>functions.kv_get<|tool_call_argument_begin|>{}",
+		"kimi section delimiter":  "<|tool_calls_section_begin|>",
+	}
+	for name, content := range cases {
+		if !LeakedToolCallText(content) {
+			t.Errorf("%s: expected leak detection for %q", name, content)
+		}
+	}
+}
+
+func TestLeakedToolCallText_IgnoresProse(t *testing.T) {
+	cases := []string{
+		"",
+		"Call functions.kv_get with the key you need.",
+		"The tool `functions.kv_get:0` was invoked earlier.",
+		"Here is a JSON object: {\"key\": \"value\"}",
+		"Top stories:\n1. [Title](https://example.com)",
+	}
+	for _, content := range cases {
+		if LeakedToolCallText(content) {
+			t.Errorf("false positive on %q", content)
+		}
+	}
+}
+
+func TestLooksLikeLeakedToolCall_RequiresStopWithoutCalls(t *testing.T) {
+	leaked := "functions.kv_get:0{\"key\": \"a\"}"
+	if !LooksLikeLeakedToolCall(&ChatResponse{Content: leaked, FinishReason: "stop"}) {
+		t.Error("stop + no tool calls + leaked text should be detected")
+	}
+	if LooksLikeLeakedToolCall(&ChatResponse{Content: leaked, FinishReason: "tool_calls", ToolCalls: []ToolCall{{ID: "1"}}}) {
+		t.Error("a structured tool_calls response is not a leak even if the text echoes one")
+	}
+	if LooksLikeLeakedToolCall(&ChatResponse{Content: leaked, FinishReason: "length"}) {
+		t.Error("a truncated response is a different fault, not a leak")
+	}
+	if LooksLikeLeakedToolCall(nil) {
+		t.Error("nil response must not be a leak")
+	}
+}

--- a/internal/llm/openrouter/openrouter.go
+++ b/internal/llm/openrouter/openrouter.go
@@ -205,6 +205,11 @@ func (c *Client) resetSticky() {
 	c.stickyMu.Unlock()
 }
 
+// ResetUpstreamPreference implements llm.UpstreamFaultReporter: the router
+// calls it when a 200 response turned out to be broken (a tool call leaked as
+// text), which the error-based reset above cannot see.
+func (c *Client) ResetUpstreamPreference() { c.resetSticky() }
+
 func (c *Client) Name() string { return c.name }
 
 // SupportsStreaming implements llm.StreamingProvider.
@@ -311,8 +316,11 @@ func (c *Client) chatCompletionInner(ctx context.Context, req llm.ChatRequest) (
 		return nil, fmt.Errorf("no choices in response")
 	}
 
-	c.recordProvider(apiResp.Provider)
-	return buildChatResponse(&apiResp), nil
+	built := buildChatResponse(&apiResp)
+	if !llm.LooksLikeLeakedToolCall(built) {
+		c.recordProvider(apiResp.Provider)
+	}
+	return built, nil
 }
 
 // chatCompletionStream handles the streaming path using the shared OAI helper.
@@ -412,7 +420,9 @@ func (c *Client) chatCompletionStream(ctx context.Context, req llm.ChatRequest) 
 		}
 		chatResp.CostUSD = result.Usage.Cost
 	}
-	c.recordProvider(result.Provider)
+	if !llm.LooksLikeLeakedToolCall(chatResp) {
+		c.recordProvider(result.Provider)
+	}
 	return chatResp, nil
 }
 

--- a/internal/llm/openrouter/openrouter_test.go
+++ b/internal/llm/openrouter/openrouter_test.go
@@ -1086,3 +1086,47 @@ func TestStickyRouting_StreamMidStreamErrorResets(t *testing.T) {
 		t.Fatalf("mid-stream error must reset sticky preference, got %+v", p)
 	}
 }
+
+func TestStickyRouting_NotRecordedOnLeakedToolCall(t *testing.T) {
+	var bodies []apiRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req apiRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		bodies = append(bodies, req)
+		resp := okResponseWithProvider("Decart")
+		resp.Choices[0].Message.Content = "Checking.functions.kv_get:0{\"key\": \"a\"}"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient("k", srv.URL, srv.Client())
+	c.SetProviderRouting(nil, nil, time.Hour)
+	base := time.Unix(1_000_000, 0)
+	c.now = func() time.Time { return base }
+
+	for i := 0; i < 2; i++ {
+		if _, err := c.ChatCompletion(context.Background(), simpleReq()); err != nil {
+			t.Fatalf("call %d: %v", i+1, err)
+		}
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("want 2 captured requests, got %d", len(bodies))
+	}
+	if bodies[1].Provider != nil {
+		t.Errorf("a leaked 200 must not pin the upstream, got %+v", bodies[1].Provider)
+	}
+}
+
+func TestResetUpstreamPreference_ClearsSticky(t *testing.T) {
+	c := New("k")
+	c.SetProviderRouting(nil, nil, time.Hour)
+	c.recordProvider("Decart")
+	if p := c.buildProviderParam(); p == nil || len(p.Order) != 1 {
+		t.Fatalf("precondition: sticky should be set, got %+v", p)
+	}
+	c.ResetUpstreamPreference()
+	if p := c.buildProviderParam(); p != nil {
+		t.Errorf("sticky should be cleared, got %+v", p)
+	}
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -151,6 +151,19 @@ type ChatResponse struct {
 	// Upstream is the provider-reported serving upstream (OpenRouter's routed
 	// provider). Empty when the provider has no such concept.
 	Upstream string
+	// LeakRetry is set by the router when this completion was re-issued
+	// because the first attempt returned a tool call as plain text (see
+	// LooksLikeLeakedToolCall). It is set whether or not the retry recovered,
+	// so the audit trail records that the upstream misbehaved.
+	LeakRetry bool
+}
+
+// UpstreamFaultReporter is implemented by providers that keep per-upstream
+// state (sticky routing) which should be discarded when a response was
+// syntactically successful but semantically broken — a 200 the provider's own
+// error classification cannot see.
+type UpstreamFaultReporter interface {
+	ResetUpstreamPreference()
 }
 
 // ToolCall represents a tool invocation requested by the LLM (OpenAI format).

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -375,7 +375,7 @@ func (r *Router) completeInternal(ctx context.Context, sessionID string, message
 			req.OnStream = onStream
 		}
 	}
-	resp, err := activeProvider.ChatCompletion(ctx, req)
+	resp, err := r.primaryCompletion(ctx, sessionID, activeProvider, req, onStream, attrs)
 	if err == nil {
 		slog.Debug("llm completion",
 			"provider", r.defaultProvider,
@@ -420,6 +420,47 @@ func (r *Router) completeInternal(ctx context.Context, sessionID string, message
 	if source == "unknown" {
 		slog.Warn("no pricing data for model", "model", resp.Model)
 	}
+	return resp, nil
+}
+
+// primaryCompletion makes the primary call and re-issues it once when the
+// answer is a tool call leaked as text.
+func (r *Router) primaryCompletion(ctx context.Context, sessionID string, provider Provider, req ChatRequest, onStream StreamCallback, attrs metric.MeasurementOption) (*ChatResponse, error) {
+	resp, err := provider.ChatCompletion(ctx, req)
+	if err == nil && LooksLikeLeakedToolCall(resp) {
+		return r.retryLeakedToolCall(ctx, sessionID, provider, req, resp, onStream, attrs)
+	}
+	return resp, err
+}
+
+// retryLeakedToolCall re-issues a completion whose "final" answer was a tool
+// call rendered as plain text — an upstream that did not translate the model's
+// native call format into tool_calls. The leaked attempt was billed, so its
+// cost is recorded before the retry. A provider holding sticky-upstream state
+// is told to drop it first: the fault is invisible to its own error
+// classification (it was a 200). Exactly one retry; a second leak is returned
+// as-is for the engine's reply guard to hold.
+func (r *Router) retryLeakedToolCall(ctx context.Context, sessionID string, provider Provider, req ChatRequest, leaked *ChatResponse, onStream StreamCallback, attrs metric.MeasurementOption) (*ChatResponse, error) {
+	cost, source := TokenCost(leaked, r.pricing, provider.Name())
+	r.costTracker.RecordWithProvider(sessionID, provider.Name(), cost, leaked.TokensUsed, source)
+	r.mErrors.Add(ctx, 1, attrs)
+	slog.Warn("llm: tool call leaked into text, retrying once",
+		"provider", provider.Name(),
+		"upstream", leaked.Upstream,
+		"session", sessionID,
+		"content_len", len(leaked.Content),
+	)
+	if fr, ok := provider.(UpstreamFaultReporter); ok {
+		fr.ResetUpstreamPreference()
+	}
+	if onStream != nil {
+		onStream(StreamChunk{Reset: true})
+	}
+	resp, err := provider.ChatCompletion(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	resp.LeakRetry = true
 	return resp, nil
 }
 

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -1227,3 +1227,103 @@ func TestHasProvider_RegisteredAndUnknown(t *testing.T) {
 		t.Error("HasProvider(nope) = true, want false")
 	}
 }
+
+// leakingMockProvider returns leaked-text responses for the first leakCount
+// calls, then a clean one, and records fault reports.
+type leakingMockProvider struct {
+	name      string
+	leakCount int
+	calls     int
+	resets    int
+}
+
+func (p *leakingMockProvider) Name() string                        { return p.name }
+func (p *leakingMockProvider) HealthCheck(_ context.Context) error { return nil }
+func (p *leakingMockProvider) ResetUpstreamPreference()            { p.resets++ }
+func (p *leakingMockProvider) ChatCompletion(_ context.Context, _ ChatRequest) (*ChatResponse, error) {
+	p.calls++
+	usage := TokenUsage{Prompt: 10, Completion: 5, Total: 15}
+	if p.calls <= p.leakCount {
+		return &ChatResponse{
+			Content:      "Let me check.functions.kv_get:0{\"key\": \"log:heartbeat\"}",
+			FinishReason: "stop",
+			Model:        "test-model",
+			TokensUsed:   usage,
+			Upstream:     "Decart",
+		}, nil
+	}
+	return &ChatResponse{Content: "clean answer", FinishReason: "stop", Model: "test-model", TokensUsed: usage}, nil
+}
+
+func TestRouter_LeakedToolCallRetriedOnce(t *testing.T) {
+	ct := NewCostTracker(SessionLimits{Hard: 10.0}, nil)
+	r := NewRouter("mock", "test-model", ct)
+	p := &leakingMockProvider{name: "mock", leakCount: 1}
+	r.RegisterProvider(p)
+
+	resets := 0
+	onStream := func(c StreamChunk) {
+		if c.Reset {
+			resets++
+		}
+	}
+	resp, err := r.CompleteStream(context.Background(), "s1", []Message{{Role: "user", Content: "hi"}}, onStream)
+	if err != nil {
+		t.Fatalf("CompleteStream: %v", err)
+	}
+	if p.calls != 2 {
+		t.Errorf("provider calls = %d, want 2 (leak + one retry)", p.calls)
+	}
+	if resp.Content != "clean answer" {
+		t.Errorf("content = %q, want the retry's answer", resp.Content)
+	}
+	if !resp.LeakRetry {
+		t.Error("LeakRetry should be set on the recovered response")
+	}
+	if p.resets != 1 {
+		t.Errorf("ResetUpstreamPreference called %d times, want 1", p.resets)
+	}
+	if resets != 1 {
+		t.Errorf("stream Reset chunks = %d, want 1 so the consumer drops the leaked deltas", resets)
+	}
+	// Both attempts were billed.
+	if got := ct.SessionCost("s1"); got <= 0 {
+		t.Errorf("session cost = %v, want both attempts recorded", got)
+	}
+}
+
+func TestRouter_LeakedToolCallSecondLeakReturned(t *testing.T) {
+	ct := NewCostTracker(SessionLimits{Hard: 10.0}, nil)
+	r := NewRouter("mock", "test-model", ct)
+	p := &leakingMockProvider{name: "mock", leakCount: 5}
+	r.RegisterProvider(p)
+
+	resp, err := r.Complete(context.Background(), "s1", []Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if p.calls != 2 {
+		t.Errorf("provider calls = %d, want exactly 2 — never more than one retry", p.calls)
+	}
+	if !LeakedToolCallText(resp.Content) {
+		t.Errorf("second leak must be returned as-is for the reply guard, got %q", resp.Content)
+	}
+	if !resp.LeakRetry {
+		t.Error("LeakRetry should be set even when the retry also leaked")
+	}
+}
+
+func TestRouter_CleanResponseNotRetried(t *testing.T) {
+	ct := NewCostTracker(SessionLimits{Hard: 10.0}, nil)
+	r := NewRouter("mock", "test-model", ct)
+	p := &leakingMockProvider{name: "mock", leakCount: 0}
+	r.RegisterProvider(p)
+
+	resp, err := r.Complete(context.Background(), "s1", []Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if p.calls != 1 || resp.LeakRetry || p.resets != 0 {
+		t.Errorf("clean response: calls=%d LeakRetry=%v resets=%d, want 1/false/0", p.calls, resp.LeakRetry, p.resets)
+	}
+}

--- a/website/content/docs/reference/config.md
+++ b/website/content/docs/reference/config.md
@@ -491,6 +491,7 @@ Each signal takes `"withhold"`, `"warn"` (audit but deliver anyway), or `"off"`.
 | `on_role_markup` | string | `"withhold"` | Reply carries role/tool-call scaffolding as plain text (`<rs_tool_calls>`, `<\|im_start\|>`, `"\n\nHuman:"`, ...) instead of calling a tool |
 | `on_oversized` | string | `"withhold"` | Reply exceeds `max_reply_bytes` or `max_completion_tokens` |
 | `on_no_tool_calls` | string | `"warn"` | A schedule named a skill and the turn made no tool calls at all; only flags, since some skills legitimately finish without tools |
+| `on_leaked_tool_call` | string | `"withhold"` | The final reply carries a tool call rendered as plain text (`functions.kv_get:0{...}`) — an upstream that failed to parse the model's native call format. The router retries such a response once before the guard sees it |
 | `max_reply_bytes` | int | `16000` | Caps the final reply in bytes (~4 Telegram chunks, under half that adapter's own render limit). Negative disables |
 | `max_completion_tokens` | int | `0` | Caps provider-reported completion tokens. `0` disables — it measures the same thing as `max_reply_bytes` |
 | `excerpt_bytes` | int | `200` | How much of the held reply reaches the audit detail. Negative disables |

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -443,6 +443,10 @@ Each signal takes "withhold", "warn" (audit but deliver anyway) or "off".
     on_no_tool_calls = "warn"        # a schedule named a skill and no tool ran;
                                      # only flags, since some skills legitimately
                                      # finish without tools
+    on_leaked_tool_call = "withhold" # reply carries a tool call as plain text
+                                     # (functions.kv_get:0{...}) — the upstream
+                                     # failed to parse the model's call format;
+                                     # the router retries once before this
     max_reply_bytes = 16000          # ~4 Telegram chunks, well under that
                                      # adapter's own 35000-byte render limit;
                                      # negative disables (a written 0 defaults)


### PR DESCRIPTION
**TL;DR:** one OpenRouter upstream (Decart) returns Kimi tool calls as plain text with `finish_reason: stop`. In the 2026-09-03..05 audit that was 7 of 7 Decart completions and it killed 4 of 10 heartbeats. Nothing in the stack recognised the shape. This adds detection, one retry with a sticky-routing reset, and a reply-guard signal for the case where the retry also fails.

Findings and evidence: `design/agent-ops-findings-2026-09-05.md` F1/F8. Plan: `design/plans/7-agent-ops-fixes-2026-09.md` C1+C2.

**What to review**

1. `internal/llm/leak.go` - the detector. Regex requires the trailing `{` so a prose mention of `functions.kv_get` does not match. Kimi's native `<|tool_call_begin|>` delimiters are also caught.
2. `internal/llm/router.go` `primaryCompletion` / `retryLeakedToolCall` - exactly one retry. The leaked attempt is billed to the session and counted in `mErrors`. A provider implementing the new `llm.UpstreamFaultReporter` is told to drop its sticky preference first, because the fault is a 200 and invisible to the error-based reset. `StreamChunk{Reset: true}` reuses the existing replay contract so a live stream discards the leaked deltas.
3. `internal/llm/openrouter/openrouter.go` - `recordProvider` is skipped on a leaked 200 (both paths), and `ResetUpstreamPreference` wraps `resetSticky`.
4. `internal/agent/replyguard.go` - new `leaked_tool_call` signal, config `[safety.reply_guard] on_leaked_tool_call`, default `withhold`. Unlike `no_tool_calls` it fires after successful tool rounds too - 3 of the 7 leaks happened mid-turn.
5. `ChatResponse.LeakRetry` surfaces as `leaked_tool_call_retry: true` in the LLM audit detail so the next audit can count recoveries.

Not in this PR: pinning `provider_order` in the deployed TOML (operator action, no code).

<details>
<summary>Tests</summary>

- `internal/llm/leak_test.go`: the three shapes from the audit, Kimi delimiters, prose negatives, finish-reason gating.
- `router_test.go`: leak then clean (2 calls, reset called once, `LeakRetry` set, stream Reset emitted, both attempts billed); leak twice (exactly 2 calls, second leak returned); clean response untouched.
- `openrouter_test.go`: a leaked 200 does not pin the upstream; `ResetUpstreamPreference` clears it.
- `engine_replyguard_test.go`: end-to-end withhold with audit signals `[leaked_tool_call, no_tool_calls]`; trips with prior tool records; `off` skips.
- `config_test.go`: default `withhold`, explicit value survives, typo rejected; `llms-full.txt` drift test updated.

`just test` green. `just lint` has 6 pre-existing `SA5011` staticcheck hits in test files that also fail on `main`; none in this diff.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPzDejjvYWA2Dj2L6X2Q3
