### PR TITLE
feat(scheduler): surface last run and kv_get updated_at to the model

### DIFF
--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -1683,7 +1683,7 @@ func buildScheduledMessage(sc config.ScheduleConfig, entry scheduler.Entry, targ
 		ExternalID:     target.ExternalID,
 		ConversationID: conversationID,
 		UserName:       "scheduler",
-		Text:           scheduler.FormatScheduledText(entry.Name, entry.Skill, now, loc),
+		Text:           scheduler.FormatScheduledTextWithPrev(entry.Name, entry.Skill, now, entry.PrevRun, loc),
 		SkillName:      sc.Skill,
 		ScheduleName:   sc.Name,
 		ScheduleCron:   sc.Schedule,

--- a/cmd/denkeeper/main_test.go
+++ b/cmd/denkeeper/main_test.go
@@ -495,6 +495,13 @@ func TestBuildScheduledMessage_TextIncludesDateHeader(t *testing.T) {
 	if msg.Text != wantText {
 		t.Errorf("Text = %q, want %q", msg.Text, wantText)
 	}
+
+	entry.PrevRun = now.Add(-3 * time.Hour)
+	withPrev := buildScheduledMessage(sc, entry, target, "chan:main", sydney, now)
+	wantPrev := "[Scheduled: heartbeat | 2026-07-07T10:45:00+10:00 Australia/Sydney | 2026-W28 | last run 2026-07-07T07:45:00+10:00 (3h ago)]"
+	if withPrev.Text != wantPrev {
+		t.Errorf("Text with PrevRun = %q, want %q", withPrev.Text, wantPrev)
+	}
 	if !msg.Timestamp.Equal(now) {
 		t.Errorf("Timestamp = %v, want %v (must match the rendered header)", msg.Timestamp, now)
 	}

--- a/internal/api/dryrun.go
+++ b/internal/api/dryrun.go
@@ -373,7 +373,7 @@ func (s *Server) handleDryRunSchedule(w http.ResponseWriter, r *http.Request) {
 		Channel:     entry.Channel,
 	}
 	convID := newDryRunConvID()
-	msg := configmcp.BuildScheduledMessage(cfg, agent.AdapterBinding{}, convID, asOf, e.Location())
+	msg := configmcp.BuildScheduledMessage(cfg, agent.AdapterBinding{}, convID, asOf, time.Time{}, e.Location())
 
 	s.runDryRun(w, r, e, msg, agent.ExecPolicy{
 		Kind:      agent.ExecDryRun,
@@ -557,7 +557,7 @@ func buildSkillDryRunMessage(mode, skillName string, sk skill.Skill, input dryRu
 				SessionTier: entry.SessionTier,
 				SessionMode: entry.SessionMode,
 				Channel:     entry.Channel,
-			}, agent.AdapterBinding{}, convID, asOf, loc), ""
+			}, agent.AdapterBinding{}, convID, asOf, time.Time{}, loc), ""
 		}
 		// Nothing schedules this skill; the caller asked for a scheduled run
 		// anyway ("what would happen if I scheduled it"), so synthesise the

