### PR TITLE
feat(agent): answer a scheduled skill dropped for missing tools with a notice

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -971,6 +971,11 @@ func (e *Engine) RemoveMemoryEntry(heading string) error {
 type buildSystemPromptResult struct {
 	prompt        string
 	matchedSkills []skill.Skill
+	// droppedScheduledMissing lists the tools the schedule-driven skill
+	// required but the registry lacks; empty when it was injected. Only the
+	// scheduled skill is tracked — an ambient skill going inactive is not a
+	// reason to skip the turn.
+	droppedScheduledMissing []string
 }
 
 // buildSystemPrompt assembles the current system prompt from the persona (if set)
@@ -1048,7 +1053,7 @@ Today is %s %s (ISO week %04d-W%02d, %s). This date is authoritative — never i
 		MessageText: msg.Text,
 		SkillName:   msg.SkillName,
 	})
-	active := e.filterUnsatisfiedSkills(matched, msg)
+	active, droppedMissing := e.filterUnsatisfiedSkills(matched, msg)
 	// The not-found warning is deliberately evaluated against the pre-filter
 	// set: a skill dropped for unsatisfied requirements was found, and
 	// filterUnsatisfiedSkills has already warned about it by name. Everything
@@ -1061,9 +1066,9 @@ Today is %s %s (ISO week %04d-W%02d, %s). This date is authoritative — never i
 		)
 	}
 	if suffix := skill.BuildPromptSection(active); suffix != "" {
-		return buildSystemPromptResult{prompt: base + "\n\n" + suffix, matchedSkills: active}
+		return buildSystemPromptResult{prompt: base + "\n\n" + suffix, matchedSkills: active, droppedScheduledMissing: droppedMissing}
 	}
