### PR TITLE
fix(agent): nudge before reusing intermediate content on an empty final

### DIFF
--- a/internal/agent/engine.go
+++ b/internal/agent/engine.go
@@ -2443,14 +2443,21 @@ func (e *Engine) wrapUpToolLoop(ctx context.Context, convID string, reason loopS
 // content after tool rounds. It first checks for accumulated intermediate
 // content, then falls back to nudging the model for a response.
 func (e *Engine) recoverEmptyToolResponse(ctx context.Context, convID string, resp *llm.ChatResponse, llmMessages []llm.Message, accumulated string, run turnRun) (*llm.ChatResponse, []llm.Message, error) {
-	if strings.TrimSpace(accumulated) != "" {
+	haveAccumulated := strings.TrimSpace(accumulated) != ""
+	// Reasoning with no content means the model wrote its answer into the
+	// wrong field (kimi-k2.6 does this after long tool chains); replaying its
+	// intermediate narration would deliver the wrong message, so ask again
+	// first. No reasoning means a transport fault, where the narration is the
+	// best available answer and a retry is unlikely to do better.
+	if haveAccumulated && strings.TrimSpace(resp.ThinkingContent) == "" {
 		e.logger.Info("using accumulated content from intermediate tool rounds",
 			"accumulated_len", len(accumulated))
 		resp.Content = accumulated
 		return resp, llmMessages, nil
 	}
 	e.logger.Warn("empty response after tool rounds, retrying with nudge",
-		"finish_reason", resp.FinishReason)
+		"finish_reason", resp.FinishReason,
+		"thinking_len", len(resp.ThinkingContent))
 	llmMessages = append(llmMessages, llm.Message{
 		Role:    "user",
 		Content: "Please provide your response based on the tool results above.",
@@ -2461,6 +2468,11 @@ func (e *Engine) recoverEmptyToolResponse(ctx context.Context, convID string, re
 		return nil, llmMessages, fmt.Errorf("LLM completion (nudge retry): %w", err)
 	}
 	e.emitLLMAudit(ctx, convID, nudgeResp, "", llmAuditOpts{nudgeRetry: true})
+	if strings.TrimSpace(nudgeResp.Content) == "" && haveAccumulated {
+		e.logger.Info("nudge returned empty content, falling back to accumulated content",
+			"accumulated_len", len(accumulated))
+		nudgeResp.Content = accumulated
+	}
 	return nudgeResp, llmMessages, nil
 }
 

--- a/internal/agent/engine_test.go
+++ b/internal/agent/engine_test.go
@@ -5018,6 +5018,80 @@ func TestRecoverEmptyToolResponse_WhitespaceAccumulatedFallsThroughToNudge(t *te
 	}
 }
 
+func newRecoveryEngine(t *testing.T, provider *sequentialProvider) *Engine {
+	t.Helper()
+	store, err := NewInMemoryStore()
+	if err != nil {
+		t.Fatalf("creating store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	router := llm.NewRouter("mock", "test-model", llm.NewCostTracker(llm.SessionLimits{}, nil))
+	router.RegisterProvider(provider)
+	permissions, err := security.NewPermissionEngine("autonomous")
+	if err != nil {
+		t.Fatalf("creating permissions: %v", err)
+	}
+	return NewEngine("default", router, store, nil, permissions, nil, "Test.", nil, nil, nil, testLogger())
+}
+
+// An empty final that carries reasoning is the model answering in the wrong
+// field; the nudge must run before the intermediate narration is reused.
+func TestRecoverEmptyToolResponse_ReasoningPresentNudgesBeforeAccumulated(t *testing.T) {
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{
+			{Content: "Email review complete: 32 → 0 unread.", FinishReason: "stop"},
+		},
+	}
+	engine := newRecoveryEngine(t, provider)
+
+	resp := &llm.ChatResponse{Content: "", ThinkingContent: "My job is done. Email review complete...", FinishReason: "stop"}
+	got, _, err := engine.recoverEmptyToolResponse(context.Background(), "conv-1", resp,
+		[]llm.Message{{Role: "user", Content: "hi"}}, "Already ran earlier today, continuing with cleanup...", turnRun{router: engine.router})
+	if err != nil {
+		t.Fatalf("recoverEmptyToolResponse: %v", err)
+	}
+	if got.Content != "Email review complete: 32 → 0 unread." {
+		t.Errorf("content = %q, want the nudge answer, not the intermediate narration", got.Content)
+	}
+	if provider.callIndex != 1 {
+		t.Errorf("provider calls = %d, want 1 nudge", provider.callIndex)
+	}
+}
+
+// No reasoning means a transport fault: the narration is the best available
+// answer and no round is spent on a nudge.
+func TestRecoverEmptyToolResponse_NoReasoningUsesAccumulatedWithoutNudge(t *testing.T) {
+	provider := &sequentialProvider{}
+	engine := newRecoveryEngine(t, provider)
+
+	resp := &llm.ChatResponse{Content: "", FinishReason: "stop"}
+	got, _, err := engine.recoverEmptyToolResponse(context.Background(), "conv-1", resp,
+		[]llm.Message{{Role: "user", Content: "hi"}}, "Partial progress so far.", turnRun{router: engine.router})
+	if err != nil {
+		t.Fatalf("recoverEmptyToolResponse: %v", err)
+	}
+	if got.Content != "Partial progress so far." || provider.callIndex != 0 {
+		t.Errorf("content = %q, calls = %d; want accumulated content and no nudge", got.Content, provider.callIndex)
+	}
+}
+
+func TestRecoverEmptyToolResponse_EmptyNudgeFallsBackToAccumulated(t *testing.T) {
+	provider := &sequentialProvider{
+		responses: []*llm.ChatResponse{{Content: "  ", ThinkingContent: "still thinking", FinishReason: "stop"}},
+	}
+	engine := newRecoveryEngine(t, provider)
+
+	resp := &llm.ChatResponse{Content: "", ThinkingContent: "reasoning", FinishReason: "stop"}
+	got, _, err := engine.recoverEmptyToolResponse(context.Background(), "conv-1", resp,
+		[]llm.Message{{Role: "user", Content: "hi"}}, "Narration.", turnRun{router: engine.router})
+	if err != nil {
+		t.Fatalf("recoverEmptyToolResponse: %v", err)
+	}
+	if got.Content != "Narration." || provider.callIndex != 1 {
+		t.Errorf("content = %q, calls = %d; want the accumulated fallback after one empty nudge", got.Content, provider.callIndex)
+	}
+}
+
 // TestStreamCallbackFor_ResetEmitsRollback verifies a Reset stream chunk is
 // translated into a stream_rollback ChatEvent (and nothing else).
 func TestStreamCallbackFor_ResetEmitsRollback(t *testing.T) {


### PR DESCRIPTION
**TL;DR:** on 2026-09-04 19:00 the email skill's final completion had empty `content` and the whole report in `reasoning_content`. The engine's recovery replayed the model's intermediate narration ("Already ran earlier today... continuing with cleanup") and that is what Telegram received. This flips the order for that case only.

Findings: `design/agent-ops-findings-2026-09-05.md` F6 (4th bullet). Plan: `design/plans/7-agent-ops-fixes-2026-09.md` C6.

**What to review**

`recoverEmptyToolResponse` in `internal/agent/engine.go`:

- Empty content **with** reasoning: the model answered in the wrong field, so the nudge runs first; accumulated intermediate text is used only if the nudge also comes back empty.
- Empty content **without** reasoning: a transport fault, unchanged - accumulated content is used with no extra round.

One extra LLM round in the first case, which is the case where the alternative is delivering the wrong message.

<details>
<summary>Tests</summary>

`engine_test.go`: reasoning present → nudge answer used, one provider call; no reasoning → accumulated used, zero calls; empty nudge → accumulated fallback after one call. Existing whitespace-accumulated test unchanged.

`just test` green; lint clean apart from the 6 pre-existing `SA5011` hits on `main`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPzDejjvYWA2Dj2L6X2Q3