--- a/internal/configmcp/handlers.go
+++ b/internal/configmcp/handlers.go
@@ -2073,13 +2073,16 @@ func (s *Server) locationFor(agentName string) *time.Location {
 // It is shared by the live job closure and the schedule dry-run endpoint, so a
 // preview is by construction the same message the schedule would actually
 // send, not a re-creation that can drift from it.
-func BuildScheduledMessage(cfg scheduler.Config, target agent.AdapterBinding, conversationID string, fireTime time.Time, loc *time.Location) adapter.IncomingMessage {
+//
+// prevRun is the schedule's previous fire (zero for a first fire or a
+// preview), rendered into the header so the skill never computes it.
+func BuildScheduledMessage(cfg scheduler.Config, target agent.AdapterBinding, conversationID string, fireTime, prevRun time.Time, loc *time.Location) adapter.IncomingMessage {
 	return adapter.IncomingMessage{
 		Adapter:        target.Adapter,
 		ExternalID:     target.ExternalID,
 		ConversationID: conversationID,
 		UserName:       "scheduler",
-		Text:           scheduler.FormatScheduledText(cfg.Name, cfg.Skill, fireTime, loc),
+		Text:           scheduler.FormatScheduledTextWithPrev(cfg.Name, cfg.Skill, fireTime, prevRun, loc),
 		SkillName:      cfg.Skill,
 		ScheduleName:   cfg.Name,
 		ScheduleCron:   cfg.Schedule,
@@ -2118,7 +2121,7 @@ func BuildScheduleJob(cfg scheduler.Config, handleMsg func(context.Context, adap
 		var lastErr string
 		now := time.Now()
 		for _, target := range targets {
-			msg := BuildScheduledMessage(cfg, target, conversationID, now, opts.Location)
+			msg := BuildScheduledMessage(cfg, target, conversationID, now, entry.PrevRun, opts.Location)
 			if entry.SessionMode == "isolated" {
 				msg.ConversationID = fmt.Sprintf("sched:%s:%d", entry.Name, entry.LastRun.UnixNano())
 			}

--- a/internal/configmcp/kv_tools.go
+++ b/internal/configmcp/kv_tools.go
@@ -30,7 +30,7 @@ const (
 func (s *Server) registerKVTools() {
 	s.mcpServer.AddTool(&mcp.Tool{
 		Name:        "kv_get",
-		Description: "Get a value from your key-value store. Returns null if the key doesn't exist or has expired. Keys are conventionally namespaced (`cache:*`, `log:*`, `pref:*`, `state:*`, or anything that fits the use case).",
+		Description: "Get a value from your key-value store. Returns {value, updated_at} (RFC 3339), or value null if the key doesn't exist or has expired. Keys are conventionally namespaced (`cache:*`, `log:*`, `pref:*`, `state:*`, or anything that fits the use case).",
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
@@ -109,7 +109,7 @@ func (s *Server) handleKVGet(ctx context.Context, req *mcp.CallToolRequest) (*mc
 		return toolError("key is required"), nil
 	}
 
-	val, ok, err := s.deps.KVStore.Get(ctx, s.deps.AgentName, input.Key)
+	entry, ok, err := s.deps.KVStore.GetEntry(ctx, s.deps.AgentName, input.Key)
 	if err != nil {
 		return toolError(fmt.Sprintf("kv_get failed: %v", err)), nil
 	}
@@ -117,7 +117,10 @@ func (s *Server) handleKVGet(ctx context.Context, req *mcp.CallToolRequest) (*mc
 		return toolText(`{"value": null}`), nil
 	}
 
-	resp, _ := json.Marshal(map[string]string{"value": val})
+	resp, _ := json.Marshal(map[string]string{
+		"value":      entry.Value,
+		"updated_at": entry.UpdatedAt.UTC().Format(time.RFC3339),
+	})
 	return toolText(string(resp)), nil
 }
 

--- a/internal/configmcp/kv_tools_test.go
+++ b/internal/configmcp/kv_tools_test.go
@@ -353,3 +353,37 @@ func TestHandleKVSet_DefaultTTLByPrefix(t *testing.T) {
 		t.Errorf("unmatched prefix should not expire, got %v", exp)
 	}
 }
+
+func TestHandleKVGet_ReturnsUpdatedAt(t *testing.T) {
+	session, store := newKVServer(t, nil)
+	if err := store.Set(context.Background(), "test-agent", "log:heartbeat:2026-09-04", "ran", 0); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	text, isErr := callTool(t, session, "kv_get", map[string]any{"key": "log:heartbeat:2026-09-04"})
+	if isErr {
+		t.Fatalf("kv_get failed: %s", text)
+	}
+	var resp struct {
+		Value     *string `json:"value"`
+		UpdatedAt string  `json:"updated_at"`
+	}
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshaling kv_get response: %v (body: %s)", err, text)
+	}
+	if resp.Value == nil || *resp.Value != "ran" {
+		t.Errorf("value = %v, want \"ran\"", resp.Value)
+	}
+	ts, err := time.Parse(time.RFC3339, resp.UpdatedAt)
+	if err != nil {
+		t.Fatalf("updated_at %q is not RFC 3339: %v", resp.UpdatedAt, err)
+	}
+	if time.Since(ts) > time.Minute {
+		t.Errorf("updated_at = %v, want a recent timestamp", ts)
+	}
+
+	text, isErr = callTool(t, session, "kv_get", map[string]any{"key": "missing"})
+	if isErr || text != `{"value": null}` {
+		t.Errorf("missing key: isErr=%v text=%q, want the null form unchanged", isErr, text)
+	}
+}

--- a/internal/kv/store.go
+++ b/internal/kv/store.go
@@ -43,6 +43,8 @@ type Entry struct {
 // Store provides per-agent key-value storage with optional TTL.
 type Store interface {
 	Get(ctx context.Context, agent, key string) (value string, ok bool, err error)
+	// GetEntry is Get with the row metadata (timestamps, expiry).
+	GetEntry(ctx context.Context, agent, key string) (Entry, bool, error)
 	Set(ctx context.Context, agent, key, value string, ttl time.Duration) error
 	Delete(ctx context.Context, agent, key string) error
 	List(ctx context.Context, agent, prefix string) ([]Entry, error)
@@ -136,6 +138,23 @@ func (s *SQLiteStore) Get(ctx context.Context, agent, key string) (string, bool,
 		return "", false, fmt.Errorf("kv get %q: %w", key, err)
 	}
 	return value, true, nil
+}
+
+// GetEntry returns the full row for a non-expired key.
+func (s *SQLiteStore) GetEntry(ctx context.Context, agent, key string) (Entry, bool, error) {
+	var e Entry
+	err := s.db.GetContext(ctx, &e,
+		`SELECT key, value, created_at, updated_at, expires_at FROM kv
+		 WHERE agent_name = ? AND key = ? AND (expires_at IS NULL OR expires_at > datetime('now'))`,
+		agent, key,
+	)
+	if err != nil {
+		if isNoRows(err) {
+			return Entry{}, false, nil
+		}
+		return Entry{}, false, fmt.Errorf("kv get %q: %w", key, err)
+	}
+	return e, true, nil
 }
 
 // Set stores a key-value pair. If ttl is zero, the key does not expire.

--- a/internal/kv/store_test.go
+++ b/internal/kv/store_test.go
@@ -309,3 +309,28 @@ func TestSetNX_KeyCountLimit(t *testing.T) {
 		t.Fatal("expected error or rejection for exceeding key limit")
 	}
 }
+
+func TestGetEntry_ReturnsMetadata(t *testing.T) {
+	s := mustStore(t)
+	ctx := context.Background()
+
+	if _, ok, err := s.GetEntry(ctx, "agent1", "missing"); err != nil || ok {
+		t.Fatalf("GetEntry missing: ok=%v err=%v, want ok=false", ok, err)
+	}
+	if err := s.Set(ctx, "agent1", "greeting", "hello", time.Hour); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	e, ok, err := s.GetEntry(ctx, "agent1", "greeting")
+	if err != nil || !ok {
+		t.Fatalf("GetEntry: ok=%v err=%v", ok, err)
+	}
+	if e.Key != "greeting" || e.Value != "hello" {
+		t.Errorf("entry = %+v, want key/value greeting/hello", e)
+	}
+	if e.UpdatedAt.IsZero() || time.Since(e.UpdatedAt) > time.Minute {
+		t.Errorf("UpdatedAt = %v, want a recent timestamp", e.UpdatedAt)
+	}
+	if e.ExpiresAt == nil {
+		t.Error("ExpiresAt = nil, want the TTL expiry")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -99,6 +99,7 @@ type Entry struct {
 	Tags        []string
 	Enabled     bool
 	LastRun     time.Time // zero if never fired
+	PrevRun     time.Time // the fire before LastRun; zero until the second fire
 	NextRun     time.Time // zero if disabled or indeterminate
 }
 
@@ -494,6 +495,7 @@ func (s *Scheduler) runInterval(e *internalEntry) {
 		case t := <-ticker.C:
 			now := t.In(s.loc)
 			s.mu.Lock()
+			e.PrevRun = e.LastRun
 			e.LastRun = now
 			e.NextRun = now.Add(e.expr.interval)
 			snapshot := e.Entry
@@ -532,6 +534,7 @@ func (s *Scheduler) runCron(e *internalEntry) {
 			lastFiredMinute = minuteStart
 
 			s.mu.Lock()
+			e.PrevRun = e.LastRun
 			e.LastRun = minuteStart
 			e.NextRun = e.expr.cron.next(minuteStart, s.loc)
 			snapshot := e.Entry

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -356,6 +356,39 @@ func TestScheduler_MultipleFiresUpdateLastRun(t *testing.T) {
 	}
 }
 
+func TestScheduler_PrevRunReachesJobOnSecondFire(t *testing.T) {
+	s := New(discardLogger(), nil)
+
+	seen := make(chan Entry, 5)
+	if err := s.Register(Config{
+		Name:     "fast",
+		Type:     "agent",
+		Schedule: "@every 15ms",
+		Enabled:  true,
+	}, func(e Entry) { seen <- e }); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	s.Start()
+	defer s.Stop()
+
+	var fires []Entry
+	for i := 0; i < 2; i++ {
+		select {
+		case e := <-seen:
+			fires = append(fires, e)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("fire %d did not arrive within timeout", i+1)
+		}
+	}
+	if !fires[0].PrevRun.IsZero() {
+		t.Errorf("first fire PrevRun = %v, want zero", fires[0].PrevRun)
+	}
+	if fires[1].PrevRun.IsZero() || !fires[1].PrevRun.Equal(fires[0].LastRun) {
+		t.Errorf("second fire PrevRun = %v, want the first fire's LastRun %v", fires[1].PrevRun, fires[0].LastRun)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RegisterAndStart tests
 // ---------------------------------------------------------------------------

--- a/internal/scheduler/timefmt.go
+++ b/internal/scheduler/timefmt.go
@@ -12,6 +12,17 @@ import (
 //
 // Example: [Scheduled: heartbeat | 2026-07-07T10:45:00+10:00 Australia/Sydney | 2026-W28]
 func FormatScheduledText(name, skill string, fireTime time.Time, loc *time.Location) string {
+	return FormatScheduledTextWithPrev(name, skill, fireTime, time.Time{}, loc)
+}
+
+// FormatScheduledTextWithPrev is FormatScheduledText plus the previous fire
+// of the same schedule, so a skill can compare against its last run without
+// doing date arithmetic itself (which it gets wrong). A zero prevRun omits
+// the segment rather than printing "never": a first fire after a restart must
+// not read as a reason to do extra work.
+//
+// Example: [Scheduled: heartbeat | 2026-07-07T10:45:00+10:00 Australia/Sydney | 2026-W28 | last run 2026-07-07T07:45:00+10:00 (3h ago)]
+func FormatScheduledTextWithPrev(name, skill string, fireTime, prevRun time.Time, loc *time.Location) string {
 	if loc == nil {
 		loc = time.UTC
 	}
@@ -21,5 +32,25 @@ func FormatScheduledText(name, skill string, fireTime time.Time, loc *time.Locat
 		label = "Scheduled: " + skill
 	}
 	isoYear, isoWeek := t.ISOWeek()
-	return fmt.Sprintf("[%s | %s %s | %04d-W%02d]", label, t.Format(time.RFC3339), loc, isoYear, isoWeek)
+	head := fmt.Sprintf("[%s | %s %s | %04d-W%02d", label, t.Format(time.RFC3339), loc, isoYear, isoWeek)
+	if prevRun.IsZero() {
+		return head + "]"
+	}
+	return fmt.Sprintf("%s | last run %s (%s ago)]", head, prevRun.In(loc).Format(time.RFC3339), humanAgo(fireTime.Sub(prevRun)))
+}
+
+// humanAgo renders a duration at the coarsest unit that still reads as
+// "recent": minutes under an hour, hours under two days, days beyond.
+func humanAgo(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Round(time.Minute)/time.Minute))
+	case d < 48*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Round(time.Hour)/time.Hour))
+	default:
+		return fmt.Sprintf("%dd", int(d.Round(24*time.Hour)/(24*time.Hour)))
+	}
 }

--- a/internal/scheduler/timefmt_test.go
+++ b/internal/scheduler/timefmt_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 )
@@ -131,5 +132,48 @@ func TestScheduler_LocationGetter(t *testing.T) {
 	sydney := mustLoadSydney(t)
 	if got := New(logger, sydney).Location(); got != sydney {
 		t.Errorf("explicit loc: got %v, want %v", got, sydney)
+	}
+}
+
+func TestFormatScheduledTextWithPrev_AppendsLastRun(t *testing.T) {
+	sydney := mustLoadSydney(t)
+	fire := time.Date(2026, 9, 4, 14, 30, 0, 0, sydney)
+	prev := time.Date(2026, 9, 4, 8, 30, 0, 0, sydney)
+
+	got := FormatScheduledTextWithPrev("heartbeat", "heartbeat", fire, prev, sydney)
+	want := "[Scheduled: heartbeat | 2026-09-04T14:30:00+10:00 Australia/Sydney | 2026-W36 | last run 2026-09-04T08:30:00+10:00 (6h ago)]"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatScheduledTextWithPrev_ZeroOmitsSegment(t *testing.T) {
+	sydney := mustLoadSydney(t)
+	fire := time.Date(2026, 7, 7, 10, 45, 0, 0, sydney)
+
+	got := FormatScheduledTextWithPrev("heartbeat", "heartbeat", fire, time.Time{}, sydney)
+	if got != FormatScheduledText("heartbeat", "heartbeat", fire, sydney) {
+		t.Errorf("zero prevRun must render identically to the plain header, got %q", got)
+	}
+	if strings.Contains(got, "last run") {
+		t.Errorf("zero prevRun must not mention a last run: %q", got)
+	}
+}
+
+func TestHumanAgo_Units(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                   "0m",
+		45 * time.Minute:    "45m",
+		90 * time.Minute:    "2h",
+		6 * time.Hour:       "6h",
+		47 * time.Hour:      "47h",
+		49 * time.Hour:      "2d",
+		10 * 24 * time.Hour: "10d",
+		-5 * time.Minute:    "0m",
+	}
+	for d, want := range cases {
+		if got := humanAgo(d); got != want {
+			t.Errorf("humanAgo(%v) = %q, want %q", d, got, want)
+		}
 	}
 }


### PR DESCRIPTION
**TL;DR:** two scheduled runs in the 2026-09-03..05 audit skipped real work because the skill computed "time since last run" itself and got it wrong ("6 hours ago - well within the 2-hour window"), and `kv_get` gave it no timestamp to work with. This puts both facts in front of the model so no skill has to do date arithmetic.

Findings: `design/agent-ops-findings-2026-09-05.md` F2. Plan: `design/plans/7-agent-ops-fixes-2026-09.md` C3+C4.

**What to review**

1. `internal/scheduler/scheduler.go` - `Entry.PrevRun`, set from `LastRun` before it is overwritten in both `runCron` and `runInterval`. `LastRun` itself was already the current fire by the time the job ran, so it could not be used.
2. `internal/scheduler/timefmt.go` - `FormatScheduledTextWithPrev` appends `| last run 2026-09-04T08:30:51+10:00 (6h ago)` inside the existing brackets. A zero `PrevRun` renders the old header byte-for-byte: a first fire after a restart must not say "never" and invite extra work. `humanAgo` is minutes under an hour, hours under two days, days beyond.
3. Both producers pass it (`buildScheduledMessage` in main.go, `configmcp.BuildScheduledMessage` in the config-MCP job closure). The two dry-run callers pass zero - a preview has no previous fire.
4. `kv.Store.GetEntry` + `kv_get` now returns `{"value": ..., "updated_at": "RFC3339"}`. The missing-key form `{"value": null}` is unchanged.

The skills that used to carry idempotency guards were already rewritten this session to drop them (heartbeat 1.7.0 etc.); this PR is what lets any future guard be a string comparison.

<details>
<summary>Tests</summary>

- `timefmt_test.go`: exact header with and without `PrevRun`; `humanAgo` units incl. rounding and negative.
- `scheduler_test.go`: `PrevRun` is zero on the first fire and equals the first fire's `LastRun` on the second.
- `kv/store_test.go`: `GetEntry` missing / present with metadata and TTL expiry.
- `configmcp/kv_tools_test.go`: `kv_get` returns a parseable `updated_at`; missing key unchanged.
- `cmd/denkeeper/main_test.go`: `buildScheduledMessage` renders the segment from `entry.PrevRun`.

`just test` green; lint clean apart from the 6 pre-existing `SA5011` hits on `main`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPzDejjvYWA2Dj2L6X2Q3
