### PR TITLE
feat(kv): namespace default TTLs for kv_set

### DIFF
--- a/cmd/denkeeper/main.go
+++ b/cmd/denkeeper/main.go
@@ -850,6 +850,7 @@ func connectConfigMCP(ctx context.Context, agentName, skillsDir string, e *agent
 
 		KVListMaxBytes:       abc.cfg.KV.ListMaxBytes,
 		KVListValueHeadBytes: abc.cfg.KV.ListValueHeadBytes,
+		KVDefaultTTL:         abc.cfg.KV.DefaultTTLs(),
 		CostSummary: func() configmcp.CostSummaryData {
 			return configmcp.CostSummaryData{
 				GlobalCost:    costTracker.GlobalCost(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1179,6 +1179,26 @@ type KVConfig struct {
 	ListValueHeadBytes int `toml:"list_value_head_bytes"`
 	// CleanupInterval is how often expired keys are purged (Go duration string).
 	CleanupInterval string `toml:"cleanup_interval"`
+	// DefaultTTL maps a key prefix (must end in ":") to the expiry applied by
+	// kv_set when the call passes no ttl. Longest matching prefix wins; an
+	// explicit ttl always wins. Prose rules asking skills to remember a ttl
+	// decay; this does not.
+	DefaultTTL map[string]string `toml:"default_ttl"`
+}
+
+// DefaultTTLs returns the parsed prefix → duration map. Validation has already
+// rejected unparsable entries, so parse errors are not reachable here.
+func (k *KVConfig) DefaultTTLs() map[string]time.Duration {
+	if len(k.DefaultTTL) == 0 {
+		return nil
+	}
+	out := make(map[string]time.Duration, len(k.DefaultTTL))
+	for prefix, raw := range k.DefaultTTL {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			out[prefix] = d
+		}
+	}
+	return out
 }
 
 type LogConfig struct {
@@ -2246,6 +2266,18 @@ func validateKV(k *KVConfig) error {
 	}
 	if k.ListValueHeadBytes > k.ListMaxBytes {
 		return fmt.Errorf("config: kv.list_value_head_bytes (%d) must not exceed kv.list_max_bytes (%d)", k.ListValueHeadBytes, k.ListMaxBytes)
+	}
+	for prefix, raw := range k.DefaultTTL {
+		if prefix == "" || !strings.HasSuffix(prefix, ":") {
+			return fmt.Errorf("config: kv.default_ttl key %q must be a namespace prefix ending in \":\"", prefix)
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return fmt.Errorf("config: kv.default_ttl[%q]: invalid duration %q: %w", prefix, raw, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("config: kv.default_ttl[%q] must be positive, got %s", prefix, raw)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5190,3 +5190,34 @@ func TestEvalConfig_TraceBytesCapFallsBackToDefault(t *testing.T) {
 		t.Errorf("TraceBytesCap() = %d on a zero value, want %d", got, DefaultMaxTraceBytes)
 	}
 }
+
+func TestParse_KVDefaultTTL_Parsed(t *testing.T) {
+	cfg, err := Parse([]byte(baseConfig + `
+[kv]
+default_ttl = { "log:" = "720h", "log:heartbeat:" = "168h", "cache:" = "1h30m" }
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	got := cfg.KV.DefaultTTLs()
+	if got["log:"] != 720*time.Hour || got["log:heartbeat:"] != 168*time.Hour || got["cache:"] != 90*time.Minute {
+		t.Errorf("DefaultTTLs = %v", got)
+	}
+	if empty := (&KVConfig{}).DefaultTTLs(); empty != nil {
+		t.Errorf("no config should yield nil, got %v", empty)
+	}
+}
+
+func TestParse_KVDefaultTTL_RejectsBadEntries(t *testing.T) {
+	cases := map[string]string{
+		"bad duration":  `default_ttl = { "log:" = "30 days" }`,
+		"zero duration": `default_ttl = { "log:" = "0s" }`,
+		"missing colon": `default_ttl = { "log" = "720h" }`,
+	}
+	for name, line := range cases {
+		_, err := Parse([]byte(baseConfig + "\n[kv]\n" + line + "\n"))
+		if err == nil || !strings.Contains(err.Error(), "kv.default_ttl") {
+			t.Errorf("%s: expected a kv.default_ttl validation error, got %v", name, err)
+		}
+	}
+}

--- a/internal/configmcp/kv_tools.go
+++ b/internal/configmcp/kv_tools.go
@@ -42,7 +42,7 @@ func (s *Server) registerKVTools() {
 
 	s.mcpServer.AddTool(&mcp.Tool{
 		Name:        "kv_set",
-		Description: "Store a key-value pair. Overwrites any existing value. Use ttl to set an expiry. Use a `prefix:subkey` shape so kv_list stays useful; see system prompt for namespace conventions.",
+		Description: "Store a key-value pair. Overwrites any existing value. Use ttl to set an expiry; when omitted, a namespace default may apply (operator-configured per prefix, e.g. log:*). Use a `prefix:subkey` shape so kv_list stays useful; see system prompt for namespace conventions.",
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
@@ -143,12 +143,27 @@ func (s *Server) handleKVSet(ctx context.Context, req *mcp.CallToolRequest) (*mc
 	if err != nil {
 		return toolError(err.Error()), nil
 	}
+	if strings.TrimSpace(input.TTL) == "" {
+		ttl = defaultTTLFor(s.deps.KVDefaultTTL, input.Key)
+	}
 
 	if err := s.deps.KVStore.Set(ctx, s.deps.AgentName, input.Key, input.Value, ttl); err != nil {
 		return toolError(fmt.Sprintf("kv_set failed: %v", err)), nil
 	}
 
 	return toolText(`{"ok": true}`), nil
+}
+
+// defaultTTLFor picks the longest configured prefix that key starts with.
+func defaultTTLFor(defaults map[string]time.Duration, key string) time.Duration {
+	var best string
+	var ttl time.Duration
+	for prefix, d := range defaults {
+		if strings.HasPrefix(key, prefix) && len(prefix) > len(best) {
+			best, ttl = prefix, d
+		}
+	}
+	return ttl
 }
 
 func (s *Server) handleKVDelete(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/configmcp/kv_tools_test.go
+++ b/internal/configmcp/kv_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -299,4 +300,56 @@ func TestHandleKVList_DescriptionStatesLiveCaps(t *testing.T) {
 		return
 	}
 	t.Fatal("kv_list not advertised")
+}
+
+func TestHandleKVSet_DefaultTTLByPrefix(t *testing.T) {
+	session, store := newKVServer(t, func(d *configmcp.Deps) {
+		d.KVDefaultTTL = map[string]time.Duration{
+			"log:":           720 * time.Hour,
+			"log:heartbeat:": 168 * time.Hour,
+		}
+	})
+	ctx := context.Background()
+	set := func(key, ttl string) {
+		t.Helper()
+		args := map[string]any{"key": key, "value": "v"}
+		if ttl != "" {
+			args["ttl"] = ttl
+		}
+		if text, isErr := callTool(t, session, "kv_set", args); isErr {
+			t.Fatalf("kv_set %s: %s", key, text)
+		}
+	}
+	expiry := func(key string) *time.Time {
+		t.Helper()
+		entries, err := store.List(ctx, "test-agent", key)
+		if err != nil || len(entries) != 1 {
+			t.Fatalf("List %s: n=%d err=%v", key, len(entries), err)
+		}
+		return entries[0].ExpiresAt
+	}
+	within := func(got *time.Time, want time.Duration) bool {
+		if got == nil {
+			return false
+		}
+		d := time.Until(*got)
+		return d > want-time.Minute && d <= want+time.Minute
+	}
+
+	set("log:email-cleanup:2026-09-05", "")
+	if exp := expiry("log:email-cleanup:2026-09-05"); !within(exp, 720*time.Hour) {
+		t.Errorf("log: prefix default not applied, expiry = %v", exp)
+	}
+	set("log:heartbeat:2026-09-05", "")
+	if exp := expiry("log:heartbeat:2026-09-05"); !within(exp, 168*time.Hour) {
+		t.Errorf("longest prefix should win, expiry = %v", exp)
+	}
+	set("log:heartbeat:2026-09-06", "24h")
+	if exp := expiry("log:heartbeat:2026-09-06"); !within(exp, 24*time.Hour) {
+		t.Errorf("explicit ttl should win, expiry = %v", exp)
+	}
+	set("pref:email_noise_senders", "")
+	if exp := expiry("pref:email_noise_senders"); exp != nil {
+		t.Errorf("unmatched prefix should not expire, got %v", exp)
+	}
 }

--- a/internal/configmcp/server.go
+++ b/internal/configmcp/server.go
@@ -105,6 +105,11 @@ type Deps struct {
 	// [kv] list_value_head_bytes.
 	KVListValueHeadBytes int
 
+	// KVDefaultTTL maps a key prefix to the expiry kv_set applies when the
+	// call passes no ttl. Longest matching prefix wins. Sourced from
+	// [kv] default_ttl.
+	KVDefaultTTL map[string]time.Duration
+
 	// CostSummary returns a snapshot of cost tracking data. If nil,
 	// get_cost_summary is disabled.
 	CostSummary func() CostSummaryData

--- a/website/content/docs/reference/config.md
+++ b/website/content/docs/reference/config.md
@@ -504,6 +504,7 @@ Each signal takes `"withhold"`, `"warn"` (audit but deliver anyway), or `"off"`.
 | `list_max_bytes` | int | `16384` | Total value bytes a single `kv_list` response may carry |
 | `list_value_head_bytes` | int | `1024` | Per-value cap inside a `kv_list` response |
 | `cleanup_interval` | string | `"1h"` | Background cleanup interval for expired keys |
+| `default_ttl` | table | none | Expiry applied by `kv_set` when the call passes no `ttl`, keyed by namespace prefix (must end in `:`). Longest matching prefix wins; an explicit `ttl` always wins. Example: `default_ttl = { "log:" = "720h", "cache:" = "168h" }` |
 
 Per-agent key-value storage with optional TTL. Exposed as Config MCP tools (`kv_get`, `kv_set`, `kv_delete`, `kv_list`, `kv_set_nx`). Useful for locks, counters, caches, and cross-session coordination.
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -350,6 +350,9 @@ Global MCP settings.
     list_max_bytes = 16384           # total value bytes per kv_list response
     list_value_head_bytes = 1024     # per-value cap inside a kv_list response
     cleanup_interval = "1h"          # expiry cleanup interval
+    # default_ttl = { "log:" = "720h", "cache:" = "168h" }
+    #                                # expiry kv_set applies when no ttl is
+    #                                # passed, by namespace prefix (longest wins)
 
 ### [audit]
 


### PR DESCRIPTION
**TL;DR:** 0 of 30 `kv_set` calls in the 2026-09-03..05 audit passed a `ttl`, 1 of 239 keys had an expiry, and the memory-gardener was spending ~$0.10/day deleting three keys by hand. A prose rule asking skills to remember a ttl decays; this makes it config.

Findings: `design/agent-ops-findings-2026-09-05.md` F7. Plan: `design/plans/7-agent-ops-fixes-2026-09.md` C7.

**What to review**

1. `[kv] default_ttl = { "log:" = "720h", "cache:" = "168h" }` in `internal/config/config.go`. Keys must end in `:`, durations must parse and be positive, both checked in `validateKV`. `KVConfig.DefaultTTLs()` hands the parsed map to `configmcp.Deps.KVDefaultTTL`.
2. `handleKVSet`: applies the longest matching prefix only when the call passed no `ttl`. An explicit `ttl` always wins. `kv_set_nx` is untouched (locks already pass one).
3. `kv_set` tool description mentions that a namespace default may apply, so the model knows why a key it wrote without a ttl expires.

Suggested deployed value once merged: `default_ttl = { "log:" = "720h", "cache:" = "168h" }`. The skill edits made live this session already pass explicit ttls on every `log:*` write; this is the safety net for the ones that will be written without one.

<details>
<summary>Tests</summary>

- `config_test.go`: parsed map incl. `1h30m`; nil when unset; bad duration, zero, and a key without `:` each rejected naming `kv.default_ttl`.
- `kv_tools_test.go`: `log:` default applied, longer `log:heartbeat:` prefix wins, explicit `ttl` wins, unmatched `pref:` key does not expire.
- `llms-full.txt` drift test updated.

`just test` green; lint clean apart from the 6 pre-existing `SA5011` hits on `main`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKPzDejjvYWA2Dj2L6X2Q3