-	return buildSystemPromptResult{prompt: base, matchedSkills: active}
+	return buildSystemPromptResult{prompt: base, matchedSkills: active, droppedScheduledMissing: droppedMissing}
 }
 
 func skillNameMatched(matched []skill.Skill, name string) bool {
@@ -1087,11 +1092,11 @@ func skillNameMatched(matched []skill.Skill, name string) bool {
 //
 // Inspired by the reactive dependency-driven activation model in
 // https://github.com/cordiverse/paper/blob/main/paper.pdf.
-func (e *Engine) filterUnsatisfiedSkills(matched []skill.Skill, msg adapter.IncomingMessage) []skill.Skill {
+func (e *Engine) filterUnsatisfiedSkills(matched []skill.Skill, msg adapter.IncomingMessage) ([]skill.Skill, []string) {
 	// No tool manager means no capability information at all; guessing which
 	// way is worse than not filtering, so declared requirements are ignored.
 	if e.tools == nil || !anySkillRequiresTools(matched) {
-		return matched
+		return matched, nil
 	}
 
 	names := e.tools.ToolNames()
@@ -1101,6 +1106,7 @@ func (e *Engine) filterUnsatisfiedSkills(matched []skill.Skill, msg adapter.Inco
 	}
 
 	active := make([]skill.Skill, 0, len(matched))
+	var droppedMissing []string
 	for _, s := range matched {
 		missing := missingRequiredTools(s, available)
 		changed := e.recordSkillSatisfaction(s.Name, missing)
@@ -1111,6 +1117,7 @@ func (e *Engine) filterUnsatisfiedSkills(matched []skill.Skill, msg adapter.Inco
 			}
 			active = append(active, s)
 		case msg.SkillName == s.Name:
+			droppedMissing = missing
 			// Per occurrence, not per state change: a scheduled run that
 			// silently does nothing is an operational failure.
 			e.logger.Warn("scheduled skill deactivated — required tools unavailable, body will not be injected",
@@ -1128,7 +1135,34 @@ func (e *Engine) filterUnsatisfiedSkills(matched []skill.Skill, msg adapter.Inco
 			)
 		}
 	}
-	return active
+	return active, droppedMissing
+}
+
+// scheduledSkillSkipNotice is the reply for a schedule-driven turn whose skill
+// was dropped for missing tools. The LLM is not called: a scheduled message
+// names one skill, and without it there is nothing to do but say so where
+// the schedule's channel can see it — the Warn log is not read at 08:30.
+// Empty when the turn should proceed.
+func (e *Engine) scheduledSkillSkipNotice(ctx context.Context, msg adapter.IncomingMessage, convID string, prep turnPrep) string {
+	missing := prep.sysResult.droppedScheduledMissing
+	if !msg.IsScheduled || msg.SkillName == "" || len(missing) == 0 {
+		return ""
+	}
+	detail, _ := json.Marshal(map[string]any{
+		"skill":    msg.SkillName,
+		"schedule": msg.ScheduleName,
+		"missing":  missing,
+	})
+	e.emitAudit(ctx, audit.Event{
+		Category:       audit.CategorySkill,
+		Action:         "deactivated",
+		Summary:        fmt.Sprintf("Skill %s skipped — required tools unavailable: %s", msg.SkillName, strings.Join(missing, ", ")),
+		Detail:         string(detail),
+		Status:         audit.StatusError,
+		Source:         "engine",
+		ConversationID: convID,
+	})
+	return fmt.Sprintf("[engine: %s skipped — required tools unavailable: %s]", msg.SkillName, strings.Join(missing, ", "))
 }
 
 // anySkillRequiresTools reports whether any matched skill declares a tool
@@ -1537,6 +1571,14 @@ func (e *Engine) chatWithApproval(ctx context.Context, msg adapter.IncomingMessa
 	}
 	convID := prep.convID
 	span.SetAttributes(attribute.String("conversation.id", convID))
+
+	if notice := e.scheduledSkillSkipNotice(ctx, msg, convID, prep); notice != "" {
+		resp := &llm.ChatResponse{Content: notice, FinishReason: "stop"}
+		if err := e.persistTurn(ctx, msg, policy, prep, resp, notice, nil); err != nil {
+			return turnOutcome{convID: convID}, err
+		}
+		return turnOutcome{response: notice, convID: convID, resp: resp}, nil
+	}
 
 	ctx = e.turnContext(ctx, msg, convID, prep.sysResult.matchedSkills, policy)
 

--- a/internal/agent/engine_skill_satisfaction_test.go
+++ b/internal/agent/engine_skill_satisfaction_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/Temikus/denkeeper/internal/adapter"
+	"github.com/Temikus/denkeeper/internal/audit"
 	"github.com/Temikus/denkeeper/internal/llm"
 	"github.com/Temikus/denkeeper/internal/security"
 	"github.com/Temikus/denkeeper/internal/skill"
@@ -118,7 +120,7 @@ func TestFilterUnsatisfiedSkills_MissingToolExcludes(t *testing.T) {
 	e := newSatisfactionEngine(t, newSatisfactionToolManager(t, "kv_get"), []skill.Skill{s}, nil)
 
 	msg := satisfactionMessage("sat-missing", "anything")
-	if got := e.filterUnsatisfiedSkills([]skill.Skill{s}, msg); len(got) != 0 {
+	if got, _ := e.filterUnsatisfiedSkills([]skill.Skill{s}, msg); len(got) != 0 {
 		t.Fatalf("filtered set = %d skills, want 0 (gmail_list is not registered)", len(got))
 	}
 
@@ -137,7 +139,7 @@ func TestFilterUnsatisfiedSkills_AllPresentIncludes(t *testing.T) {
 	e := newSatisfactionEngine(t, newSatisfactionToolManager(t, "kv_get", "kv_set", "kv_list"), []skill.Skill{s}, nil)
 
 	msg := satisfactionMessage("sat-present", "anything")
-	got := e.filterUnsatisfiedSkills([]skill.Skill{s}, msg)
+	got, _ := e.filterUnsatisfiedSkills([]skill.Skill{s}, msg)
 	if len(got) != 1 || got[0].Name != "inbox-triage" {
 		t.Fatalf("filtered set = %+v, want the skill kept (every declared tool is registered)", got)
 	}
@@ -154,7 +156,7 @@ func TestFilterUnsatisfiedSkills_NilManagerNoFilter(t *testing.T) {
 	e := newSatisfactionEngine(t, nil, []skill.Skill{s}, nil)
 
 	msg := satisfactionMessage("sat-nil-mgr", "anything")
-	got := e.filterUnsatisfiedSkills([]skill.Skill{s}, msg)
+	got, _ := e.filterUnsatisfiedSkills([]skill.Skill{s}, msg)
 	if len(got) != 1 {
 		t.Fatalf("filtered set = %d skills, want 1 — a nil manager carries no capability information", len(got))
 	}
@@ -230,8 +232,11 @@ func TestFilterUnsatisfiedSkills_ScheduledSkillExcludedWarns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("chat: %v", err)
 	}
-	if !strings.Contains(result, "Nothing to do.") {
-		t.Errorf("result = %q, want the turn to complete normally", result)
+	if result != "[engine: nightly skipped — required tools unavailable: gmail_list]" {
+		t.Errorf("result = %q, want the skip notice", result)
+	}
+	if provider.callIndex != 0 {
+		t.Errorf("provider called %d times, want 0 — a dropped scheduled skill must not spend an LLM round", provider.callIndex)
 	}
 
 	out := logs.String()
@@ -334,5 +339,84 @@ func TestFilterUnsatisfiedSkills_ExcludedSkillDoesNotDriveTurn(t *testing.T) {
 	}
 	if len(usages) != 1 || usages[0].SkillName != "triage" {
 		t.Errorf("recorded %+v, want one usage of triage after its tool returned", usages)
+	}
+}
+
+// A dropped scheduled skill answers with a notice on the schedule's channel,
+// audits it, and persists the turn like any other.
+func TestScheduledSkillDropped_NoticeAuditedAndPersisted(t *testing.T) {
+	provider := &sequentialProvider{}
+	s := skilltest.NewWithRequiresTools("heartbeat", "Heartbeat", []string{"schedule:heartbeat"},
+		"SKILL-BODY-MARKER", []string{"find-tasks", "find-projects"})
+	e := newSatisfactionEngine(t, newSatisfactionToolManager(t, "kv_get"), []skill.Skill{s}, provider)
+	auditor := &collectingAuditor{}
+	e.SetAuditor(auditor)
+
+	msg := satisfactionMessage("sat-dropped", "[Scheduled: heartbeat | 2026-09-05T08:30:51+10:00 Australia/Sydney | 2026-W36]")
+	msg.SkillName = "heartbeat"
+	msg.ScheduleName = "heartbeat"
+	msg.IsScheduled = true
+
+	result, err := e.ChatWithEvents(context.Background(), msg, nil)
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if !strings.HasPrefix(result, "[engine: heartbeat skipped — required tools unavailable: ") {
+		t.Fatalf("result = %q, want the skip notice", result)
+	}
+	if !strings.Contains(result, "find-tasks") || !strings.Contains(result, "find-projects") {
+		t.Errorf("result = %q, want both missing tools named", result)
+	}
+
+	var found *audit.Event
+	for i := range auditor.events {
+		ev := auditor.events[i]
+		if ev.Category == audit.CategorySkill && ev.Action == "deactivated" {
+			found = &ev
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no skill/deactivated audit event among %d events", len(auditor.events))
+	}
+	if found.Status != audit.StatusError {
+		t.Errorf("audit status = %q, want %q", found.Status, audit.StatusError)
+	}
+	var detail map[string]any
+	if err := json.Unmarshal([]byte(found.Detail), &detail); err != nil {
+		t.Fatalf("audit detail is not JSON: %v (%q)", err, found.Detail)
+	}
+	if detail["skill"] != "heartbeat" || detail["schedule"] != "heartbeat" {
+		t.Errorf("audit detail = %v, want skill and schedule named", detail)
+	}
+
+	msgs, err := e.memory.GetMessages(context.Background(), "default:test:sat-dropped", 10)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 2 || msgs[1].Role != "assistant" || msgs[1].Content != result {
+		t.Errorf("stored messages = %+v, want user + assistant notice", msgs)
+	}
+}
+
+// A live command turn keeps the old behaviour: the skill body is withheld but
+// the model still answers.
+func TestScheduledSkillDropped_LiveTurnStillRuns(t *testing.T) {
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{Content: "Answered anyway.", TokensUsed: llm.TokenUsage{Total: 5}, FinishReason: "stop"},
+		},
+	}
+	s := skilltest.NewWithRequiresTools("nightly", "Nightly run", []string{"command:nightly"},
+		"SKILL-BODY-MARKER", []string{"gmail_list"})
+	e := newSatisfactionEngine(t, newSatisfactionToolManager(t, "kv_get"), []skill.Skill{s}, provider)
+
+	msg := satisfactionMessage("sat-live", "/nightly")
+	result, err := e.ChatWithEvents(context.Background(), msg, nil)
+	if err != nil {
+		t.Fatalf("chat: %v", err)
+	}
+	if result != "Answered anyway." {
+		t.Errorf("result = %q, want the model's answer", result)
 	}
 }


### PR DESCRIPTION
**TL;DR:** when `requires.tools` gating drops the skill a schedule named, the engine used to run a skill-less LLM turn and Warn to the log. In the 2026-09-05 audit the Todoist MCP server was down, the heartbeat spent its round reasoning about tools it did not have, and nobody read the Warn at 08:30. The scheduled turn now short-circuits with a one-line notice on the schedule's channel.

Findings: `design/agent-ops-findings-2026-09-05.md` F3. Plan: `design/plans/7-agent-ops-fixes-2026-09.md` C5.

**What to review**

1. `filterUnsatisfiedSkills` returns the missing tools of the schedule-driven skill alongside the active set; `buildSystemPromptResult.droppedScheduledMissing` carries it. Only the scheduled skill is tracked - an ambient skill going inactive is not a reason to skip a turn.
2. `scheduledSkillSkipNotice` in `chatWithApproval`, right after `prepareTurn`: audits `skill` / `deactivated` at `error` status with skill, schedule, and missing tools, and returns `[engine: heartbeat skipped — required tools unavailable: find-tasks, find-projects]`. No `Router.Complete` call. The turn persists normally (user message + notice), so history stays consistent.
3. Live command turns are unchanged: the body is withheld, the model still answers. The existing `TestFilterUnsatisfiedSkills_ScheduledSkillExcludedWarns` was updated to the new contract (provider called 0 times).

Pairs with the skill edits already made live this session (`requires_tools` set on heartbeat, email-review-cleanup, curiosity-loop, daily-hn-report, daily-github-trending) - without those the gating has nothing to check.

<details>
<summary>Tests</summary>

- `engine_skill_satisfaction_test.go`: scheduled drop returns the notice, provider not called, audit event with JSON detail, user + assistant messages persisted; live command turn still gets the model's answer; existing filter tests adjusted for the second return value.

`just test` green; lint clean apart from the 6 pre-existing `SA5011` hits on `main`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPzDejjvYWA2Dj2L6X2Q3
